### PR TITLE
Cross-site links open in new tabs, case codes linked, search functional

### DIFF
--- a/is/writing/avian-district/index.html
+++ b/is/writing/avian-district/index.html
@@ -350,7 +350,7 @@ a:hover { color: var(--link-hover); }
     <p class="title-sub">Official portal · Services, notices, and public records</p>
     <div class="notice-box">
       <span class="notice-label">District Notice</span>
-      Quiet hours compliance review in progress (AMNC-2026-011A). Residents of Municipal Oak are reminded that 6:29 AM is before 6:30 AM.
+      Quiet hours compliance review in progress (<a href="/is/writing/nest-court/" target="_blank" style="color:inherit;text-decoration:underline">AMNC-2026-011A</a>). Residents of Municipal Oak are reminded that 6:29 AM is before 6:30 AM.
     </div>
   </div>
 </div>
@@ -369,27 +369,27 @@ a:hover { color: var(--link-hover); }
   <div class="section-heading">District Services</div>
 
   <div class="services-grid">
-    <a class="service-card" href="/is/writing/nest-court/">
+    <a class="service-card" href="/is/writing/nest-court/" target="_blank">
       <div class="card-category">Judicial</div>
       <div class="card-title">Nest Court — eCourt Public Portal</div>
       <div class="card-desc">Case filings, hearing schedules, rulings, and docket records. Public access under Ordinance 14.7(b). Spectators reviewing active cases are asked to refrain from editorial commentary in the queue.</div>
     </a>
-    <a class="service-card" href="/is/writing/bird-coo/">
+    <a class="service-card" href="/is/writing/bird-coo/" target="_blank">
       <div class="card-category">Media</div>
       <div class="card-title">The Municipal Coo</div>
       <div class="card-desc">The district's newspaper of record. Published weekly. Court coverage, community letters, classifieds, and licensed practitioner advertising. The Coo operates independently of the Clerk's Office and has been reminded of this whenever it publishes something the Clerk's Office would have preferred it didn't.</div>
     </a>
-    <a class="service-card" href="/is/writing/secondnest/">
+    <a class="service-card" href="/is/writing/secondnest/" target="_blank">
       <div class="card-category">Community</div>
       <div class="card-title">SecondNest</div>
       <div class="card-desc">Community personals platform. The Clerk's Office does not operate, endorse, or moderate SecondNest. Residents who recognise someone on the platform are encouraged to mind their business.</div>
     </a>
-    <a class="service-card" href="/is/writing/perch-chat/">
+    <a class="service-card" href="/is/writing/perch-chat/" target="_blank">
       <div class="card-category">Community</div>
       <div class="card-title">The Perch — Community Chat</div>
       <div class="card-desc">District messaging platform maintained by the Clerk's Office for municipal coordination. Used by residents for municipal coordination approximately 15% of the time.</div>
     </a>
-    <a class="service-card full-width" href="/is/writing/karen-hawk/">
+    <a class="service-card full-width" href="/is/writing/karen-hawk/" target="_blank">
       <div class="card-category">Licensed Practitioner</div>
       <div class="card-title">Karen Hawk, Attorney at Law</div>
       <div class="card-desc">Family law. Eighteen years. The Clerk's Office processes her filings more frequently than any other practitioner's. This is not an endorsement. It is a volume observation.</div>
@@ -433,7 +433,7 @@ a:hover { color: var(--link-hover); }
 
   <div class="faq-item">
     <div class="faq-q">How do I file a nest abandonment claim?</div>
-    <div class="faq-a">Petitions may be submitted through the <a href="/is/writing/nest-court/">eCourt Public Portal</a> or in person during business hours. Documentation should include a description of the nest, the date of departure, and evidence of where the respondent went. "He knows what he did" is not evidence.</div>
+    <div class="faq-a">Petitions may be submitted through the <a href="/is/writing/nest-court/" target="_blank">eCourt Public Portal</a> or in person during business hours. Documentation should include a description of the nest, the date of departure, and evidence of where the respondent went. "He knows what he did" is not evidence.</div>
   </div>
   <div class="faq-item">
     <div class="faq-q">How do I file a noise complaint?</div>
@@ -476,11 +476,11 @@ a:hover { color: var(--link-hover); }
     </div>
     <div class="footer-col footer-links">
       <h4>District Services</h4>
-      <p><a href="/is/writing/nest-court/">Nest Court</a></p>
-      <p><a href="/is/writing/bird-coo/">The Municipal Coo</a></p>
-      <p><a href="/is/writing/secondnest/">SecondNest</a></p>
-      <p><a href="/is/writing/perch-chat/">The Perch</a></p>
-      <p><a href="/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a></p>
+      <p><a href="/is/writing/nest-court/" target="_blank">Nest Court</a></p>
+      <p><a href="/is/writing/bird-coo/" target="_blank">The Municipal Coo</a></p>
+      <p><a href="/is/writing/secondnest/" target="_blank">SecondNest</a></p>
+      <p><a href="/is/writing/perch-chat/" target="_blank">The Perch</a></p>
+      <p><a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk, Attorney at Law</a></p>
     </div>
   </footer>
 

--- a/is/writing/bird-coo/index.html
+++ b/is/writing/bird-coo/index.html
@@ -123,7 +123,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./issues/index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-03-10.html
+++ b/is/writing/bird-coo/issues/2026-03-10.html
@@ -114,7 +114,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-03-17.html
+++ b/is/writing/bird-coo/issues/2026-03-17.html
@@ -117,7 +117,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-03-24.html
+++ b/is/writing/bird-coo/issues/2026-03-24.html
@@ -122,7 +122,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-03-31.html
+++ b/is/writing/bird-coo/issues/2026-03-31.html
@@ -118,7 +118,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-04-07.html
+++ b/is/writing/bird-coo/issues/2026-04-07.html
@@ -123,7 +123,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-04-14.html
+++ b/is/writing/bird-coo/issues/2026-04-14.html
@@ -41,7 +41,7 @@
 <h2 class="lead-headline">Dove v. Dove Hearing Concludes; Ruling Expected</h2>
 <div class="lead-dateline">Nest Court, Chamber B · Court Desk</div>
 <div class="lead-text">
-<p>The hearing on the merits in Dove v. Dove (AMNC-2026-007B) concluded Monday after approximately ninety minutes of testimony. Both parties appeared pro se. A witness for the Petitioner was also heard.</p>
+<p>The hearing on the merits in Dove v. Dove (<a href="/is/writing/nest-court/" target="_blank" style="color:inherit">AMNC-2026-007B</a>) concluded Monday after approximately ninety minutes of testimony. Both parties appeared pro se. A witness for the Petitioner was also heard.</p>
 <p>Details of the testimony have not been released, though the Clerk's office confirmed that a six-page supplemental filing by the witness was entered into the record over the objection of no one, because no one had been asked.</p>
 <p>Hon. M. Owl is expected to issue a ruling within ten business days. The Court has reminded both parties that "business days" does not include weekends, holidays, or days when the Clerk is not in the mood to process paperwork.</p>
 <p>The disputed nest at 14 Sycamore Lane, Lot 7, remains occupied by the Petitioner and two unhatched eggs.</p>
@@ -121,7 +121,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-04-21.html
+++ b/is/writing/bird-coo/issues/2026-04-21.html
@@ -122,7 +122,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-04-28.html
+++ b/is/writing/bird-coo/issues/2026-04-28.html
@@ -41,7 +41,7 @@
 <h2 class="lead-headline">Conrad Performs Unauthorized Dawn Concert; Three Residents File Joint Complaint</h2>
 <div class="lead-dateline">Municipal Oak · District Desk</div>
 <div class="lead-text">
-<p>Conrad, the mockingbird currently facing a noise/nuisance charge (AMNC-2026-011A), performed what witnesses described as a "forty-five-minute set" beginning at 4:32 AM on Saturday, thirteen days before his scheduled hearing.</p>
+<p>Conrad, the mockingbird currently facing a noise/nuisance charge (<a href="/is/writing/nest-court/" target="_blank" style="color:inherit">AMNC-2026-011A</a>), performed what witnesses described as a "forty-five-minute set" beginning at 4:32 AM on Saturday, thirteen days before his scheduled hearing.</p>
 <p>The performance, which neighbors say included original material as well as "impressions of what sounded like an argument between two doves," drew three new formal complaints and one unsigned note that read simply, "We know it's you."</p>
 <p>Conrad has not responded to requests for comment but was observed on the same branch Sunday morning at approximately 4:40 AM, tuning.</p>
 <p>His attorney, understood to be representing himself, has not filed any pre-hearing motions. The Clerk's office has confirmed the hearing will proceed as scheduled and has added a line to the docket description: "Respondent is advised that continued performances may be interpreted as contempt of quiet."</p>
@@ -121,7 +121,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-05-05.html
+++ b/is/writing/bird-coo/issues/2026-05-05.html
@@ -41,7 +41,7 @@
 <h2 class="lead-headline">Conrad Noise Hearing Draws Unexpected Attendance</h2>
 <div class="lead-dateline">Nest Court, Chamber B · Court Desk</div>
 <div class="lead-text">
-<p>The hearing in Municipal District v. Conrad (AMNC-2026-011A) took place Monday to what the Clerk's office described as "the fullest gallery since Finch v. Finch."</p>
+<p>The hearing in Municipal District v. Conrad (<a href="/is/writing/nest-court/" target="_blank" style="color:inherit">AMNC-2026-011A</a>) took place Monday to what the Clerk's office described as "the fullest gallery since Finch v. Finch."</p>
 <p>Conrad, representing himself, arrived with prepared remarks and what he described as "a contextual performance sample." Hon. M. Owl denied the sample before it began.</p>
 <p>Testimony from three residents of Municipal Oak described the pre-dawn performances as "impossible to sleep through," "deliberately aimed at specific windows," and, from one witness, "honestly pretty good, which makes it worse."</p>
 <p>Conrad argued that his singing constituted protected expression. The Court noted that protection does not extend to 4:30 AM or to material that two witnesses independently identified as "a reenactment of someone else's divorce."</p>
@@ -124,7 +124,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-05-12.html
+++ b/is/writing/bird-coo/issues/2026-05-12.html
@@ -41,7 +41,7 @@
 <h2 class="lead-headline">Conrad Noise Ruling: Restricted Hours, No Restrictions on Feeling</h2>
 <div class="lead-dateline">Nest Court, Chamber B · Court Desk</div>
 <div class="lead-text">
-<p>Hon. M. Owl has issued the ruling in Municipal District v. Conrad (AMNC-2026-011A).</p>
+<p>Hon. M. Owl has issued the ruling in Municipal District v. Conrad (<a href="/is/writing/nest-court/" target="_blank" style="color:inherit">AMNC-2026-011A</a>).</p>
 <p>The Court found that the Respondent's pre-dawn vocal performances constituted a noise disturbance under Avian Municipal Ordinance 9.3(a), but declined to impose a full singing ban.</p>
 <p>Instead, the Court has ordered a "quiet hours" restriction prohibiting amplified or sustained vocal performance between 9 PM and 6:30 AM. The Court's written opinion noted: "The Respondent is permitted to feel whatever he feels. He is not permitted to feel it at volume before sunrise."</p>
 <p>Conrad was observed leaving the courtroom without comment. By Wednesday he had been heard singing at 6:34 AM, which technically complies.</p>
@@ -121,7 +121,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-05-19.html
+++ b/is/writing/bird-coo/issues/2026-05-19.html
@@ -122,7 +122,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-05-26.html
+++ b/is/writing/bird-coo/issues/2026-05-26.html
@@ -122,7 +122,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/2026-06-02.html
+++ b/is/writing/bird-coo/issues/2026-06-02.html
@@ -55,10 +55,10 @@
 <div class="court-notice-header">Avian Municipal Nest Court — Branch Division</div>
 <h3>Docket Summary — Spring Term</h3>
 <p>The Clerk's office reports the following active matters for the current term:</p>
-<p>AMNC-2026-007B (Dove v. Dove) — Ruling issued. Compliance monitoring.</p>
-<p>AMNC-2026-009A (Wren v. Wren) — Ruled. Respondent ordered to vary the rhythm.</p>
-<p>AMNC-2026-011A (Municipal District v. Conrad) — Ruled. Quiet hours in effect. One potential violation under review.</p>
-<p>AMNC-2026-014B (Pigeon v. Pigeon) — Default ruling entered. No further action.</p>
+<p><a href="/is/writing/nest-court/" target="_blank" style="color:inherit">AMNC-2026-007B</a> (Dove v. Dove) — Ruling issued. Compliance monitoring.</p>
+<p><a href="/is/writing/nest-court/" target="_blank" style="color:inherit">AMNC-2026-009A</a> (Wren v. Wren) — Ruled. Respondent ordered to vary the rhythm.</p>
+<p><a href="/is/writing/nest-court/" target="_blank" style="color:inherit">AMNC-2026-011A</a> (Municipal District v. Conrad) — Ruled. Quiet hours in effect. One potential violation under review.</p>
+<p><a href="/is/writing/nest-court/" target="_blank" style="color:inherit">AMNC-2026-014B</a> (Pigeon v. Pigeon) — Default ruling entered. No further action.</p>
 <p>The Court notes that the spring term has been "active in a way that suggests the winter was difficult for many." This is not a legal observation.</p>
 <p>Clerk: T. Nuthatch.</p>
 <div class="court-notice-footer">Nest Court of the Avian Municipal District · 14 Municipal Oak, Third Fork · Sycamore District</div>
@@ -128,7 +128,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
 <p><a href="./index.html">Past Issues</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 

--- a/is/writing/bird-coo/issues/index.html
+++ b/is/writing/bird-coo/issues/index.html
@@ -84,7 +84,7 @@
 <p>The Municipal Coo is the local online edition for the Avian Municipal District.</p>
 <p><a href="../index.html">Return to current issue</a></p>
 <div class="district-links">
-<p><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+<p><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </div>
 </footer>
 </div>

--- a/is/writing/karen-hawk/index.html
+++ b/is/writing/karen-hawk/index.html
@@ -1114,11 +1114,11 @@
         </div>
         <div class="footer-block">
           <h3>District Links</h3>
-          <a href="/is/writing/avian-district/">Avian Municipal District</a>
-          <a href="/is/writing/nest-court/">Nest Court</a>
-          <a href="/is/writing/bird-coo/">The Municipal Coo</a>
-          <a href="/is/writing/secondnest/">SecondNest</a>
-          <a href="/is/writing/perch-chat/">The Perch</a>
+          <a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a>
+          <a href="/is/writing/nest-court/" target="_blank">Nest Court</a>
+          <a href="/is/writing/bird-coo/" target="_blank">The Municipal Coo</a>
+          <a href="/is/writing/secondnest/" target="_blank">SecondNest</a>
+          <a href="/is/writing/perch-chat/" target="_blank">The Perch</a>
         </div>
       </div>
       <p class="footer-disclaimer">

--- a/is/writing/nest-court-proceedings-pigeon/index.html
+++ b/is/writing/nest-court-proceedings-pigeon/index.html
@@ -74,7 +74,7 @@ color:#2a2620;
 
 <div class="shell">
 <div class="hd">
-  <a class="hd-back" href="/is/writing/nest-court/">← Case Docket</a>
+  <a class="hd-back" href="/is/writing/nest-court/" target="_blank">← Case Docket</a>
   <div class="hd-case">District v. Pigeon</div>
   <div class="hd-meta">AMNC-2024-119A · Noise / nuisance · Gallery seat assigned</div>
 </div>
@@ -89,10 +89,10 @@ color:#2a2620;
     <span>Avian Municipal Nest Court</span>
   </div>
   <div class="ft-links">
-    <a href="/is/writing/bird-coo/">The Municipal Coo</a>
-    <a href="/is/writing/secondnest/">SecondNest</a>
-    <a href="/is/writing/perch-chat/">The Perch</a>
-    <a href="/is/writing/avian-district/">Avian Municipal District</a>
+    <a href="/is/writing/bird-coo/" target="_blank">The Municipal Coo</a>
+    <a href="/is/writing/secondnest/" target="_blank">SecondNest</a>
+    <a href="/is/writing/perch-chat/" target="_blank">The Perch</a>
+    <a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a>
   </div>
 </footer>
 </div>
@@ -266,7 +266,7 @@ function renderAssessment() {
   h += '<div class="assess-owl-t" style="margin-top:.6rem">"No fine is imposed. The Respondent is referred to the district\u2019s community services office for a voluntary check-in. The Court does not compel attendance but notes that the Respondent has been cooing alone for eighteen months and that the volume, in the Court\u2019s experience, is unlikely to decrease on its own."</div>';
   h += '</div></div>';
 
-  h += '<div class="card"><div class="cl"><div class="cl-t">Other cases open for gallery observation: <a href="/is/writing/nest-court-proceedings/">Dove v. Dove</a> \u00b7 <a href="/is/writing/nest-court-proceedings-starling/">Starling v. Starling</a></div></div></div>';
+  h += '<div class="card"><div class="cl"><div class="cl-t">Other cases open for gallery observation: <a href="/is/writing/nest-court-proceedings/" target="_blank">Dove v. Dove</a> \u00b7 <a href="/is/writing/nest-court-proceedings-starling/" target="_blank">Starling v. Starling</a></div></div></div>';
 
   document.getElementById('content').innerHTML = h;
   renderPips();

--- a/is/writing/nest-court-proceedings-starling/index.html
+++ b/is/writing/nest-court-proceedings-starling/index.html
@@ -74,7 +74,7 @@ color:#2a2620;
 
 <div class="shell">
 <div class="hd">
-  <a class="hd-back" href="/is/writing/nest-court/">← Case Docket</a>
+  <a class="hd-back" href="/is/writing/nest-court/" target="_blank">← Case Docket</a>
   <div class="hd-case">Starling v. Starling</div>
   <div class="hd-meta">AMNC-2025-022C · Egg custody · Gallery seat assigned</div>
 </div>
@@ -89,10 +89,10 @@ color:#2a2620;
     <span>Avian Municipal Nest Court</span>
   </div>
   <div class="ft-links">
-    <a href="/is/writing/bird-coo/">The Municipal Coo</a>
-    <a href="/is/writing/secondnest/">SecondNest</a>
-    <a href="/is/writing/perch-chat/">The Perch</a>
-    <a href="/is/writing/avian-district/">Avian Municipal District</a>
+    <a href="/is/writing/bird-coo/" target="_blank">The Municipal Coo</a>
+    <a href="/is/writing/secondnest/" target="_blank">SecondNest</a>
+    <a href="/is/writing/perch-chat/" target="_blank">The Perch</a>
+    <a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a>
   </div>
 </footer>
 </div>
@@ -264,7 +264,7 @@ function renderAssessment() {
   h += '<div class="assess-owl-t" style="margin-top:.6rem">"Relocation beyond 0.5 miles by either party requires prior Court approval. The eggs are not to be used as evidence in future proceedings. They are eggs."</div>';
   h += '</div></div>';
 
-  h += '<div class="card"><div class="cl"><div class="cl-t">Other cases open for gallery observation: <a href="/is/writing/nest-court-proceedings/">Dove v. Dove</a> \u00b7 <a href="/is/writing/nest-court-proceedings-pigeon/">District v. Pigeon</a></div></div></div>';
+  h += '<div class="card"><div class="cl"><div class="cl-t">Other cases open for gallery observation: <a href="/is/writing/nest-court-proceedings/" target="_blank">Dove v. Dove</a> \u00b7 <a href="/is/writing/nest-court-proceedings-pigeon/" target="_blank">District v. Pigeon</a></div></div></div>';
 
   document.getElementById('content').innerHTML = h;
   renderPips();

--- a/is/writing/nest-court-proceedings/index.html
+++ b/is/writing/nest-court-proceedings/index.html
@@ -106,7 +106,7 @@ overflow:hidden;
 <div class="shell">
 
 <div class="hd">
-  <a class="hd-back" href="/is/writing/nest-court/">← Case Docket</a>
+  <a class="hd-back" href="/is/writing/nest-court/" target="_blank">← Case Docket</a>
   <div class="hd-case">Dove v. Dove</div>
   <div class="hd-meta">AMNC-2026-007B · Nest abandonment · Gallery seat assigned</div>
 </div>
@@ -125,10 +125,10 @@ overflow:hidden;
     <span>Avian Municipal Nest Court</span>
   </div>
   <div class="ft-links">
-    <a href="/is/writing/bird-coo/">The Municipal Coo</a>
-    <a href="/is/writing/secondnest/">SecondNest</a>
-    <a href="/is/writing/perch-chat/">The Perch</a>
-    <a href="/is/writing/avian-district/">Avian Municipal District</a>
+    <a href="/is/writing/bird-coo/" target="_blank">The Municipal Coo</a>
+    <a href="/is/writing/secondnest/" target="_blank">SecondNest</a>
+    <a href="/is/writing/perch-chat/" target="_blank">The Perch</a>
+    <a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a>
   </div>
 </footer>
 
@@ -322,7 +322,7 @@ function renderAssessment() {
   h += '<div class="assess-owl-t" style="margin-top:.6rem">"A No-Perch Order is granted at a modified radius of thirty wingspans. Custody of the two eggs is awarded to the Petitioner, with supervised visitation through the Clerk\u2019s office. The Respondent is reminded that \u2018supervised\u2019 means someone is watching. It will not be Ms. Sparrow."</div>';
   h += '</div></div>';
 
-  h += '<div class="card"><div class="cl"><div class="cl-t">Other cases open for gallery observation: <a href="/is/writing/nest-court-proceedings-starling/">Starling v. Starling</a> \u00b7 <a href="/is/writing/nest-court-proceedings-pigeon/">District v. Pigeon</a></div></div></div>';
+  h += '<div class="card"><div class="cl"><div class="cl-t">Other cases open for gallery observation: <a href="/is/writing/nest-court-proceedings-starling/" target="_blank">Starling v. Starling</a> \u00b7 <a href="/is/writing/nest-court-proceedings-pigeon/" target="_blank">District v. Pigeon</a></div></div></div>';
 
   document.getElementById('content').innerHTML = h;
   renderPips();

--- a/is/writing/nest-court/index.html
+++ b/is/writing/nest-court/index.html
@@ -608,7 +608,7 @@
     }
     .footer-bottom a { color: rgba(255,255,255,0.4); }
 
-    /* ── search box (decorative) ───────────────── */
+    /* ── search box ───────────────── */
     .case-search-box {
       background: var(--bg-white);
       border: 1px solid var(--border);
@@ -701,6 +701,11 @@
     }
     .docket-row.expanded {
       background: var(--bg-alt) !important;
+    }
+    .docket-row.search-highlight {
+      background: rgba(139, 115, 66, 0.08);
+      outline: 1px solid var(--seal-gold);
+      outline-offset: -1px;
     }
 
     /* ── gallery assessment link ───────────────── */
@@ -927,7 +932,7 @@
           </tr>
           <tr class="docket-row active-case" data-case="AMNC-2026-007B">
             <td><span class="case-link">AMNC-2026-007B</span></td>
-            <td><a href="../nest-court-proceedings/" class="case-caption-link"><strong>Dove v. Dove</strong></a></td>
+            <td><a href="../nest-court-proceedings/" class="case-caption-link" target="_blank"><strong>Dove v. Dove</strong></a></td>
             <td>Nest Abandonment</td>
             <td>Feb 12, 2026</td>
             <td><span class="status-badge status-active">Active</span></td>
@@ -948,14 +953,14 @@
           </tr>
           <tr class="docket-row" data-case="AMNC-2025-022C">
             <td><span class="case-link">AMNC-2025-022C</span></td>
-            <td><a href="../nest-court-proceedings-starling/" class="case-caption-link">Starling v. Starling</a></td>
+            <td><a href="../nest-court-proceedings-starling/" class="case-caption-link" target="_blank">Starling v. Starling</a></td>
             <td>Egg Custody</td>
             <td>Jun 02, 2025</td>
             <td><span class="status-badge status-closed">Closed</span></td>
           </tr>
           <tr class="docket-row" data-case="AMNC-2024-119A">
             <td><span class="case-link">AMNC-2024-119A</span></td>
-            <td><a href="../nest-court-proceedings-pigeon/" class="case-caption-link">Avian Mun. Dist. v. Pigeon (J.)</a></td>
+            <td><a href="../nest-court-proceedings-pigeon/" class="case-caption-link" target="_blank">Avian Mun. Dist. v. Pigeon (J.)</a></td>
             <td>Noise / Nuisance</td>
             <td>Dec 14, 2024</td>
             <td><span class="status-badge status-closed">Closed</span></td>
@@ -1550,7 +1555,7 @@
 
         </div><!-- /filings-list dove -->
         <div class="panel-actions">
-          <a href="../nest-court-proceedings/" class="btn-gallery">View Gallery Assessment &rarr;</a>
+          <a href="../nest-court-proceedings/" class="btn-gallery" target="_blank">View Gallery Assessment &rarr;</a>
         </div>
       </div>
 
@@ -1950,7 +1955,7 @@
 
         </div><!-- /filings-list starling -->
         <div class="panel-actions">
-          <a href="../nest-court-proceedings-starling/" class="btn-gallery">View Gallery Assessment &rarr;</a>
+          <a href="../nest-court-proceedings-starling/" class="btn-gallery" target="_blank">View Gallery Assessment &rarr;</a>
         </div>
       </div>
 
@@ -2078,7 +2083,7 @@
 
         </div><!-- /filings-list pigeon -->
         <div class="panel-actions">
-          <a href="../nest-court-proceedings-pigeon/" class="btn-gallery">View Gallery Assessment &rarr;</a>
+          <a href="../nest-court-proceedings-pigeon/" class="btn-gallery" target="_blank">View Gallery Assessment &rarr;</a>
         </div>
       </div>
 
@@ -2199,7 +2204,7 @@
         </div>
       </div>
       <div class="district-resources">
-        <a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/bird-coo/">The Municipal Coo</a> · <a href="/is/writing/secondnest/">SecondNest</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk, Attorney at Law</a>
+        <a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/bird-coo/" target="_blank">The Municipal Coo</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk, Attorney at Law</a>
       </div>
       <div class="footer-bottom">
         <span>NestLaw&trade; eCourt Portal v2.3.1 · Maintained by Avian Municipal District IT Services. Do not peck the equipment.</span>
@@ -2249,22 +2254,52 @@
       });
     });
 
-    // Search button
+    // Search button — functional docket search
     document.querySelector('.search-btn').addEventListener('click', function() {
-      const input = document.getElementById('caseNo').value.trim();
-      const nameInput = document.getElementById('partyName').value.trim();
-      const existing = document.querySelector('.search-result-msg');
+      var caseInput = document.getElementById('caseNo').value.trim().toUpperCase();
+      var nameInput = document.getElementById('partyName').value.trim().toLowerCase();
+      var typeInput = document.getElementById('caseType').value;
+      var existing = document.querySelector('.search-result-msg');
       if (existing) existing.remove();
-      const msg = document.createElement('p');
+
+      // Remove previous highlights
+      document.querySelectorAll('.docket-row.search-highlight').forEach(function(r) {
+        r.classList.remove('search-highlight');
+      });
+
+      if (!caseInput && !nameInput && typeInput === 'All Types') {
+        var msg = document.createElement('p');
+        msg.className = 'search-result-msg';
+        msg.style.cssText = 'font-size:0.78rem;color:#7A7A7A;margin-top:8px;font-style:italic;';
+        msg.textContent = 'Please enter a case number, party name, or species. Alternatively, you may review the full docket below. It is not long.';
+        document.querySelector('.case-search-box').appendChild(msg);
+        return;
+      }
+
+      var rows = document.querySelectorAll('.docket-row');
+      var matches = [];
+      rows.forEach(function(row) {
+        var cells = row.querySelectorAll('td');
+        var rowCase = (cells[0] ? cells[0].textContent.trim().toUpperCase() : '');
+        var rowName = (cells[1] ? cells[1].textContent.trim().toLowerCase() : '');
+        var rowType = (cells[2] ? cells[2].textContent.trim() : '');
+        var caseMatch = !caseInput || rowCase.indexOf(caseInput) !== -1;
+        var nameMatch = !nameInput || rowName.indexOf(nameInput) !== -1;
+        var typeMatch = typeInput === 'All Types' || rowType === typeInput;
+        if (caseMatch && nameMatch && typeMatch) matches.push(row);
+      });
+
+      var msg = document.createElement('p');
       msg.className = 'search-result-msg';
       msg.style.cssText = 'font-size:0.78rem;color:#7A7A7A;margin-top:8px;font-style:italic;';
 
-      if (input || nameInput) {
-        msg.textContent = 'No additional cases match your search. The docket shown below represents the complete public record. If you believe a case is missing, it may be sealed, expunged, or simply none of your business.';
+      if (matches.length > 0) {
+        matches.forEach(function(row) { row.classList.add('search-highlight'); });
+        msg.textContent = matches.length + (matches.length === 1 ? ' case found.' : ' cases found.') + ' Highlighted below.';
+        matches[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
       } else {
-        msg.textContent = 'Please enter a case number, party name, or species. Alternatively, you may review the full docket below. It is not long.';
+        msg.textContent = 'No cases match your search. The docket shown below represents the complete public record. If you believe a case is missing, it may be sealed, expunged, or simply none of your business.';
       }
-
       document.querySelector('.case-search-box').appendChild(msg);
     });
 

--- a/is/writing/secondnest/index.html
+++ b/is/writing/secondnest/index.html
@@ -465,7 +465,7 @@ margin-top:10px;
 
 <div class="sponsor-banner">
   <div class="sponsor-label">Sponsored</div>
-  <a class="sponsor-copy" href="/is/writing/karen-hawk/">
+  <a class="sponsor-copy" href="/is/writing/karen-hawk/" target="_blank">
     <strong>Karen Hawk, Attorney at Law</strong>
     Back on the market? Karen Hawk can make sure you left the last one cleanly.
   </a>
@@ -496,7 +496,7 @@ margin-top:10px;
     <h4>How it works</h4>
     <p>Post a profile. Browse other profiles. If someone interests you, leave a feather. They'll be notified through the branch correspondence system. What happens after that is between you and your capacity for hope.</p>
     <p>There is no matching algorithm. There is no compatibility score. You read someone's words and you decide if those words sound like a bird you'd want to share a branch with. That's the whole technology.</p>
-    <p>If you'd prefer a shorter format, the <a href="/is/writing/bird-coo/">Municipal Coo</a> classifieds section also runs personal ads weekly.</p>
+    <p>If you'd prefer a shorter format, the <a href="/is/writing/bird-coo/" target="_blank">Municipal Coo</a> classifieds section also runs personal ads weekly.</p>
   </div>
   <div class="about-block">
     <h4>Who this is for</h4>
@@ -539,7 +539,7 @@ margin-top:10px;
   </div>
   <div class="faq-item">
     <div class="faq-q">Is SecondNest affiliated with the Nest Court or the Municipal Coo?</div>
-    <div class="faq-a">No. SecondNest is independently operated. We have no relationship with <a href="/is/writing/nest-court/">the Court</a> or <a href="/is/writing/bird-coo/">the newspaper</a>. We do occasionally sell ad space, which is not the same thing as endorsement, affiliation, or advice. If you see someone from your case on here, that is coincidence. Or the district is small. Both are true.</div>
+    <div class="faq-a">No. SecondNest is independently operated. We have no relationship with <a href="/is/writing/nest-court/" target="_blank">the Court</a> or <a href="/is/writing/bird-coo/" target="_blank">the newspaper</a>. We do occasionally sell ad space, which is not the same thing as endorsement, affiliation, or advice. If you see someone from your case on here, that is coincidence. Or the district is small. Both are true.</div>
   </div>
   <div class="faq-item">
     <div class="faq-q">The site looks like it was made in 2003.</div>
@@ -549,7 +549,7 @@ margin-top:10px;
 
 <footer class="site-footer">
   <p>SecondNest · For birds who still read the bio.</p>
-  <p class="district-link"><a href="/is/writing/avian-district/">Avian Municipal District</a> · <a href="/is/writing/nest-court/">Nest Court</a> · <a href="/is/writing/bird-coo/">The Municipal Coo</a> · <a href="/is/writing/perch-chat/">The Perch</a> · <a href="/is/writing/karen-hawk/">Karen Hawk</a></p>
+  <p class="district-link"><a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/bird-coo/" target="_blank">The Municipal Coo</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
 </footer>
 
 </div>
@@ -582,7 +582,7 @@ margin-top:10px;
       <p>SecondNest is for birds. You seem like a perfectly fine mammal, but this is not your site. We wish you well in your own species' romantic endeavors, which by all accounts are also difficult.</p>
       <p>If you believe this determination was made in error, you are welcome to try again with your feet.</p>
       <div class="ref">Ref: SN-VERIFY-2026-NR · Flagged: non-avian input detected</div>
-      <div class="ref" style="margin-top:8px">Wrongful denial of service? <a href="/is/writing/karen-hawk/" style="color:#b0a888">Karen Hawk, Attorney at Law</a></div>
+      <div class="ref" style="margin-top:8px">Wrongful denial of service? <a href="/is/writing/karen-hawk/" target="_blank" style="color:#b0a888">Karen Hawk, Attorney at Law</a></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- **New tab behavior**: All cross-site `<a>` links now open in new tabs (`target="_blank"`) across all 22 bird-universe HTML files (~120 links). Previously only bird-docket did this.
- **Case code linking**: AMNC case codes in avian-district banner notice and bird-coo issue body text are now clickable links to the nest-court docket (8 references across 6 files).
- **Functional search**: Nest-court case search now actually works — matches case number (full or partial), party name, and type filter against docket rows. Matching rows are highlighted with a gold outline and scrolled into view. In-character "no results" messaging preserved.

## Test plan
- [ ] Click any cross-site link on avian-district — verify it opens in a new tab
- [ ] Click AMNC-2026-011A in the avian-district banner — verify it opens nest-court
- [ ] On nest-court, search "dove" — verify Dove v. Dove is highlighted and scrolled to
- [ ] On nest-court, search by type "Noise / Nuisance" — verify 3 cases highlighted
- [ ] On nest-court, search gibberish — verify in-character no-results message
- [ ] Verify bird-coo issue body text case codes are clickable (e.g., 2026-06-02 docket summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)