### PR TITLE
Connect interactive endpoints across sites

### DIFF
--- a/is/writing/nest-court-proceedings-pigeon/index.html
+++ b/is/writing/nest-court-proceedings-pigeon/index.html
@@ -37,6 +37,8 @@ color:#2a2620;
 .qt-a{font-family:'IBM Plex Mono',monospace;font-size:10px;color:#a09880;margin-top:6px}
 .cl{margin:1rem 0;padding:.8rem 1rem;background:#eee9de;border-radius:10px}
 .cl-t{font-family:'IBM Plex Mono',monospace;font-size:13px;line-height:1.6;color:#7a7264;font-style:italic}
+.cl-t a{color:#7a7264;transition:color .15s}
+.cl-t a:hover{color:#4a4438}
 .q{font-family:'Source Serif 4',Georgia,serif;font-size:19px;color:#2a2620;line-height:1.5;margin:1.5rem 0 1rem}
 .opt{background:#fff;border:1.5px solid #e0dbd0;border-radius:12px;padding:1rem 1.1rem;margin-bottom:8px;cursor:pointer;transition:all .2s;-webkit-tap-highlight-color:transparent}
 .opt:hover{border-color:#c47a5a;background:#fdf9f4}
@@ -263,6 +265,9 @@ function renderAssessment() {
   h += '<div class="assess-owl-t" style="margin-top:.6rem">"Standard municipal quiet hours apply. The Court declines to impose stricter hours than those that govern every other resident of this district. A pigeon is a resident."</div>';
   h += '<div class="assess-owl-t" style="margin-top:.6rem">"No fine is imposed. The Respondent is referred to the district\u2019s community services office for a voluntary check-in. The Court does not compel attendance but notes that the Respondent has been cooing alone for eighteen months and that the volume, in the Court\u2019s experience, is unlikely to decrease on its own."</div>';
   h += '</div></div>';
+
+  h += '<div class="card"><div class="cl"><div class="cl-t">Other cases open for gallery observation: <a href="/is/writing/nest-court-proceedings/">Dove v. Dove</a> \u00b7 <a href="/is/writing/nest-court-proceedings-starling/">Starling v. Starling</a></div></div></div>';
+
   document.getElementById('content').innerHTML = h;
   renderPips();
   document.getElementById('goBtn').style.display = 'none';

--- a/is/writing/nest-court-proceedings-starling/index.html
+++ b/is/writing/nest-court-proceedings-starling/index.html
@@ -37,6 +37,8 @@ color:#2a2620;
 .qt-a{font-family:'IBM Plex Mono',monospace;font-size:10px;color:#a09880;margin-top:6px}
 .cl{margin:1rem 0;padding:.8rem 1rem;background:#eee9de;border-radius:10px}
 .cl-t{font-family:'IBM Plex Mono',monospace;font-size:13px;line-height:1.6;color:#7a7264;font-style:italic}
+.cl-t a{color:#7a7264;transition:color .15s}
+.cl-t a:hover{color:#4a4438}
 .q{font-family:'Source Serif 4',Georgia,serif;font-size:19px;color:#2a2620;line-height:1.5;margin:1.5rem 0 1rem}
 .opt{background:#fff;border:1.5px solid #e0dbd0;border-radius:12px;padding:1rem 1.1rem;margin-bottom:8px;cursor:pointer;transition:all .2s;-webkit-tap-highlight-color:transparent}
 .opt:hover{border-color:#c47a5a;background:#fdf9f4}
@@ -261,6 +263,9 @@ function renderAssessment() {
   h += '<div class="assess-owl-t">"Custody arrangement approved: primary residence with the Petitioner. Alternating weekends and shared Wednesday evenings with the Respondent. One floating holiday to be agreed upon annually by both parties. The Court reminds both parties that \u2018floating\u2019 refers to the schedule, not the method of transport."</div>';
   h += '<div class="assess-owl-t" style="margin-top:.6rem">"Relocation beyond 0.5 miles by either party requires prior Court approval. The eggs are not to be used as evidence in future proceedings. They are eggs."</div>';
   h += '</div></div>';
+
+  h += '<div class="card"><div class="cl"><div class="cl-t">Other cases open for gallery observation: <a href="/is/writing/nest-court-proceedings/">Dove v. Dove</a> \u00b7 <a href="/is/writing/nest-court-proceedings-pigeon/">District v. Pigeon</a></div></div></div>';
+
   document.getElementById('content').innerHTML = h;
   renderPips();
   document.getElementById('goBtn').style.display = 'none';

--- a/is/writing/nest-court-proceedings/index.html
+++ b/is/writing/nest-court-proceedings/index.html
@@ -55,6 +55,8 @@ overflow:hidden;
 /* CLERK NOTES */
 .cl{margin:1rem 0;padding:.8rem 1rem;background:#eee9de;border-radius:10px}
 .cl-t{font-family:'IBM Plex Mono',monospace;font-size:13px;line-height:1.6;color:#7a7264;font-style:italic}
+.cl-t a{color:#7a7264;transition:color .15s}
+.cl-t a:hover{color:#4a4438}
 
 /* QUESTION */
 .q{font-family:'Source Serif 4',Georgia,serif;font-size:19px;color:#2a2620;line-height:1.5;margin:1.5rem 0 1rem}
@@ -319,6 +321,8 @@ function renderAssessment() {
   h += '<div class="assess-owl-t">"The petition is granted. The nest at 14 Sycamore Lane is awarded to the Petitioner, including all materials. The zip tie is designated a structural fixture of the nest and is not awarded to either party individually. It is the nest\u2019s."</div>';
   h += '<div class="assess-owl-t" style="margin-top:.6rem">"A No-Perch Order is granted at a modified radius of thirty wingspans. Custody of the two eggs is awarded to the Petitioner, with supervised visitation through the Clerk\u2019s office. The Respondent is reminded that \u2018supervised\u2019 means someone is watching. It will not be Ms. Sparrow."</div>';
   h += '</div></div>';
+
+  h += '<div class="card"><div class="cl"><div class="cl-t">Other cases open for gallery observation: <a href="/is/writing/nest-court-proceedings-starling/">Starling v. Starling</a> \u00b7 <a href="/is/writing/nest-court-proceedings-pigeon/">District v. Pigeon</a></div></div></div>';
 
   document.getElementById('content').innerHTML = h;
   renderPips();

--- a/is/writing/secondnest/index.html
+++ b/is/writing/secondnest/index.html
@@ -582,6 +582,7 @@ margin-top:10px;
       <p>SecondNest is for birds. You seem like a perfectly fine mammal, but this is not your site. We wish you well in your own species' romantic endeavors, which by all accounts are also difficult.</p>
       <p>If you believe this determination was made in error, you are welcome to try again with your feet.</p>
       <div class="ref">Ref: SN-VERIFY-2026-NR · Flagged: non-avian input detected</div>
+      <div class="ref" style="margin-top:8px">Wrongful denial of service? <a href="/is/writing/karen-hawk/" style="color:#b0a888">Karen Hawk, Attorney at Law</a></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- **Proceedings gallery cross-reference**: After completing a gallery assessment, a clerk's note lists the other two cases available for observation with links. Uses existing `.cl` styling (monospace, muted).
- **SecondNest rejection → Karen Hawk**: After the "you type like someone with thumbs" rejection, a small ad line: "Wrongful denial of service? Karen Hawk, Attorney at Law." Consistent with SecondNest's existing Karen Hawk sponsor placement.

## Files changed
- `nest-court-proceedings/index.html` — CSS for clerk note links + cross-reference to Starling & Pigeon
- `nest-court-proceedings-pigeon/index.html` — same, cross-references Dove & Starling
- `nest-court-proceedings-starling/index.html` — same, cross-references Dove & Pigeon
- `secondnest/index.html` — Karen Hawk ad line after rejection

## Test plan
- [ ] Complete each proceedings assessment and verify cross-reference appears after Judge Owl's ruling
- [ ] Verify cross-reference links point to correct cases (each page links to the OTHER two)
- [ ] Trigger SecondNest rejection and verify Karen Hawk line appears below the ref code
- [ ] Verify no JS errors on any modified page

🤖 Generated with [Claude Code](https://claude.com/claude-code)