### PR TITLE
Writing hover: reinstate the hovered card's copy

### DIFF
--- a/creative-house.css
+++ b/creative-house.css
@@ -444,6 +444,11 @@ footer {
   .writing-house .house-frame:hover .room-copy {
     opacity: 0;
   }
+
+  .writing-house .room:hover .room-copy,
+  .writing-house .room:focus-visible .room-copy {
+    opacity: 1;
+  }
 }
 
 .writing-house .mobile-hero {


### PR DESCRIPTION
## Summary
- Adds `.writing-house .room:hover .room-copy, .writing-house .room:focus-visible .room-copy { opacity: 1 }` after the existing `house-frame:hover` fade-all rule
- Frame-hover still fades every label (seal puzzle reveals), but the card you're targeting keeps its copy so you can read what you're about to click
- Desktop + motion-safe only (inherited from the parent media query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)