### PR TITLE
Fix Perch observer bar brightness and access line break

### DIFF
--- a/is/writing/perch-chat/index.html
+++ b/is/writing/perch-chat/index.html
@@ -623,8 +623,9 @@
     }
 
     .chat-input a {
-      color: var(--text-muted);
+      color: var(--text-dim);
       text-decoration: underline;
+      text-decoration-color: var(--border);
     }
 
     @media (max-width: 700px) {
@@ -891,7 +892,7 @@
       },
       {
         text: "Access granted.",
-        sub: "You have been admitted as a Silent Observer.\nYou may read. You may not post.\n\nTo request posting privileges, contact the channel administrator: access@ajin.im",
+        sub: "You have been admitted as a Silent Observer.\nYou may read. You may not post.\n\nTo request posting privileges, contact the channel\u00A0administrator: access@ajin.im",
         button: "Enter",
         final: true
       }


### PR DESCRIPTION
## Summary
- Dim observer bar link from `--text-muted` to `--text-dim` (79% → 46% relative brightness vs chat text) and dim underline to `--border` color
- Add non-breaking space between "channel" and "administrator" on access screen to prevent unwanted word-wrap

## Verification
Both fixes verified via preview with computed style inspection:
- Observer link: `rgb(92, 90, 82)` vs chat text `rgb(200, 196, 184)` — clearly receded
- Access screen: "channel administrator: access@ajin.im" stays on one line

## Test plan
- [ ] Load The Perch, complete access flow, confirm "channel administrator:" stays on one line
- [ ] In chat view, confirm observer bar text is visually dimmer than chat messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)