### PR TITLE
Add "The House Chips of AI" essay

### DIFF
--- a/is/writing/essays/_src/the-house-chips-of-ai.md
+++ b/is/writing/essays/_src/the-house-chips-of-ai.md
@@ -1,0 +1,71 @@
+### The House Chips of AI
+
+**You pay in dollars. You work in tokens. The house sets the rules.**
+
+An AI subscription is not a software product. It is access to a private economy.
+
+That access is paid for in dollars, but used through a different set of units: input tokens, output tokens, cached tokens, context windows, message caps, credits, sessions, reset windows, model tiers. In API products, the exchange rate may appear on a pricing page, although the actual cost can still become difficult to predict once context length, tool use, caching, model choice, and product changes enter the picture. In consumer subscriptions, the exchange rate is more obscured, hidden behind limits and plan language.
+
+The monthly fee is only the entry point. The real accounting begins when the system meters access.
+
+Behind the monthly fee, the user is buying exposure to an internal market whose rules can change after purchase.
+
+#### The Price of Asking
+
+A token begins as a technical unit: a fragment of text processed by a model. Commercially, it becomes something else. It is a unit of cost and capacity: what the user can do, and how much of it.
+
+Around it sit other internal denominations: credits, messages, usage windows, context limits, model tiers, reset times. Together, they turn compute into a privately managed balance. The actual consumption happens inside the platform's own accounting system.
+
+These are the house chips of AI: units that may not matter outside the platform, but matter intensely inside it. They decide how much work the user can do, which model they can use, how long a session can continue, and when access must pause.
+
+This is an internal economy, not only a pricing model.
+
+#### The Strange Economy of the Subscription
+
+Subscription usage is the clearest version of this economy because the exchange rate is hidden.
+
+A user pays a monthly fee, but what they receive is not a fixed product in the ordinary sense. They receive a shifting claim on scarce inference capacity. The value of that claim depends on model access, message limits, reset windows, context length, tool availability, anti-abuse systems, peak-time constraints, and product decisions the company may later revise.
+
+There is a practical reason for this. Inference has real marginal costs. GPUs are finite. Heavy users can overwhelm flat-rate plans. A subscription product needs some way to prevent unlimited consumption from breaking the economics of the service. The scarcity is real. So is the internal economy built to manage it.
+
+A paid AI plan is a managed allocation of future compute: partly the model, partly the interface, partly the rules that decide how much of the model the user can actually reach.
+
+This is why AI subscriptions feel different from older software subscriptions. A writing app, note app, or design tool may add or remove features, but users are usually not rationing access to the basic act of using it. With AI, the paid product is tied to a scarce resource that can be restricted or repriced without changing the listed monthly fee.
+
+#### Cash Now, Compute Later
+
+When users prepay for AI access, the company receives cash now while owing future compute later.
+
+That makes AI usage limits economically closer to loyalty liabilities, prepaid credits, airline miles, or game currency than ordinary SaaS features. The obligation is not always denominated cleanly, and the user may not see a precise balance. But the platform has still sold access to future scarce capacity.
+
+Closed-loop value systems do not become trivial just because they are not legal tender. Airline miles, credit-card points, gift cards, and game currencies create liabilities, user expectations, arbitrage behavior, and disputes over fairness.
+
+AI usage credits belong in that family. The redemption object is usable cognition: drafting, coding, analysis, search, summarization, translation, planning, judgment support.
+
+#### When the Reset Becomes an Economic Event
+
+Game economies are the clearest analogy, because players already understand that private currencies are real inside the world where they operate.
+
+A game company can change the price of an item, the value of a premium currency, the drop rate of a rare reward, or the reset window for daily access. Players do not experience those changes as neutral interface updates. They experience them as economic events.
+
+AI platforms are beginning to make similar changes, but the language around them is still borrowed from SaaS operations: usage limits, plan updates, model availability, resets, temporary capacity, abuse prevention.
+
+The reset is where this becomes visible. A usage reset can be good customer service and still be economically revealing. When a platform restores a subscriber's usage after product problems, the adjustment is economic as well as operational: it changes how much internal value a paid user can consume under the same fiat price.
+
+The reverse is also true. When caps shorten, sessions clip, or the same kind of task starts consuming more quota than before, the monthly price stays the same while the subscription is worth less.
+
+That is the key difference between a normal product update and an economic event inside a platform: the bill may not change, while the house chips buy more or less than they did before.
+
+#### Premium Currency for Cognition
+
+In games, users would ask whether the currency had been diluted, the reward nerfed, or the rules changed unfairly. In AI, many users still lack the vocabulary to describe what happened. A model quietly gets worse at a task. A cap tightens. A feature moves to a higher tier. The same work starts costing more quota. Each changes the internal value of the plan, but without shared terms, the conversation stays at "it feels worse lately."
+
+The game industry's vocabulary did not arrive from policy papers. "Nerf" emerged on forums. "Pay-to-win" came from player frustration at specific design choices. The terms exist because players needed them to argue about what was happening to the economies they lived inside. AI users are early in the same process.
+
+#### The Rules Behind the Plan
+
+Usage caps, reset windows, and model tiers look like operational settings. Together, they define what a paid plan is worth.
+
+Naming this is not a claim that the economy is illegitimate. It is a prerequisite for talking about it clearly, for users, for press, and eventually for accountants and regulators. Private economies that cannot be described cannot be evaluated.
+
+Tokens began as a way for machines to count language. They are becoming a way for platforms to price, ration, and govern access to cognition.

--- a/is/writing/essays/index.html
+++ b/is/writing/essays/index.html
@@ -42,6 +42,13 @@
         <div class="essay-list">
             <article class="essay-entry">
               <h2>
+                <a href="./the-house-chips-of-ai/index.html">
+                  The House Chips of AI
+                </a>
+              </h2>
+            </article>
+            <article class="essay-entry">
+              <h2>
                 <a href="./already-seen/index.html">
                   Already Seen
                 </a>

--- a/is/writing/essays/the-house-chips-of-ai/index.html
+++ b/is/writing/essays/the-house-chips-of-ai/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="/img/a3.png" />
+    <link rel="apple-touch-icon" href="/img/a3.png" />
+    <title>The House Chips of AI | ajin.im/is/writing/essays</title>
+    <meta name="description" content="An AI subscription is not a software product. It is access to a private economy — paid in dollars, metered in tokens, credits, and limits the platform sets." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&family=DM+Mono:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../../../creative-house.css" />
+    <script src="../../../../analytics.js" defer></script>
+  </head>
+  <body class="post-page">
+    <main class="post-shell">
+      <header class="post-head">
+        <a class="back-link" href="../index.html">Back to essays</a>
+        <p class="path-mark">ajin.im is writing essays</p>
+        <h1 class="post-title">The House Chips of AI</h1>
+      </header>
+
+      <article class="post-body">
+        <p><strong>You pay in dollars. You work in tokens. The house sets the rules.</strong></p>
+        <p>An AI subscription is not a software product. It is access to a private economy.</p>
+        <p>That access is paid for in dollars, but used through a different set of units: input tokens, output tokens, cached tokens, context windows, message caps, credits, sessions, reset windows, model tiers. In API products, the exchange rate may appear on a pricing page, although the actual cost can still become difficult to predict once context length, tool use, caching, model choice, and product changes enter the picture. In consumer subscriptions, the exchange rate is more obscured, hidden behind limits and plan language.</p>
+        <p>The monthly fee is only the entry point. The real accounting begins when the system meters access.</p>
+        <p>Behind the monthly fee, the user is buying exposure to an internal market whose rules can change after purchase.</p>
+
+        <h3>The Price of Asking</h3>
+        <p>A token begins as a technical unit: a fragment of text processed by a model. Commercially, it becomes something else. It is a unit of cost and capacity: what the user can do, and how much of it.</p>
+        <p>Around it sit other internal denominations: credits, messages, usage windows, context limits, model tiers, reset times. Together, they turn compute into a privately managed balance. The actual consumption happens inside the platform&rsquo;s own accounting system.</p>
+        <p>These are the house chips of AI: units that may not matter outside the platform, but matter intensely inside it. They decide how much work the user can do, which model they can use, how long a session can continue, and when access must pause.</p>
+        <p>This is an internal economy, not only a pricing model.</p>
+
+        <h3>The Strange Economy of the Subscription</h3>
+        <p>Subscription usage is the clearest version of this economy because the exchange rate is hidden.</p>
+        <p>A user pays a monthly fee, but what they receive is not a fixed product in the ordinary sense. They receive a shifting claim on scarce inference capacity. The value of that claim depends on model access, message limits, reset windows, context length, tool availability, anti-abuse systems, peak-time constraints, and product decisions the company may later revise.</p>
+        <p>There is a practical reason for this. Inference has real marginal costs. GPUs are finite. Heavy users can overwhelm flat-rate plans. A subscription product needs some way to prevent unlimited consumption from breaking the economics of the service. The scarcity is real. So is the internal economy built to manage it.</p>
+        <p>A paid AI plan is a managed allocation of future compute: partly the model, partly the interface, partly the rules that decide how much of the model the user can actually reach.</p>
+        <p>This is why AI subscriptions feel different from older software subscriptions. A writing app, note app, or design tool may add or remove features, but users are usually not rationing access to the basic act of using it. With AI, the paid product is tied to a scarce resource that can be restricted or repriced without changing the listed monthly fee.</p>
+
+        <h3>Cash Now, Compute Later</h3>
+        <p>When users prepay for AI access, the company receives cash now while owing future compute later.</p>
+        <p>That makes AI usage limits economically closer to loyalty liabilities, prepaid credits, airline miles, or game currency than ordinary SaaS features. The obligation is not always denominated cleanly, and the user may not see a precise balance. But the platform has still sold access to future scarce capacity.</p>
+        <p>Closed-loop value systems do not become trivial just because they are not legal tender. Airline miles, credit-card points, gift cards, and game currencies create liabilities, user expectations, arbitrage behavior, and disputes over fairness.</p>
+        <p>AI usage credits belong in that family. The redemption object is usable cognition: drafting, coding, analysis, search, summarization, translation, planning, judgment support.</p>
+
+        <h3>When the Reset Becomes an Economic Event</h3>
+        <p>Game economies are the clearest analogy, because players already understand that private currencies are real inside the world where they operate.</p>
+        <p>A game company can change the price of an item, the value of a premium currency, the drop rate of a rare reward, or the reset window for daily access. Players do not experience those changes as neutral interface updates. They experience them as economic events.</p>
+        <p>AI platforms are beginning to make similar changes, but the language around them is still borrowed from SaaS operations: usage limits, plan updates, model availability, resets, temporary capacity, abuse prevention.</p>
+        <p>The reset is where this becomes visible. A usage reset can be good customer service and still be economically revealing. When a platform restores a subscriber&rsquo;s usage after product problems, the adjustment is economic as well as operational: it changes how much internal value a paid user can consume under the same fiat price.</p>
+        <p>The reverse is also true. When caps shorten, sessions clip, or the same kind of task starts consuming more quota than before, the monthly price stays the same while the subscription is worth less.</p>
+        <p>That is the key difference between a normal product update and an economic event inside a platform: the bill may not change, while the house chips buy more or less than they did before.</p>
+
+        <h3>Premium Currency for Cognition</h3>
+        <p>In games, users would ask whether the currency had been diluted, the reward nerfed, or the rules changed unfairly. In AI, many users still lack the vocabulary to describe what happened. A model quietly gets worse at a task. A cap tightens. A feature moves to a higher tier. The same work starts costing more quota. Each changes the internal value of the plan, but without shared terms, the conversation stays at &ldquo;it feels worse lately.&rdquo;</p>
+        <p>The game industry&rsquo;s vocabulary did not arrive from policy papers. &ldquo;Nerf&rdquo; emerged on forums. &ldquo;Pay-to-win&rdquo; came from player frustration at specific design choices. The terms exist because players needed them to argue about what was happening to the economies they lived inside. AI users are early in the same process.</p>
+
+        <h3>The Rules Behind the Plan</h3>
+        <p>Usage caps, reset windows, and model tiers look like operational settings. Together, they define what a paid plan is worth.</p>
+        <p>Naming this is not a claim that the economy is illegitimate. It is a prerequisite for talking about it clearly, for users, for press, and eventually for accountants and regulators. Private economies that cannot be described cannot be evaluated.</p>
+        <p>Tokens began as a way for machines to count language. They are becoming a way for platforms to price, ration, and govern access to cognition.</p>
+      </article>
+    </main>
+  </body>
+</html>

--- a/is/writing/loose/index.html
+++ b/is/writing/loose/index.html
@@ -74,6 +74,14 @@
             <article class="archive-card">
               <p class="archive-meta"><span class="loose-tag loose-tag-essay">essay</span> New &middot; 2026</p>
               <h2>
+                <a href="/is/writing/essays/the-house-chips-of-ai/">The House Chips of AI</a>
+              </h2>
+              <p>An AI subscription is not a software product. It is access to a private economy &mdash; paid in dollars, metered in tokens, credits, and limits the platform sets.</p>
+            </article>
+
+            <article class="archive-card">
+              <p class="archive-meta"><span class="loose-tag loose-tag-essay">essay</span></p>
+              <h2>
                 <a href="/is/writing/essays/every-few-years/">Every Few Years, The Country Goes Off</a>
               </h2>
               <p>I am Korean. I grew up inside these explosions. Four cases &mdash; PC bangs, coffee shops, jjimjilbang, the run &mdash; and a pattern that keeps repeating.</p>


### PR DESCRIPTION
## Summary
- New text essay at `/is/writing/essays/the-house-chips-of-ai/` (uses standard creative-house essay template)
- Source markdown saved to `_src/the-house-chips-of-ai.md`
- Listed at top of `/is/writing/loose/` with the "New · 2026" tag (previous "Every Few Years" entry demoted to plain essay tag)
- Added as a new entry at the top of `/is/writing/essays/` list (kept "Every Few Years" as the essay-page feature per the don't-auto-promote rule)

## Test plan
- [ ] `/is/writing/loose/` — new essay sits at the top of the essays section with "New · 2026"
- [ ] `/is/writing/essays/` — feature is still "Every Few Years"; "The House Chips of AI" is the first entry in the list
- [ ] `/is/writing/essays/the-house-chips-of-ai/` — renders with section headings (h3, italic serif), back-link returns to essays index

🤖 Generated with [Claude Code](https://claude.com/claude-code)