### PR TITLE
Add /is/running personal stats page

### DIFF
--- a/_scripts/build_root.py
+++ b/_scripts/build_root.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
-"""Build ajin.im/index.html from templates/root.html + content/stats.md.
+"""Build ajin.im pages from templates/ + content/stats.md.
+
+Renders:
+  - index.html              (root sentence page) from templates/root.html
+  - is/running/index.html   (personal stats page) from templates/running.html
 
 Usage:
-    python3 _scripts/build_root.py          # write index.html
-    python3 _scripts/build_root.py --check  # print output, don't write
+    python3 _scripts/build_root.py          # write both
+    python3 _scripts/build_root.py --check  # print output sizes, don't write
 """
 
 import argparse
@@ -11,9 +15,11 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-TEMPLATE_PATH = ROOT / "templates" / "root.html"
+ROOT_TEMPLATE_PATH = ROOT / "templates" / "root.html"
+RUNNING_TEMPLATE_PATH = ROOT / "templates" / "running.html"
 STATS_PATH = ROOT / "content" / "stats.md"
 INDEX_PATH = ROOT / "index.html"
+RUNNING_INDEX_PATH = ROOT / "is" / "running" / "index.html"
 
 EARTH_KM = 40075
 MOON_KM = 384400
@@ -125,6 +131,10 @@ def earth_prose(total_km: int) -> str:
     return f"{ratio:.1f} times around earth"
 
 
+def earth_multiplier(total_km: int) -> str:
+    return f"{total_km / EARTH_KM:.2f}×"
+
+
 def render_reading_current(books: list[tuple[str, str]]) -> str:
     if not books:
         raise StatsError("reading_current: at least one book required")
@@ -158,7 +168,23 @@ def render_reading_year(books: list[tuple[str, str]]) -> str:
     return out
 
 
-def build(check_only: bool = False) -> str:
+def render(template_path: Path, replacements: dict[str, str]) -> str:
+    if not template_path.is_file():
+        raise StatsError(f"template not found: {template_path}")
+    template = template_path.read_text(encoding="utf-8")
+    used = {t: v for t, v in replacements.items() if t in template}
+    if not used:
+        raise StatsError(f"template uses no known tokens: {template_path}")
+    output = template
+    for token, value in used.items():
+        output = output.replace(token, value)
+    leftover = [t for t in used if t in output]
+    if leftover:
+        raise StatsError(f"unresolved tokens after substitution in {template_path.name}: {leftover}")
+    return output
+
+
+def build(check_only: bool = False) -> None:
     sections = parse_stats(STATS_PATH)
 
     running_kv = parse_kv(require(sections, "running"), "running")
@@ -171,6 +197,7 @@ def build(check_only: bool = False) -> str:
     remaining_km = MOON_KM - total_km
     remaining_fmt = f"{remaining_km:,}"
     earth = earth_prose(total_km)
+    earth_mult = earth_multiplier(total_km)
 
     books_current = parse_books(require(sections, "reading_current"), "reading_current")
     reading_current_html = render_reading_current(books_current)
@@ -182,45 +209,35 @@ def build(check_only: bool = False) -> str:
     if not learning:
         raise StatsError("learning: section body is empty")
 
-    if not TEMPLATE_PATH.is_file():
-        raise StatsError(f"template not found: {TEMPLATE_PATH}")
-    template = TEMPLATE_PATH.read_text(encoding="utf-8")
-
     replacements = {
         "{{running_total_km}}": total_km_fmt,
         "{{running_since}}": str(since_year),
         "{{running_earth_prose}}": earth,
+        "{{running_earth_multiplier}}": earth_mult,
         "{{running_moon_remaining}}": remaining_fmt,
         "{{reading_current}}": reading_current_html,
         "{{reading_year}}": reading_year_str,
         "{{learning}}": learning,
     }
 
-    for token in replacements:
-        if token not in template:
-            raise StatsError(f"template missing token: {token}")
+    targets: list[tuple[Path, Path]] = [
+        (ROOT_TEMPLATE_PATH, INDEX_PATH),
+        (RUNNING_TEMPLATE_PATH, RUNNING_INDEX_PATH),
+    ]
 
-    output = template
-    for token, value in replacements.items():
-        output = output.replace(token, value)
-
-    unresolved = [t for t in replacements if t in output]
-    if unresolved:
-        raise StatsError(f"unresolved tokens after substitution: {unresolved}")
-
-    if not check_only:
-        INDEX_PATH.write_text(output, encoding="utf-8")
-
-    print(f"running: {total_km_fmt} km since {since_year} — {earth} — {remaining_fmt} km left")
+    print(f"running: {total_km_fmt} km since {since_year} — {earth} ({earth_mult}) — {remaining_fmt} km left")
     print(f"reading_current: {len(books_current)} book(s)")
     print(f"reading_year: {len(books_year)} book(s) (actives + paused combined)")
     print(f"learning: {learning!r}")
-    if check_only:
-        print(f"--check mode: would write {INDEX_PATH} ({len(output)} bytes)")
-    else:
-        print(f"wrote {INDEX_PATH} ({len(output)} bytes)")
 
-    return output
+    for tpl, out_path in targets:
+        output = render(tpl, replacements)
+        if check_only:
+            print(f"--check mode: would write {out_path} ({len(output)} bytes)")
+        else:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(output, encoding="utf-8")
+            print(f"wrote {out_path} ({len(output)} bytes)")
 
 
 def main() -> int:

--- a/is/running/index.html
+++ b/is/running/index.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ajin.im is running</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;1,8..60,400&family=IBM+Plex+Mono:wght@300;400&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #1a1612;
+    --text: #e8e0d0;
+    --text-soft: #8a7f70;
+    --text-faint: #6a6055;
+    --rule: rgba(138, 127, 112, 0.18);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Source Serif 4', Georgia, serif;
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
+  }
+
+  /* subtle warm grain — continuous with root page */
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.85 0 0 0 0 0.78 0 0 0 0 0.66 0 0 0 0.06 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    opacity: 0.4;
+    mix-blend-mode: overlay;
+    z-index: 1;
+  }
+
+  main {
+    position: relative;
+    z-index: 2;
+    max-width: 560px;
+    margin: 0 auto;
+    padding: 10vh 8vw 8vh;
+  }
+
+  .title {
+    font-size: 1.35rem;
+    font-weight: 400;
+    letter-spacing: -0.005em;
+    margin-bottom: 3.5rem;
+    color: var(--text);
+    animation: fade 0.9s ease-out 0.1s both;
+  }
+
+  .title .prefix {
+    color: var(--text-faint);
+  }
+
+  .title .verb {
+    font-style: italic;
+  }
+
+  /* numbers block */
+  .stats {
+    margin-bottom: 3.5rem;
+    animation: fade 0.9s ease-out 0.25s both;
+  }
+
+  .stat {
+    display: flex;
+    align-items: baseline;
+    gap: 0.9rem;
+    padding: 0.6rem 0;
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .stat:first-child { border-top: 1px solid var(--rule); }
+
+  .stat-value {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 1.45rem;
+    font-weight: 300;
+    color: var(--text);
+    letter-spacing: -0.01em;
+    flex-shrink: 0;
+    min-width: 7.5rem;
+  }
+
+  .stat-label {
+    font-size: 0.92rem;
+    color: var(--text-soft);
+    line-height: 1.5;
+  }
+
+  .updated {
+    margin-top: 1rem;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.72rem;
+    color: var(--text-faint);
+    letter-spacing: 0.02em;
+  }
+
+  /* prose sections */
+  .prose {
+    color: var(--text-soft);
+    font-size: 1rem;
+    line-height: 1.7;
+    margin-bottom: 2.2rem;
+  }
+
+  .prose.first { animation: fade 0.9s ease-out 0.4s both; }
+  .prose.second { animation: fade 0.9s ease-out 0.55s both; }
+
+  .prose p { margin-bottom: 1rem; }
+  .prose p:last-child { margin-bottom: 0; }
+
+  .prose .em { color: var(--text); font-style: italic; }
+
+  .divider {
+    width: 40px;
+    height: 1px;
+    background: var(--rule);
+    margin: 2.8rem 0;
+  }
+
+  @keyframes fade {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  @media (max-width: 600px) {
+    main { padding: 7vh 7vw 6vh; }
+    .title { font-size: 1.18rem; margin-bottom: 2.5rem; }
+    .stat-value { font-size: 1.2rem; min-width: 6rem; }
+    .stat-label { font-size: 0.88rem; }
+    .prose { font-size: 0.96rem; }
+    .divider { margin: 2.2rem 0; }
+  }
+</style>
+</head>
+<body>
+
+<main>
+
+  <div class="title">
+    <span class="prefix">ajin.im is</span> <span class="verb">running to the moon</span>
+  </div>
+
+  <div class="stats">
+    <div class="stat">
+      <div class="stat-value">75,000 km</div>
+      <div class="stat-label">running, since 2009</div>
+    </div>
+    <div class="stat">
+      <div class="stat-value">1.87×</div>
+      <div class="stat-label">around the earth</div>
+    </div>
+    <div class="stat">
+      <div class="stat-value">309,400 km</div>
+      <div class="stat-label">to the moon</div>
+    </div>
+    <div class="updated">updated daily</div>
+  </div>
+
+  <div class="divider"></div>
+
+  <div class="prose first">
+    <p>
+      The <span class="em">common swift</span> spends almost its entire life in the air. Over a lifetime it covers roughly two million miles, about four round trips to the moon.
+    </p>
+    <p>
+      One trip is enough for me.
+    </p>
+  </div>
+
+  <div class="divider"></div>
+
+  <div class="prose second">
+    <p>
+      I've been running at least 10 km a day since 2009, and 15 km since 2017. I don't always wear the watch, so the numbers above aren't exact.
+    </p>
+    <p>
+      The earth is 40,075 km around. The moon is 384,400 km from here. If I keep going, I should make it.
+    </p>
+  </div>
+
+</main>
+
+</body>
+</html>

--- a/templates/running.html
+++ b/templates/running.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ajin.im is running</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;1,8..60,400&family=IBM+Plex+Mono:wght@300;400&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #1a1612;
+    --text: #e8e0d0;
+    --text-soft: #8a7f70;
+    --text-faint: #6a6055;
+    --rule: rgba(138, 127, 112, 0.18);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Source Serif 4', Georgia, serif;
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
+  }
+
+  /* subtle warm grain — continuous with root page */
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.85 0 0 0 0 0.78 0 0 0 0 0.66 0 0 0 0.06 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    opacity: 0.4;
+    mix-blend-mode: overlay;
+    z-index: 1;
+  }
+
+  main {
+    position: relative;
+    z-index: 2;
+    max-width: 560px;
+    margin: 0 auto;
+    padding: 10vh 8vw 8vh;
+  }
+
+  .title {
+    font-size: 1.35rem;
+    font-weight: 400;
+    letter-spacing: -0.005em;
+    margin-bottom: 3.5rem;
+    color: var(--text);
+    animation: fade 0.9s ease-out 0.1s both;
+  }
+
+  .title .prefix {
+    color: var(--text-faint);
+  }
+
+  .title .verb {
+    font-style: italic;
+  }
+
+  /* numbers block */
+  .stats {
+    margin-bottom: 3.5rem;
+    animation: fade 0.9s ease-out 0.25s both;
+  }
+
+  .stat {
+    display: flex;
+    align-items: baseline;
+    gap: 0.9rem;
+    padding: 0.6rem 0;
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .stat:first-child { border-top: 1px solid var(--rule); }
+
+  .stat-value {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 1.45rem;
+    font-weight: 300;
+    color: var(--text);
+    letter-spacing: -0.01em;
+    flex-shrink: 0;
+    min-width: 7.5rem;
+  }
+
+  .stat-label {
+    font-size: 0.92rem;
+    color: var(--text-soft);
+    line-height: 1.5;
+  }
+
+  .updated {
+    margin-top: 1rem;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.72rem;
+    color: var(--text-faint);
+    letter-spacing: 0.02em;
+  }
+
+  /* prose sections */
+  .prose {
+    color: var(--text-soft);
+    font-size: 1rem;
+    line-height: 1.7;
+    margin-bottom: 2.2rem;
+  }
+
+  .prose.first { animation: fade 0.9s ease-out 0.4s both; }
+  .prose.second { animation: fade 0.9s ease-out 0.55s both; }
+
+  .prose p { margin-bottom: 1rem; }
+  .prose p:last-child { margin-bottom: 0; }
+
+  .prose .em { color: var(--text); font-style: italic; }
+
+  .divider {
+    width: 40px;
+    height: 1px;
+    background: var(--rule);
+    margin: 2.8rem 0;
+  }
+
+  @keyframes fade {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  @media (max-width: 600px) {
+    main { padding: 7vh 7vw 6vh; }
+    .title { font-size: 1.18rem; margin-bottom: 2.5rem; }
+    .stat-value { font-size: 1.2rem; min-width: 6rem; }
+    .stat-label { font-size: 0.88rem; }
+    .prose { font-size: 0.96rem; }
+    .divider { margin: 2.2rem 0; }
+  }
+</style>
+</head>
+<body>
+
+<main>
+
+  <div class="title">
+    <span class="prefix">ajin.im is</span> <span class="verb">running to the moon</span>
+  </div>
+
+  <div class="stats">
+    <div class="stat">
+      <div class="stat-value">{{running_total_km}} km</div>
+      <div class="stat-label">running, since {{running_since}}</div>
+    </div>
+    <div class="stat">
+      <div class="stat-value">{{running_earth_multiplier}}</div>
+      <div class="stat-label">around the earth</div>
+    </div>
+    <div class="stat">
+      <div class="stat-value">{{running_moon_remaining}} km</div>
+      <div class="stat-label">to the moon</div>
+    </div>
+    <div class="updated">updated daily</div>
+  </div>
+
+  <div class="divider"></div>
+
+  <div class="prose first">
+    <p>
+      The <span class="em">common swift</span> spends almost its entire life in the air. Over a lifetime it covers roughly two million miles, about four round trips to the moon.
+    </p>
+    <p>
+      One trip is enough for me.
+    </p>
+  </div>
+
+  <div class="divider"></div>
+
+  <div class="prose second">
+    <p>
+      I've been running at least 10 km a day since 2009, and 15 km since 2017. I don't always wear the watch, so the numbers above aren't exact.
+    </p>
+    <p>
+      The earth is 40,075 km around. The moon is 384,400 km from here. If I keep going, I should make it.
+    </p>
+  </div>
+
+</main>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Standalone personal page at `/is/running` — same numbers as the main-page running stanza, presented as a stats block + prose
- Not linked from anywhere — for personal/bookmark use
- New token `{{running_earth_multiplier}}` (e.g. "1.87×") — used by this page only
- `build_root.py` now renders both `index.html` and `is/running/index.html` from one stats source

## Test plan
- [x] `python3 _scripts/build_root.py` writes both files cleanly
- [x] Output matches user-supplied design
- [ ] Check live page renders correctly after merge + Pages deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)