### PR TITLE
Simplify Perch observer bar, fix nest-court grid sizing

### DIFF
--- a/is/writing/nest-court/index.html
+++ b/is/writing/nest-court/index.html
@@ -324,7 +324,7 @@
       color: var(--text-tertiary);
       text-transform: uppercase;
       letter-spacing: 0.04em;
-      min-width: 120px;
+      min-width: 90px;
       flex-shrink: 0;
     }
     .field-value {
@@ -777,13 +777,15 @@
       opacity: 1;
       transform: translateX(-50%) translateY(0);
     }
+    @media (max-width: 960px) {
+      .case-info-grid { grid-template-columns: 1fr; }
+      .case-field:nth-child(even) { padding-left: 0; border-left: none; }
+      .case-field:nth-child(odd) { padding-right: 0; }
+    }
     @media (max-width: 768px) {
       .page-wrap { grid-template-columns: 1fr; }
       .site-header .wrap { flex-wrap: wrap; }
       .header-right { display: none; }
-      .case-info-grid { grid-template-columns: 1fr; }
-      .case-field:nth-child(even) { padding-left: 0; border-left: none; }
-      .case-field:nth-child(odd) { padding-right: 0; }
       .footer-grid { grid-template-columns: 1fr; }
       .district-resources-grid { grid-template-columns: 1fr; }
       .site-nav .wrap { flex-wrap: wrap; }

--- a/is/writing/perch-chat/index.html
+++ b/is/writing/perch-chat/index.html
@@ -622,12 +622,6 @@
       cursor: default;
     }
 
-    .chat-input a {
-      color: var(--text-dim);
-      text-decoration: underline;
-      text-decoration-color: var(--border);
-    }
-
     @media (max-width: 700px) {
       .mobile-header {
         display: flex;
@@ -1191,7 +1185,7 @@
                 '<div id="chat-end"></div>' +
               '</div>' +
               '<div class="chat-input-shell">' +
-                '<div class="chat-input">Observer mode. Request posting access: <a href="mailto:access@ajin.im">access@ajin.im</a></div>' +
+                '<div class="chat-input">Observer mode. To post, request access from the channel administrator.</div>' +
               '</div>' +
             '</main>' +
           '</div>' +


### PR DESCRIPTION
## Summary
- Remove email link from Perch observer bar — now plain text: "Observer mode. To post, request access from the channel administrator."
- Fix nest-court case info grid text wrapping at narrower viewports by reducing field label min-width (120px → 90px) and adding a 960px breakpoint to switch to single-column layout when sidebar squeezes the grid

## Verification
- Perch observer bar: confirmed uniform `--text-ghost` color, no link
- Nest-court at 900px: all field values fit single line (single-column grid)
- Nest-court at 1280px: two-column grid with adequate space
- Mobile (375px): clean single-column layout

## Test plan
- [ ] Load The Perch → observer bar shows plain text, no email link
- [ ] Load nest-court at ~900px width → case fields single column, no excessive wrapping
- [ ] Load nest-court at desktop width → case fields two-column layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)