### PR TITLE
Creative house: parametrize room layout + fragment math

### DIFF
--- a/creative-house.css
+++ b/creative-house.css
@@ -195,6 +195,18 @@ footer {
   counter-reset: room-counter;
 }
 
+/* Mirror data-room-count into a CSS custom property so mobile fragment math
+   is generic (authors only ever edit the data attribute). Extend the range
+   if a house ever grows past eight rooms. */
+.house-grid[data-room-count="1"] { --house-room-count: 1; }
+.house-grid[data-room-count="2"] { --house-room-count: 2; }
+.house-grid[data-room-count="3"] { --house-room-count: 3; }
+.house-grid[data-room-count="4"] { --house-room-count: 4; }
+.house-grid[data-room-count="5"] { --house-room-count: 5; }
+.house-grid[data-room-count="6"] { --house-room-count: 6; }
+.house-grid[data-room-count="7"] { --house-room-count: 7; }
+.house-grid[data-room-count="8"] { --house-room-count: 8; }
+
 .room {
   --room-col-span: 1;
   --room-row-span: 2;
@@ -366,97 +378,31 @@ footer {
   transform: translateY(var(--room-copy-offset));
 }
 
+/* Desktop puzzle layout: each .room declares its grid cell via inline custom
+   properties (--desk-col-start/--desk-col-span/--desk-row-start/--desk-row-span)
+   and the parent .house-grid declares the total grid dimensions
+   (--desk-grid-cols, --desk-grid-rows). The seal-fragment background is
+   derived from those so each tile shows its quadrant of a single image that
+   is notionally stretched across the whole grid. No per-room CSS needed. */
 @media (min-width: 1101px) {
-  .house-grid[data-room-count="4"] {
-    --house-columns: 12;
+  .house-grid {
+    --house-columns: var(--desk-grid-cols, 12);
     --house-row-step: 5.6rem;
     grid-template-columns: repeat(var(--house-columns), minmax(0, 1fr));
     grid-auto-rows: minmax(var(--house-row-step), auto);
   }
 
-  .house-grid[data-room-count="4"] .room-bic {
-    grid-column: 1 / span 7;
-    grid-row: 1 / span 4;
-    min-height: 23rem;
+  .house-grid .room {
+    grid-column: var(--desk-col-start, auto) / span var(--desk-col-span, var(--room-col-span));
+    grid-row: var(--desk-row-start, auto) / span var(--desk-row-span, var(--room-row-span));
+    min-height: var(--desk-min-height, var(--room-min-height));
   }
 
-  .house-grid[data-room-count="4"] .room-small {
-    grid-column: 8 / span 5;
-    grid-row: 1 / span 4;
-    min-height: 23rem;
-  }
-
-  .house-grid[data-room-count="4"] .room-birds {
-    grid-column: 1 / span 6;
-    grid-row: 5 / span 3;
-    min-height: 15rem;
-  }
-
-  .house-grid[data-room-count="4"] .room-loose {
-    grid-column: 7 / span 6;
-    grid-row: 5 / span 3;
-    min-height: 15rem;
-  }
-
-  .writing-house .house-grid[data-room-count="4"] .room-bic {
-    --bg-w: calc(100% * 12 / 7);
-    --bg-h: calc(100% * 7 / 4);
-    --bg-left: 0%;
-    --bg-top: 0%;
-  }
-
-  .writing-house .house-grid[data-room-count="4"] .room-small {
-    --bg-w: calc(100% * 12 / 5);
-    --bg-h: calc(100% * 7 / 4);
-    --bg-left: calc(-100% * 7 / 5);
-    --bg-top: 0%;
-  }
-
-  .writing-house .house-grid[data-room-count="4"] .room-birds {
-    --bg-w: calc(100% * 12 / 6);
-    --bg-h: calc(100% * 7 / 3);
-    --bg-left: 0%;
-    --bg-top: calc(-100% * 4 / 3);
-  }
-
-  .writing-house .house-grid[data-room-count="4"] .room-loose {
-    --bg-w: calc(100% * 12 / 6);
-    --bg-h: calc(100% * 7 / 3);
-    --bg-left: -100%;
-    --bg-top: calc(-100% * 4 / 3);
-  }
-
-  .house-grid[data-room-count="2"] {
-    --house-columns: 12;
-    --house-row-step: 5.6rem;
-    grid-template-columns: repeat(var(--house-columns), minmax(0, 1fr));
-    grid-auto-rows: minmax(var(--house-row-step), auto);
-  }
-
-  .house-grid[data-room-count="2"] .room-debugu {
-    grid-column: 1 / span 6;
-    grid-row: 1 / span 4;
-    min-height: 23rem;
-  }
-
-  .house-grid[data-room-count="2"] .room-deadend {
-    grid-column: 7 / span 6;
-    grid-row: 1 / span 4;
-    min-height: 23rem;
-  }
-
-  .writing-house .house-grid[data-room-count="2"] .room-debugu {
-    --bg-w: calc(100% * 12 / 6);
-    --bg-h: 100%;
-    --bg-left: 0%;
-    --bg-top: 0%;
-  }
-
-  .writing-house .house-grid[data-room-count="2"] .room-deadend {
-    --bg-w: calc(100% * 12 / 6);
-    --bg-h: 100%;
-    --bg-left: -100%;
-    --bg-top: 0%;
+  .writing-house .house-grid .room {
+    --bg-w: calc(var(--desk-grid-cols, 12) / var(--desk-col-span) * 100%);
+    --bg-h: calc(var(--desk-grid-rows, 1) / var(--desk-row-span) * 100%);
+    --bg-left: calc((1 - var(--desk-col-start)) / var(--desk-col-span) * 100%);
+    --bg-top: calc((1 - var(--desk-row-start)) / var(--desk-row-span) * 100%);
   }
 }
 
@@ -578,28 +524,23 @@ footer {
     min-height: 14rem;
   }
 
+  /* Seal fragments stacked top-to-bottom: N rooms show N bands covering the
+     center 80% of the seal image. Each room's --room-index (0..N-1) and the
+     grid's --house-room-count drive both the image scale and the slice
+     position, so adding a room is purely an HTML change. */
   .writing-house .room::before {
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    background-size: auto 500%;
+    background-size: auto calc(var(--house-room-count, 4) * 125%);
     background-position-x: center;
-    background-position-y: var(--mobile-band-y, 0%);
+    background-position-y: calc(
+      50% * (var(--house-room-count, 4) + 8 * var(--room-index, 0)) /
+      (5 * var(--house-room-count, 4) - 4)
+    );
     filter: saturate(1.3) brightness(1.65) contrast(1.22);
   }
-
-  .writing-house .room-bic   { --mobile-band-y: 12.5%; }
-  .writing-house .room-birds { --mobile-band-y: 37.5%; }
-  .writing-house .room-loose { --mobile-band-y: 62.5%; }
-  .writing-house .room-small { --mobile-band-y: 87.5%; }
-
-  /* Two-card layouts (e.g. /is/writing/small): 2 bands covering center 80%. */
-  .writing-house .house-grid[data-room-count="2"] .room::before {
-    background-size: auto 250%;
-  }
-  .writing-house .house-grid[data-room-count="2"] .room-debugu  { --mobile-band-y: 16.67%; }
-  .writing-house .house-grid[data-room-count="2"] .room-deadend { --mobile-band-y: 83.33%; }
 
   .writing-house .room::after {
     background: linear-gradient(

--- a/is/writing/index.html
+++ b/is/writing/index.html
@@ -28,13 +28,14 @@
       </header>
 
       <section class="house-frame" aria-label="Creative rooms">
-        <div class="house-grid" data-room-count="4">
+        <div class="house-grid" data-room-count="4" style="--desk-grid-rows: 7;">
           <a
-            class="room room-bic room-featured"
+            class="room room-featured"
             href="https://propagandaformyself.xyz"
             target="_blank"
             rel="noreferrer noopener"
             data-room="bic"
+            style="--room-index: 0; --desk-col-start: 1; --desk-col-span: 7; --desk-row-start: 1; --desk-row-span: 4; --desk-min-height: 23rem;"
           >
             <div class="room-copy">
               <p class="room-kicker">Room <span class="room-number"></span> / Live</p>
@@ -44,9 +45,10 @@
           </a>
 
           <a
-            class="room room-birds"
+            class="room"
             href="./avian-district/index.html"
             data-room="birds"
+            style="--room-index: 1; --desk-col-start: 1; --desk-col-span: 6; --desk-row-start: 5; --desk-row-span: 3; --desk-min-height: 15rem;"
           >
             <div class="room-copy">
               <p class="room-kicker">Room <span class="room-number"></span> / Active</p>
@@ -55,7 +57,12 @@
             </div>
           </a>
 
-          <a class="room room-loose" href="/is/writing/loose/" data-room="loose">
+          <a
+            class="room"
+            href="/is/writing/loose/"
+            data-room="loose"
+            style="--room-index: 2; --desk-col-start: 7; --desk-col-span: 6; --desk-row-start: 5; --desk-row-span: 3; --desk-min-height: 15rem;"
+          >
             <div class="room-copy">
               <p class="room-kicker">Room <span class="room-number"></span> / Live</p>
               <h2>Loose pieces</h2>
@@ -63,7 +70,12 @@
             </div>
           </a>
 
-          <a class="room room-small room-wide" href="/is/writing/small/" data-room="small">
+          <a
+            class="room room-wide"
+            href="/is/writing/small/"
+            data-room="small"
+            style="--room-index: 3; --desk-col-start: 8; --desk-col-span: 5; --desk-row-start: 1; --desk-row-span: 4; --desk-min-height: 23rem;"
+          >
             <div class="room-copy">
               <p class="room-kicker">Room <span class="room-number"></span> / Live</p>
               <h2>Small tools</h2>

--- a/is/writing/small/index.html
+++ b/is/writing/small/index.html
@@ -26,13 +26,14 @@
       </header>
 
       <section class="house-frame" aria-label="Small tools">
-        <div class="house-grid" data-room-count="2">
+        <div class="house-grid" data-room-count="2" style="--desk-grid-rows: 4;">
           <a
-            class="room room-debugu"
+            class="room"
             href="https://debugu.xyz"
             target="_blank"
             rel="noreferrer noopener"
             data-room="debugu"
+            style="--room-index: 0; --desk-col-start: 1; --desk-col-span: 6; --desk-row-start: 1; --desk-row-span: 4; --desk-min-height: 23rem;"
           >
             <div class="room-copy">
               <p class="room-kicker">Tool <span class="room-number"></span> / Live</p>
@@ -41,7 +42,12 @@
             </div>
           </a>
 
-          <a class="room room-deadend" href="/is/writing/small/deadend/" data-room="deadend">
+          <a
+            class="room"
+            href="/is/writing/small/deadend/"
+            data-room="deadend"
+            style="--room-index: 1; --desk-col-start: 7; --desk-col-span: 6; --desk-row-start: 1; --desk-row-span: 4; --desk-min-height: 23rem;"
+          >
             <div class="room-copy">
               <p class="room-kicker">Tool <span class="room-number"></span> / Live</p>
               <h2>deadend</h2>


### PR DESCRIPTION
## Summary
- Desktop puzzle placement and mobile seal-fragment positions now read from HTML custom properties instead of per-class CSS rules.
- Each `.room` declares its own `--room-index`, `--desk-col-start/span`, `--desk-row-start/span`, `--desk-min-height`; the parent `.house-grid` sets `--desk-grid-rows` and `data-room-count`. CSS derives both the desktop `--bg-w/h/left/top` puzzle offsets and the mobile band position from those values.
- Dropped all `.room-bic`, `.room-birds`, `.room-loose`, `.room-small`, `.room-debugu`, `.room-deadend` grid/background rules. Editorial modifiers (`room-featured`, `room-wide`, `room-tall`) kept.
- Net: CSS -41 lines; adding a new room becomes an HTML-only change.

## Test plan
- [x] Desktop 1280px /is/writing/ — 4-room asymmetric puzzle (7+5 top, 6+6 bottom) intact; seal image tiles match pre-refactor bg offsets exactly.
- [x] Desktop 1280px /is/writing/small/ — 2-room split; circuit board image intact.
- [x] Tablet 768px — both pages stack into fragmented bands that reassemble the seal/circuit top-to-bottom.
- [x] Mobile 375px — 4-card bands at 12.5/37.5/62.5/87.5% and 2-card bands at 16.67/83.33% (matches pre-refactor values).
- [x] Breakpoint 1101px — puzzle layout; 1100px — stacked layout.
- [x] Hypothetical 5-room scenario — generic CSS handles it (data-room-count=5, --desk-grid-rows=10, new room with its own `--desk-*` vars). Mobile bands computed correctly at 11.9/30.95/50/69.05/88.1% via `50% * (N + 8i) / (5N − 4)`.
- [x] `.house-frame:hover` seal-reassembly rules untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)