### PR TITLE
Trim Coo footer, fix Perch access linebreak, dim observer bar

### DIFF
--- a/is/writing/bird-coo/index.html
+++ b/is/writing/bird-coo/index.html
@@ -123,8 +123,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./issues/index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-03-10.html
+++ b/is/writing/bird-coo/issues/2026-03-10.html
@@ -114,8 +114,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-03-17.html
+++ b/is/writing/bird-coo/issues/2026-03-17.html
@@ -117,8 +117,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-03-24.html
+++ b/is/writing/bird-coo/issues/2026-03-24.html
@@ -122,8 +122,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-03-31.html
+++ b/is/writing/bird-coo/issues/2026-03-31.html
@@ -118,8 +118,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-04-07.html
+++ b/is/writing/bird-coo/issues/2026-04-07.html
@@ -123,8 +123,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-04-14.html
+++ b/is/writing/bird-coo/issues/2026-04-14.html
@@ -121,8 +121,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-04-21.html
+++ b/is/writing/bird-coo/issues/2026-04-21.html
@@ -122,8 +122,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-04-28.html
+++ b/is/writing/bird-coo/issues/2026-04-28.html
@@ -121,8 +121,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-05-05.html
+++ b/is/writing/bird-coo/issues/2026-05-05.html
@@ -124,8 +124,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-05-12.html
+++ b/is/writing/bird-coo/issues/2026-05-12.html
@@ -121,8 +121,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-05-19.html
+++ b/is/writing/bird-coo/issues/2026-05-19.html
@@ -122,8 +122,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-05-26.html
+++ b/is/writing/bird-coo/issues/2026-05-26.html
@@ -122,8 +122,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-06-02.html
+++ b/is/writing/bird-coo/issues/2026-06-02.html
@@ -128,8 +128,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/index.html
+++ b/is/writing/bird-coo/issues/index.html
@@ -84,8 +84,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District.</p>
 <p><a href="../index.html">Return to current issue</a></p>
 <div class="district-links">
-<p>District Services: <a href="https://ajin.im/is/writing/avian-district/">Avian Municipal District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court — eCourt Public Portal</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest — Community Personals</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch — Community Chat</a></p>
-<p class="licensed-notice">Licensed practitioners who advertise in this publication: <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+<p><a href="https://ajin.im/is/writing/avian-district/">Avian District</a> · <a href="https://ajin.im/is/writing/nest-court/">Nest Court</a> · <a href="https://ajin.im/is/writing/secondnest/">SecondNest</a> · <a href="https://ajin.im/is/writing/perch-chat/">The Perch</a> · <a href="https://ajin.im/is/writing/karen-hawk/">Karen Hawk</a></p>
 </div>
 </footer>
 </div>

--- a/is/writing/bird-coo/styles.css
+++ b/is/writing/bird-coo/styles.css
@@ -524,11 +524,6 @@ a {
   text-underline-offset: 2px;
 }
 
-.page-footer .licensed-notice {
-  margin-top: 0.2rem;
-  font-style: italic;
-}
-
 /* ── ARCHIVE ── */
 
 .archive-shell {

--- a/is/writing/perch-chat/index.html
+++ b/is/writing/perch-chat/index.html
@@ -614,7 +614,7 @@
       padding: 0.5rem 0.7rem;
       border: 1px solid var(--border-ui);
       background: var(--bg-panel-4);
-      color: var(--text-muted);
+      color: var(--text-ghost);
       font-family: "IBM Plex Mono", monospace;
       font-size: 0.7rem;
       line-height: 1.5;
@@ -623,8 +623,7 @@
     }
 
     .chat-input a {
-      color: var(--text);
-      font-weight: 500;
+      color: var(--text-muted);
       text-decoration: underline;
     }
 
@@ -892,7 +891,7 @@
       },
       {
         text: "Access granted.",
-        sub: "You have been admitted as a Silent Observer.\nYou may read. You may not post.\n\nTo request posting privileges, contact the channel administrator:\naccess@ajin.im",
+        sub: "You have been admitted as a Silent Observer.\nYou may read. You may not post.\n\nTo request posting privileges, contact the channel administrator: access@ajin.im",
         button: "Enter",
         final: true
       }


### PR DESCRIPTION
## Summary
- Simplify Coo footer to just short site names: `Avian District · Nest Court · SecondNest · The Perch · Karen Hawk`
- Fix line break between "administrator:" and "access@ajin.im" on Perch access verification screen
- Dim the observer mode bar so it doesn't compete with chat text (text-ghost + text-muted colors)