### PR TITLE
Add /is/learning/konbini: Japanese-first immersion webapp

### DIFF
--- a/_scripts/build_konbini.py
+++ b/_scripts/build_konbini.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+KONBINI_ROOT = REPO_ROOT / "is" / "learning" / "konbini"
+CONTENT_ROOT = KONBINI_ROOT / "content"
+OUTPUT_PATH = KONBINI_ROOT / "content.json"
+
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+BLOCK_RE = re.compile(r"^::([a-z-]+)(?:\[(.*?)\])?\n(.*?)^::\s*$", re.DOTALL | re.MULTILINE)
+FURIGANA_RE = re.compile(r"《[^》]*》")
+FURIGANA_UNCLOSED_RE = re.compile(r"《[^》]*$|^[^《]*》", re.MULTILINE)
+
+
+class BuildError(Exception):
+    pass
+
+
+def parse_frontmatter(raw: str, source: Path) -> tuple[dict, str]:
+    match = FRONTMATTER_RE.match(raw)
+    if not match:
+        raise BuildError(f"{source}: missing or malformed frontmatter")
+    fm_text, body = match.group(1), match.group(2)
+    fm: dict = {}
+    current_key = None
+    current_block: list[str] | None = None
+    for line in fm_text.splitlines():
+        if current_block is not None:
+            if line.startswith("  ") or line == "":
+                current_block.append(line[2:] if line.startswith("  ") else "")
+                continue
+            fm[current_key] = "\n".join(current_block).rstrip()
+            current_block = None
+        m = re.match(r"^([a-z_][a-z0-9_]*):\s*(.*)$", line)
+        if not m:
+            continue
+        key, value = m.group(1), m.group(2).strip()
+        if value == "|":
+            current_key = key
+            current_block = []
+        else:
+            fm[key] = _coerce(value)
+    if current_block is not None:
+        fm[current_key] = "\n".join(current_block).rstrip()
+    return fm, body
+
+
+def _coerce(value: str):
+    if value in ("null", ""):
+        return None
+    if value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
+def validate_furigana(text: str, source: Path) -> None:
+    opens = text.count("《")
+    closes = text.count("》")
+    if opens != closes:
+        raise BuildError(
+            f"{source}: unmatched 《 or 》 ({opens} opens, {closes} closes)"
+        )
+
+
+def parse_blocks(body: str, source: Path) -> list[dict]:
+    blocks: list[dict] = []
+    for m in BLOCK_RE.finditer(body):
+        block_type = m.group(1)
+        arg = m.group(2)
+        inner = m.group(3).rstrip()
+        validate_furigana(inner, source)
+        if arg is not None:
+            validate_furigana(arg, source)
+        blocks.append(_shape_block(block_type, arg, inner, source))
+    return blocks
+
+
+def _shape_block(block_type: str, arg: str | None, body: str, source: Path) -> dict:
+    block: dict = {"type": block_type}
+    if arg is not None:
+        block["arg"] = arg
+    if block_type == "player-choice":
+        options = []
+        for line in body.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            m = re.match(r"^([a-z]):\s*(.*?)(?:\s*\|\s*(.+))?$", line)
+            if not m:
+                raise BuildError(
+                    f"{source}: malformed player-choice option: {line!r}"
+                )
+            label, text, tag = m.group(1), m.group(2).strip(), (m.group(3) or "").strip() or None
+            options.append({"label": label, "text": text, "response_id": tag})
+        block["options"] = options
+    elif block_type == "nutrition":
+        rows = []
+        for line in body.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if "|" not in line:
+                raise BuildError(f"{source}: nutrition row missing |: {line!r}")
+            left, right = line.split("|", 1)
+            rows.append({"left": left.strip(), "right": right.strip()})
+        block["rows"] = rows
+    else:
+        block["body"] = body
+    return block
+
+
+def parse_sections(body: str) -> dict[str, str]:
+    sections: dict[str, str] = {}
+    current = None
+    buffer: list[str] = []
+    for line in body.splitlines():
+        m = re.match(r"^##\s+(.+)$", line)
+        if m:
+            if current is not None:
+                sections[current] = "\n".join(buffer).strip()
+            current = m.group(1).strip()
+            buffer = []
+        elif current is not None:
+            buffer.append(line)
+    if current is not None:
+        sections[current] = "\n".join(buffer).strip()
+    return sections
+
+
+def validate_dialogue(blocks: list[dict], source: Path) -> None:
+    last_choice_tags: set[str] | None = None
+    for block in blocks:
+        if block["type"] == "player-choice":
+            last_choice_tags = {
+                o["response_id"]
+                for o in block["options"]
+                if o["response_id"] is not None
+            }
+        elif block["type"] == "clerk-branch":
+            arg = block.get("arg")
+            if arg is None:
+                raise BuildError(f"{source}: clerk-branch missing [id]")
+            if last_choice_tags is None or arg not in last_choice_tags:
+                raise BuildError(
+                    f"{source}: clerk-branch[{arg}] has no matching preceding player-choice response_id"
+                )
+
+
+def build_items() -> dict:
+    items: dict = {}
+    for path in sorted((CONTENT_ROOT / "items").glob("*.md")):
+        raw = path.read_text(encoding="utf-8")
+        fm, body = parse_frontmatter(raw, path)
+        sections = parse_sections(body)
+        for required in ("id", "name_jp", "name_en", "price", "zone", "description_jp", "description_en"):
+            if required not in fm or fm[required] in (None, ""):
+                raise BuildError(f"{path}: missing required field '{required}'")
+        validate_furigana(fm["description_jp"], path)
+        items[fm["id"]] = {
+            **fm,
+            "front": parse_blocks(sections.get("front", ""), path),
+            "back": parse_blocks(sections.get("back", ""), path),
+        }
+    return items
+
+
+def build_notices() -> dict:
+    notices: dict = {}
+    for path in sorted((CONTENT_ROOT / "notices").glob("*.md")):
+        raw = path.read_text(encoding="utf-8")
+        fm, body = parse_frontmatter(raw, path)
+        sections = parse_sections(body)
+        body_text = sections.get("body", "")
+        blocks = parse_blocks(body_text, path)
+        # Remaining prose (lines between :: blocks) is kept as raw paragraphs.
+        prose = re.sub(BLOCK_RE, "", body_text).strip()
+        validate_furigana(prose, path)
+        notices[fm["id"]] = {
+            **fm,
+            "blocks": blocks,
+            "prose": prose,
+        }
+    return notices
+
+
+def build_dialogue() -> dict:
+    dialogue: dict = {}
+    for path in sorted((CONTENT_ROOT / "dialogue").glob("*.md")):
+        raw = path.read_text(encoding="utf-8")
+        fm, body = parse_frontmatter(raw, path)
+        sections = parse_sections(body)
+        blocks = parse_blocks(sections.get("script", ""), path)
+        validate_dialogue(blocks, path)
+        dialogue[fm["id"]] = {**fm, "script": blocks}
+    return dialogue
+
+
+def build_vocab() -> dict:
+    vocab_path = CONTENT_ROOT / "vocab.md"
+    raw = vocab_path.read_text(encoding="utf-8")
+    _, body = parse_frontmatter(raw, vocab_path)
+    entries: dict = {}
+    current_id = None
+    current: dict = {}
+    for line in body.splitlines():
+        m = re.match(r"^##\s+([a-z0-9-]+)\s*$", line)
+        if m:
+            if current_id is not None:
+                entries[current_id] = current
+            current_id = m.group(1)
+            current = {}
+            continue
+        if current_id is None:
+            continue
+        m = re.match(r"^([a-z_][a-z0-9_]*):\s*(.*)$", line)
+        if m:
+            current[m.group(1)] = _coerce(m.group(2).strip())
+    if current_id is not None:
+        entries[current_id] = current
+    return entries
+
+
+def build_ui_strings() -> dict:
+    path = CONTENT_ROOT / "ui" / "strings.md"
+    raw = path.read_text(encoding="utf-8")
+    _, body = parse_frontmatter(raw, path)
+    strings: dict = {}
+    current_key = None
+    current: dict = {}
+    multiline_key: str | None = None
+    multiline_buf: list[str] = []
+    for line in body.splitlines():
+        if multiline_key is not None:
+            if line.startswith("  ") or line == "":
+                multiline_buf.append(line[2:] if line.startswith("  ") else "")
+                continue
+            current[multiline_key] = "\n".join(multiline_buf).rstrip()
+            multiline_key = None
+            multiline_buf = []
+        m = re.match(r"^###\s+(.+)$", line)
+        if m:
+            if current_key is not None:
+                strings[current_key] = current
+            current_key = m.group(1).strip()
+            current = {}
+            continue
+        if line.startswith("## ") or current_key is None:
+            continue
+        m = re.match(r"^(jp|en|jp_style):\s*(.*)$", line)
+        if m:
+            key, value = m.group(1), m.group(2).strip()
+            if value == "|":
+                multiline_key = key
+                multiline_buf = []
+            else:
+                current[key] = _coerce(value) if value else ""
+    if multiline_key is not None:
+        current[multiline_key] = "\n".join(multiline_buf).rstrip()
+    if current_key is not None:
+        strings[current_key] = current
+    return strings
+
+
+def main() -> int:
+    try:
+        output = {
+            "items": build_items(),
+            "notices": build_notices(),
+            "dialogue": build_dialogue(),
+            "vocab": build_vocab(),
+            "ui_strings": build_ui_strings(),
+        }
+    except BuildError as exc:
+        print(f"build error: {exc}", file=sys.stderr)
+        return 1
+    OUTPUT_PATH.write_text(
+        json.dumps(output, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        f"wrote {OUTPUT_PATH.relative_to(REPO_ROOT)}: "
+        f"{len(output['items'])} items, "
+        f"{len(output['notices'])} notices, "
+        f"{len(output['dialogue'])} dialogues, "
+        f"{len(output['vocab'])} vocab, "
+        f"{len(output['ui_strings'])} ui strings"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/is/learning/konbini/app.js
+++ b/is/learning/konbini/app.js
@@ -1,0 +1,803 @@
+// Konbini — vanilla JS MVP.
+// Routes: #/, #/item/:id, #/board, #/board/:id, #/saved, #/about
+
+const STORAGE_KEYS = {
+  saved: "konbini.savedWords",
+  basket: "konbini.basket",
+};
+
+const ZONE_ORDER = ["food_aisle", "drinks_fridge", "hot_case"];
+
+const state = {
+  content: null,
+  saved: new Set(loadJSON(STORAGE_KEYS.saved, [])),
+  basket: loadJSON(STORAGE_KEYS.basket, []), // array of itemIds; duplicates allowed
+};
+
+function loadJSON(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function persistSet(key, set) {
+  try {
+    localStorage.setItem(key, JSON.stringify([...set]));
+  } catch {
+    /* ignore quota */
+  }
+}
+
+function persistBasket() {
+  try {
+    localStorage.setItem(STORAGE_KEYS.basket, JSON.stringify(state.basket));
+  } catch {
+    /* ignore */
+  }
+}
+
+function basketTotal() {
+  return state.basket.reduce((sum, id) => {
+    const item = state.content.items[id];
+    return sum + (item ? Number(item.price) || 0 : 0);
+  }, 0);
+}
+
+function basketGrouped() {
+  const map = new Map();
+  for (const id of state.basket) {
+    map.set(id, (map.get(id) ?? 0) + 1);
+  }
+  return [...map.entries()].map(([id, count]) => ({
+    item: state.content.items[id],
+    count,
+  }));
+}
+
+// Rounding rule (spec delta §9, unchanged): next ¥1000; next ¥500 if total ≤ 500.
+function roundUpPayment(total) {
+  if (total <= 0) return 0;
+  if (total <= 500) return Math.ceil(total / 500) * 500;
+  return Math.ceil(total / 1000) * 1000;
+}
+
+// ── HTML escape ──
+function esc(str) {
+  if (str == null) return "";
+  return String(str)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+// Resolve [word-id] markers to their vocab surface and drop 《…》 furigana notation,
+// returning a plain-text comparable string (used to dedupe labels that match content).
+function resolvePlain(text) {
+  if (text == null) return "";
+  return String(text)
+    .replace(/\[([a-z0-9][a-z0-9-]*)\]/g, (full, id) => {
+      const entry = state.content?.vocab?.[id];
+      return entry?.surface ?? full;
+    })
+    .replace(/《[^》]*》/g, "")
+    .trim();
+}
+
+// ── Furigana rendering ──
+// Two markers in content:
+//   [word-id]       → <ruby class="word" data-word="word-id">surface<rt>reading</rt></ruby>
+//   漢字《ふりがな》 → <ruby>漢字<rt>ふりがな</rt></ruby>
+// Word-id pass runs first. The 《》 pass only matches kanji immediately followed by 《…》,
+// which cannot appear inside already-formed <ruby> tags emitted by the word-id pass.
+function renderInline(text) {
+  if (text == null) return "";
+  const escaped = esc(text);
+  const withWords = escaped.replace(
+    /\[([a-z0-9][a-z0-9-]*)\]/g,
+    (full, id) => {
+      const entry = state.content.vocab[id];
+      if (!entry) return full; // leave bracket as literal if vocab missing
+      const surface = esc(entry.surface || id);
+      const reading = esc(entry.reading || "");
+      return (
+        `<ruby class="word" data-word="${esc(id)}" tabindex="0" role="button">` +
+        `${surface}<rt>${reading}</rt></ruby>`
+      );
+    },
+  );
+  // Kanji range: CJK Unified Ideographs + iteration mark 々
+  return withWords.replace(
+    /([\u3400-\u9FFF々]+)《([^》]+)》/g,
+    (_, kanji, read) => `<ruby>${kanji}<rt>${read}</rt></ruby>`,
+  );
+}
+
+// ── Router ──
+function parseHash() {
+  const raw = location.hash.replace(/^#/, "") || "/";
+  const parts = raw.split("/").filter(Boolean);
+  return parts;
+}
+
+function route() {
+  const parts = parseHash();
+  const app = document.getElementById("app");
+  app.scrollTo?.({ top: 0 });
+  window.scrollTo({ top: 0 });
+  if (parts.length === 0) return renderShelves(app);
+  if (parts[0] === "item" && parts[1]) return renderItem(app, parts[1]);
+  if (parts[0] === "board" && parts[1]) return renderNotice(app, parts[1]);
+  if (parts[0] === "board") return renderBoard(app);
+  if (parts[0] === "saved") return renderSaved(app);
+  if (parts[0] === "about") return renderAbout(app);
+  if (parts[0] === "register" && parts[1] === "checkout")
+    return renderCheckout(app);
+  if (parts[0] === "register") return renderRegister(app);
+  return renderShelves(app);
+}
+
+// ── Chrome nav ──
+function ui(key) {
+  const entry = state.content.ui_strings[key];
+  return entry ? entry : { jp: key, en: key };
+}
+
+function renderChrome() {
+  const nav = document.getElementById("chrome-nav");
+  const basketCount = state.basket.length;
+  const items = [
+    { hash: "#/", key: "shelves_label" },
+    { hash: "#/board", key: "board_label" },
+    { hash: "#/register", key: "register_label", badge: basketCount || null },
+    { hash: "#/saved", key: "saved_label" },
+    { hash: "#/about", key: "about_label" },
+  ];
+  const hash = location.hash || "#/";
+  nav.innerHTML = items
+    .map((it) => {
+      const label = ui(it.key);
+      const active =
+        (hash === "#/" && it.hash === "#/") ||
+        (it.hash !== "#/" && hash.startsWith(it.hash));
+      const badge =
+        it.badge != null
+          ? `<span class="chrome-nav-badge">${esc(it.badge)}</span>`
+          : "";
+      return `<a href="${it.hash}" class="${active ? "is-active" : ""}" aria-label="${esc(label.en)}">${renderInline(label.jp)}${badge}</a>`;
+    })
+    .join("");
+}
+
+// ── Views ──
+function renderShelves(app) {
+  const zonesPresent = new Map();
+  for (const item of Object.values(state.content.items)) {
+    if (!zonesPresent.has(item.zone)) zonesPresent.set(item.zone, []);
+    zonesPresent.get(item.zone).push(item);
+  }
+  const orderedZones = [
+    ...ZONE_ORDER.filter((z) => zonesPresent.has(z)),
+    ...[...zonesPresent.keys()].filter((z) => !ZONE_ORDER.includes(z)),
+  ];
+
+  const sections = orderedZones
+    .map((zone) => {
+      const zoneLabel = ui(`${zone}_name`);
+      const items = zonesPresent.get(zone);
+      return `
+        <section class="zone">
+          <div class="zone-head">
+            <h2>${renderInline(zoneLabel.jp)}</h2>
+            <span class="zone-gloss">${esc(zoneLabel.en)}</span>
+          </div>
+          <div class="shelf">
+            ${items.map(renderItemCard).join("")}
+          </div>
+        </section>
+      `;
+    })
+    .join("");
+
+  app.innerHTML = `
+    <h1 class="app-heading">${renderInline(ui("shelves_label").jp)}</h1>
+    <p class="app-sublede">${renderInline(ui("first_time_greeting").jp)}</p>
+    ${sections || emptyState("basket_empty_heading")}
+  `;
+}
+
+function renderItemCard(item) {
+  return `
+    <a class="item-card" href="#/item/${esc(item.id)}">
+      <div>
+        <h3 class="item-card-name">${esc(item.name_jp)}</h3>
+        <p class="item-card-gloss">${esc(item.name_en)}</p>
+      </div>
+      <div class="item-card-meta">
+        <span class="item-card-price">¥${esc(item.price)}</span>
+        ${item.weight ? `<span class="item-card-weight">${esc(item.weight)}</span>` : ""}
+      </div>
+    </a>
+  `;
+}
+
+function renderItem(app, id) {
+  const item = state.content.items[id];
+  if (!item) {
+    app.innerHTML = `
+      <a class="back-link" href="#/">${renderInline(ui("back_label").jp)}</a>
+      <div class="empty">item not found: ${esc(id)}</div>
+    `;
+    return;
+  }
+  const inBasket = state.basket.includes(id);
+  const ctaKey = inBasket ? "take_to_register_again" : "take_to_register_default";
+  app.innerHTML = `
+    <a class="back-link" href="#/">${renderInline(ui("back_label").jp)}</a>
+    <article class="item-detail">
+      <header class="item-header">
+        <h1>${esc(item.name_jp)}</h1>
+        <p class="item-desc-jp">${renderInline(item.description_jp)}</p>
+        <p class="item-desc-en">${esc(item.description_en)}</p>
+        <div class="item-actions">
+          <span class="item-actions-price">¥${esc(item.price)}</span>
+          <button class="cta" data-act="add-to-basket" data-item="${esc(item.id)}">${renderInline(ui(ctaKey).jp)}</button>
+        </div>
+      </header>
+      <div class="package">
+        <section class="package-face package-face--front" aria-label="front">
+          <span class="face-tag">${esc(ui("front_label").en)}</span>
+          ${item.front.map(renderBlock).join("")}
+        </section>
+        <section class="package-face package-face--back" aria-label="back">
+          <span class="face-tag">${esc(ui("back_label_item").en)}</span>
+          ${item.back.map(renderBlock).join("")}
+        </section>
+      </div>
+    </article>
+  `;
+}
+
+function handleAddToBasket(itemId, btn) {
+  state.basket.push(itemId);
+  persistBasket();
+  renderChrome();
+  // Brief "added" flash then restore CTA-again label.
+  const added = ui("take_to_register_added");
+  btn.innerHTML = renderInline(added.jp);
+  btn.classList.add("is-added");
+  setTimeout(() => {
+    btn.classList.remove("is-added");
+    btn.innerHTML = renderInline(ui("take_to_register_again").jp);
+  }, 900);
+}
+
+function renderBlock(block) {
+  switch (block.type) {
+    case "banner": {
+      const argPlain = resolvePlain(block.arg);
+      const bodyPlain = resolvePlain(block.body);
+      const showArg = block.arg && argPlain !== bodyPlain;
+      return `<div class="block block-banner">${showArg ? `<span class="block-banner-arg">${renderInline(block.arg)}</span>` : ""}${renderInline(block.body)}</div>`;
+    }
+    case "hero":
+      return `<div class="block block-hero">${renderBodyAsParagraphs(block.body)}</div>`;
+    case "footer":
+      return `<div class="block block-footer">${renderBodyAsParagraphs(block.body)}</div>`;
+    case "section":
+      return `
+        <div class="block block-section">
+          ${block.arg ? `<p class="block-section-arg">${renderInline(block.arg)}</p>` : ""}
+          <div class="block-section-body">${renderBodyAsParagraphs(block.body)}</div>
+        </div>
+      `;
+    case "nutrition":
+      return `
+        <div class="block block-nutrition">
+          ${block.arg ? `<div class="block-nutrition-caption">${renderInline(block.arg)}</div>` : ""}
+          ${block.rows
+            .map(
+              (r) => `
+              <div class="block-nutrition-row">
+                <span>${renderInline(r.left)}</span>
+                <span class="block-nutrition-row-right">${renderInline(r.right)}</span>
+              </div>
+            `,
+            )
+            .join("")}
+        </div>
+      `;
+    case "fineprint":
+      return `<div class="block block-fineprint">${renderBodyAsParagraphs(block.body)}</div>`;
+    case "heading":
+      return `<h2 class="block block-heading">${renderInline(block.body)}</h2>`;
+    default:
+      return `<div class="block block-other">${renderBodyAsParagraphs(block.body || "")}</div>`;
+  }
+}
+
+function renderBodyAsParagraphs(raw) {
+  if (!raw) return "";
+  return raw
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => `<p>${renderInline(line)}</p>`)
+    .join("");
+}
+
+// ── Board (notices) ──
+function renderBoard(app) {
+  const notices = Object.values(state.content.notices);
+  if (notices.length === 0) {
+    app.innerHTML = `
+      <a class="back-link" href="#/">${renderInline(ui("back_label").jp)}</a>
+      ${deadpanEmpty("empty_board")}
+    `;
+    return;
+  }
+  app.innerHTML = `
+    <a class="back-link" href="#/">${renderInline(ui("back_label").jp)}</a>
+    <h1 class="app-heading">${renderInline(ui("board_label").jp)}</h1>
+    <div class="board">
+      ${notices.map(renderNoticeCard).join("")}
+    </div>
+  `;
+}
+
+function renderNoticeCard(notice) {
+  const headingBlock = notice.blocks.find((b) => b.type === "heading");
+  const heading = headingBlock
+    ? renderInline(headingBlock.body)
+    : esc(notice.id);
+  const meta = [
+    notice.posted_date ? esc(notice.posted_date) : null,
+    notice.posted_by ? renderInline(notice.posted_by) : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  const styleClass =
+    notice.style === "handwritten" ? " notice-card--handwritten" : "";
+  const preview = notice.prose
+    ? renderBodyAsParagraphs(notice.prose.split("\n").slice(0, 2).join("\n"))
+    : "";
+  return `
+    <a class="notice-card${styleClass}" href="#/board/${esc(notice.id)}">
+      <h3>${heading}</h3>
+      ${meta ? `<p class="notice-card-meta">${meta}</p>` : ""}
+      <div class="notice-card-body">${preview}</div>
+    </a>
+  `;
+}
+
+function renderNotice(app, id) {
+  const notice = state.content.notices[id];
+  if (!notice) {
+    app.innerHTML = `
+      <a class="back-link" href="#/board">${renderInline(ui("back_label").jp)}</a>
+      <div class="empty">notice not found: ${esc(id)}</div>
+    `;
+    return;
+  }
+  const heading = notice.blocks.find((b) => b.type === "heading");
+  const footer = notice.blocks.find((b) => b.type === "footer");
+  const styleClass =
+    notice.style === "handwritten" ? " notice-card--handwritten" : "";
+  app.innerHTML = `
+    <a class="back-link" href="#/board">${renderInline(ui("back_label").jp)}</a>
+    <article class="notice-card${styleClass}" style="max-width: 620px; margin: 0 auto;">
+      ${heading ? `<h3>${renderInline(heading.body)}</h3>` : ""}
+      <p class="notice-card-meta">
+        ${notice.posted_date ? esc(notice.posted_date) : ""}
+        ${notice.posted_by ? ` · ${renderInline(notice.posted_by)}` : ""}
+      </p>
+      <div class="notice-card-body">${renderBodyAsParagraphs(notice.prose || "")}</div>
+      ${footer ? `<p class="notice-card-meta" style="margin-top:0.8rem;">${renderInline(footer.body)}</p>` : ""}
+    </article>
+  `;
+}
+
+// ── Saved ──
+function renderSaved(app) {
+  const ids = [...state.saved];
+  if (ids.length === 0) {
+    app.innerHTML = `
+      <a class="back-link" href="#/">${renderInline(ui("back_label").jp)}</a>
+      <h1 class="app-heading">${renderInline(ui("saved_label").jp)}</h1>
+      ${deadpanEmpty("empty_saved_words")}
+    `;
+    return;
+  }
+  const rows = ids
+    .map((id) => state.content.vocab[id])
+    .filter(Boolean)
+    .map((entry) => {
+      const ruby = entry.reading
+        ? `<ruby>${esc(entry.surface)}<rt>${esc(entry.reading)}</rt></ruby>`
+        : esc(entry.surface);
+      return `
+        <li class="notice-card" style="border-left-color: var(--ink-muted);">
+          <h3>${ruby}</h3>
+          <p class="notice-card-meta">${esc(entry.jlpt || "")} · ${esc(entry.pos || "")}</p>
+          <div class="notice-card-body"><p>${esc(entry.meaning_en || "")}</p></div>
+        </li>
+      `;
+    })
+    .join("");
+  app.innerHTML = `
+    <a class="back-link" href="#/">${renderInline(ui("back_label").jp)}</a>
+    <h1 class="app-heading">${renderInline(ui("saved_label").jp)}</h1>
+    <ul class="board" style="list-style:none; padding:0; margin:0;">${rows}</ul>
+  `;
+}
+
+// ── Register (basket) ──
+function renderRegister(app) {
+  const groups = basketGrouped();
+  const total = basketTotal();
+  if (groups.length === 0) {
+    app.innerHTML = `
+      <a class="back-link" href="#/">${renderInline(ui("back_label").jp)}</a>
+      <h1 class="app-heading">${renderInline(ui("register_label").jp)}</h1>
+      ${deadpanEmpty("empty_basket")}
+    `;
+    return;
+  }
+  const rows = groups
+    .map(
+      ({ item, count }) => `
+      <li class="basket-row" data-item="${esc(item.id)}">
+        <a class="basket-row-name" href="#/item/${esc(item.id)}">
+          <span class="basket-row-jp">${esc(item.name_jp)}</span>
+          <span class="basket-row-en">${esc(item.name_en)}</span>
+        </a>
+        <span class="basket-row-price">¥${esc(item.price)}</span>
+        <span class="basket-row-count">×${count}</span>
+        <button class="basket-row-remove" data-act="basket-remove" data-item="${esc(item.id)}" aria-label="remove one">−</button>
+      </li>
+    `,
+    )
+    .join("");
+  app.innerHTML = `
+    <a class="back-link" href="#/">${renderInline(ui("back_label").jp)}</a>
+    <h1 class="app-heading">${renderInline(ui("register_label").jp)}</h1>
+    <ul class="basket">${rows}</ul>
+    <div class="basket-total">
+      <span class="basket-total-label">${renderInline(ui("total_label").jp)}</span>
+      <span class="basket-total-amount">¥${total.toLocaleString("en")}</span>
+    </div>
+    <div class="basket-actions">
+      <a class="cta cta--primary" href="#/register/checkout">${renderInline(ui("checkout_button").jp)}</a>
+    </div>
+  `;
+}
+
+function removeOneFromBasket(itemId) {
+  const idx = state.basket.lastIndexOf(itemId);
+  if (idx >= 0) {
+    state.basket.splice(idx, 1);
+    persistBasket();
+  }
+  renderChrome();
+  route();
+}
+
+// ── Checkout runner ──
+// State machine walks the checkout-standard dialogue script one turn at a time.
+// Tap-to-advance on clerk/action/exit turns; player-choice shows buttons.
+// clerk-branch[id] turns only render when their id matches the most recent choice.
+const checkout = {
+  script: null,
+  idx: 0,
+  total: 0,
+  payment: 0,
+  change: 0,
+  lastResponse: null,
+  active: false,
+};
+
+function renderCheckout(app) {
+  const script = state.content.dialogue["checkout-standard"]?.script;
+  if (!script) {
+    app.innerHTML = `<div class="empty">checkout script missing</div>`;
+    return;
+  }
+  if (state.basket.length === 0) {
+    app.innerHTML = `
+      <a class="back-link" href="#/register">${renderInline(ui("back_label").jp)}</a>
+      ${deadpanEmpty("empty_basket")}
+    `;
+    return;
+  }
+  checkout.script = script;
+  checkout.idx = 0;
+  checkout.total = basketTotal();
+  checkout.payment = roundUpPayment(checkout.total);
+  checkout.change = checkout.payment - checkout.total;
+  checkout.lastResponse = null;
+  checkout.active = true;
+  app.innerHTML = `
+    <a class="back-link" href="#/register">${renderInline(ui("back_label").jp)}</a>
+    <div class="checkout">
+      <div class="checkout-transcript" id="checkout-transcript"></div>
+      <div class="checkout-prompt" id="checkout-prompt"></div>
+    </div>
+  `;
+  advanceCheckout();
+}
+
+function advanceCheckout() {
+  if (!checkout.active) return;
+  const transcript = document.getElementById("checkout-transcript");
+  const prompt = document.getElementById("checkout-prompt");
+  if (!transcript || !prompt) return;
+
+  while (checkout.idx < checkout.script.length) {
+    const block = checkout.script[checkout.idx];
+    checkout.idx += 1;
+
+    if (block.type === "clerk") {
+      appendClerkTurn(transcript, block.body);
+      showTapToContinue(prompt);
+      return;
+    }
+    if (block.type === "clerk-branch") {
+      if (block.arg === checkout.lastResponse) {
+        appendClerkTurn(transcript, block.body);
+        showTapToContinue(prompt);
+        return;
+      }
+      continue; // skip non-matching branch silently
+    }
+    if (block.type === "player-choice") {
+      showChoices(prompt, block.options);
+      return;
+    }
+    if (block.type === "action") {
+      appendActionTurn(transcript, block.body.trim());
+      continue; // internal marker — advance through automatically
+    }
+    if (block.type === "exit") {
+      appendExitTurn(transcript, block.body);
+      showExit(prompt);
+      return;
+    }
+  }
+  // script exhausted without explicit exit (shouldn't happen per spec)
+  showExit(prompt);
+}
+
+function appendClerkTurn(transcript, rawBody) {
+  const body = substituteVars(rawBody);
+  transcript.insertAdjacentHTML(
+    "beforeend",
+    `<div class="turn turn-clerk"><div class="turn-label">店員</div><p>${renderInline(body)}</p></div>`,
+  );
+  scrollIntoView(transcript);
+}
+
+function appendActionTurn(transcript, marker) {
+  const label =
+    marker === "player_places_items"
+      ? "かごを置く"
+      : marker === "payment_exchange"
+        ? "お金のやり取り"
+        : marker;
+  transcript.insertAdjacentHTML(
+    "beforeend",
+    `<div class="turn turn-action"><em>${esc(label)}</em></div>`,
+  );
+  scrollIntoView(transcript);
+}
+
+function appendPlayerTurn(transcript, text) {
+  transcript.insertAdjacentHTML(
+    "beforeend",
+    `<div class="turn turn-player"><div class="turn-label">あなた</div><p>${renderInline(text)}</p></div>`,
+  );
+  scrollIntoView(transcript);
+}
+
+function appendExitTurn(transcript, rawBody) {
+  transcript.insertAdjacentHTML(
+    "beforeend",
+    `<div class="turn turn-exit"><p>${esc(rawBody.trim())}</p></div>`,
+  );
+  scrollIntoView(transcript);
+}
+
+function scrollIntoView(el) {
+  el.scrollTop = el.scrollHeight;
+  window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
+}
+
+function showTapToContinue(prompt) {
+  prompt.innerHTML = `
+    <button class="tap-continue" data-act="checkout-advance">
+      ${renderInline(ui("tap_to_continue").jp)}
+    </button>
+  `;
+}
+
+function showChoices(prompt, options) {
+  prompt.innerHTML = `
+    <div class="choices">
+      ${options
+        .map(
+          (o) => `
+          <button class="choice" data-act="checkout-choose" data-response-id="${esc(o.response_id || "")}" data-label="${esc(o.text)}">
+            <span class="choice-label">${esc(o.label)}</span>
+            <span class="choice-text">${renderInline(o.text)}</span>
+          </button>
+        `,
+        )
+        .join("")}
+    </div>
+  `;
+}
+
+function showExit(prompt) {
+  prompt.innerHTML = `
+    <button class="cta cta--primary" data-act="checkout-exit">out</button>
+  `;
+}
+
+function chooseCheckout(responseId, label) {
+  const transcript = document.getElementById("checkout-transcript");
+  checkout.lastResponse = responseId || null;
+  appendPlayerTurn(transcript, label);
+  advanceCheckout();
+}
+
+function exitCheckout() {
+  state.basket = [];
+  persistBasket();
+  checkout.active = false;
+  location.hash = "#/";
+}
+
+function substituteVars(text) {
+  return String(text)
+    .replaceAll("{{basket_total}}", String(checkout.total))
+    .replaceAll("{{payment_amount}}", String(checkout.payment))
+    .replaceAll("{{change_amount}}", String(checkout.change));
+}
+
+// ── About ──
+function renderAbout(app) {
+  const about = state.content.ui_strings.about_body || {};
+  const jp = (about.jp || "")
+    .split(/\n\n+/)
+    .map((p) => `<p>${renderInline(p.trim())}</p>`)
+    .join("");
+  app.innerHTML = `
+    <a class="back-link" href="#/">${renderInline(ui("back_label").jp)}</a>
+    <h1 class="app-heading">${renderInline(ui("about_label").jp)}</h1>
+    <article class="item-detail" style="max-width: 620px;">
+      <div class="package-face" style="line-height:1.85;">${jp}</div>
+      <p class="item-desc-en" style="max-width: 620px;">${esc(about.en || "")}</p>
+    </article>
+  `;
+}
+
+// ── Deadpan empty states ──
+function deadpanEmpty(key) {
+  const msg = ui(key);
+  return `<div class="empty empty--deadpan">${renderInline(msg.jp)}</div>`;
+}
+
+function emptyState(key) {
+  return deadpanEmpty(key);
+}
+
+// ── Popup ──
+const popupEl = document.getElementById("popup");
+const scrimEl = document.getElementById("popup-scrim");
+
+function openPopup(wordId) {
+  const entry = state.content.vocab[wordId];
+  if (!entry) return;
+  const surfaceRuby = entry.reading
+    ? `<ruby>${esc(entry.surface)}<rt>${esc(entry.reading)}</rt></ruby>`
+    : esc(entry.surface);
+  const saved = state.saved.has(wordId);
+  const saveLabel = ui(saved ? "save_confirmed" : "save_button");
+  const closeLabel = ui("close_button");
+  popupEl.innerHTML = `
+    <h2 class="popup-surface">${surfaceRuby}</h2>
+    <p class="popup-meta">${esc(entry.jlpt || "")}${entry.pos ? ` · ${esc(entry.pos)}` : ""}</p>
+    <p class="popup-meaning">${esc(entry.meaning_en || "")}</p>
+    ${entry.etymology ? `<p class="popup-etym">${esc(entry.etymology)}</p>` : ""}
+    ${entry.korean_parallel ? `<p class="popup-korean">${esc(entry.korean_parallel)}</p>` : ""}
+    <div class="popup-actions">
+      <button class="popup-btn" data-act="close">${renderInline(closeLabel.jp)}</button>
+      <button class="popup-btn popup-btn--primary ${saved ? "is-saved" : ""}" data-act="save" data-word="${esc(wordId)}">${renderInline(saveLabel.jp)}</button>
+    </div>
+  `;
+  popupEl.classList.add("is-open");
+  scrimEl.classList.add("is-open");
+  popupEl.setAttribute("aria-hidden", "false");
+  scrimEl.setAttribute("aria-hidden", "false");
+}
+
+function closePopup() {
+  popupEl.classList.remove("is-open");
+  scrimEl.classList.remove("is-open");
+  popupEl.setAttribute("aria-hidden", "true");
+  scrimEl.setAttribute("aria-hidden", "true");
+}
+
+function toggleSave(wordId, btn) {
+  if (state.saved.has(wordId)) {
+    state.saved.delete(wordId);
+  } else {
+    state.saved.add(wordId);
+  }
+  persistSet(STORAGE_KEYS.saved, state.saved);
+  // Update button label + class without closing
+  const saved = state.saved.has(wordId);
+  const label = ui(saved ? "save_confirmed" : "save_button");
+  btn.innerHTML = renderInline(label.jp);
+  btn.classList.toggle("is-saved", saved);
+}
+
+// ── Event delegation ──
+document.addEventListener("click", (e) => {
+  const word = e.target.closest(".word");
+  if (word) {
+    e.preventDefault();
+    openPopup(word.dataset.word);
+    return;
+  }
+  const action = e.target.closest("[data-act]");
+  if (action) {
+    const act = action.dataset.act;
+    if (act === "close") closePopup();
+    else if (act === "save") toggleSave(action.dataset.word, action);
+    else if (act === "add-to-basket")
+      handleAddToBasket(action.dataset.item, action);
+    else if (act === "checkout-advance") advanceCheckout();
+    else if (act === "checkout-choose")
+      chooseCheckout(action.dataset.responseId, action.dataset.label);
+    else if (act === "checkout-exit") exitCheckout();
+    else if (act === "basket-remove") removeOneFromBasket(action.dataset.item);
+    return;
+  }
+  if (e.target === scrimEl) closePopup();
+});
+
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") closePopup();
+  if (e.key === "Enter" && e.target.classList?.contains("word")) {
+    openPopup(e.target.dataset.word);
+  }
+});
+
+scrimEl.addEventListener("click", closePopup);
+
+window.addEventListener("hashchange", () => {
+  renderChrome();
+  route();
+});
+
+// ── Boot ──
+async function boot() {
+  try {
+    const res = await fetch("./content.json", { cache: "no-cache" });
+    state.content = await res.json();
+  } catch (err) {
+    document.getElementById("app").innerHTML = `
+      <div class="empty">コンテンツを読み込めませんでした。<br>
+      <span style="font-size:0.8em; color:var(--ink-soft);">Could not load content.json. Run <code>python3 _scripts/build_konbini.py</code>.</span></div>
+    `;
+    return;
+  }
+  renderChrome();
+  route();
+}
+
+boot();

--- a/is/learning/konbini/content.json
+++ b/is/learning/konbini/content.json
@@ -1,0 +1,1349 @@
+{
+  "items": {
+    "karaage-kun-yoru": {
+      "id": "karaage-kun-yoru",
+      "category": "fried_chicken",
+      "zone": "hot_case",
+      "price": 238,
+      "name_jp": "からあげクン 夜の味",
+      "name_en": "Karaage-kun, night flavor",
+      "weight": "5個",
+      "description_jp": "地域《ちいき》限定《げんてい》。どの夜《よる》かは書《か》かれていない。五個《ごこ》。",
+      "description_en": "Regional limited edition. Which night, it does not say. Five pieces.",
+      "front": [
+        {
+          "type": "banner",
+          "arg": "地域限定",
+          "body": "[chiiki-gentei]"
+        },
+        {
+          "type": "hero",
+          "body": "[karaage-kun]\n[yoru]の[aji]"
+        },
+        {
+          "type": "section",
+          "arg": "入数",
+          "body": "[gokoiri]"
+        },
+        {
+          "type": "footer",
+          "body": "[ondo]にご[chui]ください"
+        }
+      ],
+      "back": [
+        {
+          "type": "nutrition",
+          "arg": "1袋《ふくろ》あたり",
+          "rows": [
+            {
+              "left": "[energy]",
+              "right": "230kcal"
+            },
+            {
+              "left": "[tanpakushitsu]",
+              "right": "14.8g"
+            },
+            {
+              "left": "[shishitsu]",
+              "right": "15.2g"
+            },
+            {
+              "left": "[tansuikabutsu]",
+              "right": "8.1g"
+            },
+            {
+              "left": "[shokuen-soto]",
+              "right": "1.4g"
+            }
+          ]
+        },
+        {
+          "type": "section",
+          "arg": "[genzairyo]",
+          "body": "[toriniku]([kokusan])、[koromo]([komugiko]、[denpun]、[shokuen]、[koushinryou])、[ageabura]、[choumiryo](アミノ酸《さん》[nado])"
+        },
+        {
+          "type": "section",
+          "arg": "[allergy][hyouji]",
+          "body": "[komugi]・[toriniku]・[daizu]を[fukumu]"
+        },
+        {
+          "type": "fineprint",
+          "body": "[ohayameni][omeshiagari]ください\n[saikanetsu]は[osusume]しません"
+        }
+      ]
+    },
+    "onigiri-benizake": {
+      "id": "onigiri-benizake",
+      "category": "onigiri",
+      "zone": "food_aisle",
+      "price": 168,
+      "name_jp": "紅鮭おにぎり",
+      "name_en": "Sockeye salmon onigiri",
+      "weight": "140g",
+      "description_jp": "九月《くがつ》にとれた鮭《さけ》。少し寒《さむ》い土地《とち》の米《こめ》。どちらにも何《なに》も聞《き》かなかった。",
+      "description_en": "A salmon caught in September. Rice from a slightly colder place. Neither was asked anything.",
+      "front": [
+        {
+          "type": "banner",
+          "arg": "直火焼",
+          "body": "[jikabiyaki]"
+        },
+        {
+          "type": "hero",
+          "body": "[benizake]\nおにぎり"
+        },
+        {
+          "type": "footer",
+          "body": "[kokusanmai]使用 | 140g"
+        }
+      ],
+      "back": [
+        {
+          "type": "nutrition",
+          "arg": "1個《こ》あたり",
+          "rows": [
+            {
+              "left": "[energy]",
+              "right": "180kcal"
+            },
+            {
+              "left": "[tanpakushitsu]",
+              "right": "4.2g"
+            },
+            {
+              "left": "[shishitsu]",
+              "right": "1.8g"
+            },
+            {
+              "left": "[tansuikabutsu]",
+              "right": "36.5g"
+            },
+            {
+              "left": "[shokuen-soto]",
+              "right": "1.1g"
+            }
+          ]
+        },
+        {
+          "type": "section",
+          "arg": "[genzairyo]",
+          "body": "[kome]([kokusan])、[sake]、[shokuen]、[yakinori]、[choumiryo](アミノ酸《さん》[nado])"
+        },
+        {
+          "type": "section",
+          "arg": "[allergy][hyouji]",
+          "body": "[sake]を[fukumu]"
+        },
+        {
+          "type": "fineprint",
+          "body": "[chokusha]・[kouon-tashitsu]をさけて[hozon]してください\n[seizousho]: [miyagi]の[koujou]\n[shoumikigen]: [sokumen]に[kisai]"
+        }
+      ]
+    },
+    "tea-koi-ryokucha": {
+      "id": "tea-koi-ryokucha",
+      "category": "tea",
+      "zone": "drinks_fridge",
+      "price": 151,
+      "name_jp": "濃い緑茶",
+      "name_en": "Strong green tea",
+      "weight": "525ml",
+      "description_jp": "もっと濃《こ》くしてほしいと言《い》われた。お茶《ちゃ》は同意《どうい》した。瓶《びん》には525ミリリットルの同意《どうい》が入《はい》っている。",
+      "description_en": "Asked to be stronger. The tea agreed. The bottle holds 525ml of agreement.",
+      "front": [
+        {
+          "type": "banner",
+          "arg": "特徴",
+          "body": "[mukouryou]・[muchakushoku]"
+        },
+        {
+          "type": "hero",
+          "body": "[koi][ryokucha]"
+        },
+        {
+          "type": "section",
+          "arg": "成分強調",
+          "body": "[katechin] [nibai]"
+        },
+        {
+          "type": "footer",
+          "body": "[kokusanchaba] 100% | 525ml"
+        }
+      ],
+      "back": [
+        {
+          "type": "nutrition",
+          "arg": "100mlあたり",
+          "rows": [
+            {
+              "left": "[energy]",
+              "right": "0kcal"
+            },
+            {
+              "left": "[tanpakushitsu]",
+              "right": "0g"
+            },
+            {
+              "left": "[shishitsu]",
+              "right": "0g"
+            },
+            {
+              "left": "[tansuikabutsu]",
+              "right": "0g"
+            },
+            {
+              "left": "[shokuen-soto]",
+              "right": "0.02g"
+            },
+            {
+              "left": "[katechin]",
+              "right": "80mg"
+            }
+          ]
+        },
+        {
+          "type": "section",
+          "arg": "[genzairyo]",
+          "body": "[ryokucha]([kokusan])、[vitamin-c]"
+        },
+        {
+          "type": "section",
+          "arg": "味わい",
+          "body": "すっきりとした[atoaji]。[shokuji]と[isshoni]。"
+        },
+        {
+          "type": "fineprint",
+          "body": "[kaifuugo]は[ohayameni][onomi]ください\n[chokusha]・[kouon]をさけて[hozon]してください\n[seizousha]: [shizuoka]の[koujou]\n[youki]は[recycle]できます"
+        }
+      ]
+    }
+  },
+  "notices": {
+    "fax-service": {
+      "id": "fax-service",
+      "posted_date": "2026-02-01",
+      "posted_by": "店長《てんちょう》",
+      "notice_type": "service",
+      "style": "typed",
+      "blocks": [
+        {
+          "type": "heading",
+          "body": "[fax]サービスのご案内《あんない》"
+        },
+        {
+          "type": "footer",
+          "body": "受付《うけつけ》時間《じかん》: [eigyouchuu]"
+        }
+      ],
+      "prose": "当店《とうてん》では[fax]の[soushin]・[jushin]を承《うけたまわ》っております。\n\n[kokunai][soushin]: 1枚《まい》 [gojuuen]\n[kaigai][soushin]: 1枚《まい》 [nihyakuen]\n[jushin]: 1枚《まい》 [sanjuuen]\n\n[kaigai]の[soushin]は[kuni]により[toriatsukai]できない場合《ばあい》があります。\n詳《くわ》しくは[tenin]までお尋《たず》ねください。"
+    },
+    "lost-parakeet": {
+      "id": "lost-parakeet",
+      "posted_date": "2026-03-14",
+      "posted_by": "近所《きんじょ》の方《かた》",
+      "notice_type": "lost_pet",
+      "style": "handwritten",
+      "blocks": [
+        {
+          "type": "heading",
+          "body": "お知《し》らせ"
+        },
+        {
+          "type": "footer",
+          "body": "[sharei]あり"
+        }
+      ],
+      "prose": "[maigo]になりました。\n\n名前《なまえ》: ケイスケ\n種類《しゅるい》: [inko]\n色《いろ》: [kiiro]と[midori]\n特徴《とくちょう》: [shitsumon]でしか話《はな》しません\n\n[mikaketa]方《かた》は[renraku]ください。"
+    }
+  },
+  "dialogue": {
+    "checkout-standard": {
+      "id": "checkout-standard",
+      "trigger": "always",
+      "type": "linear",
+      "script": [
+        {
+          "type": "clerk",
+          "body": "[irasshaimase]。"
+        },
+        {
+          "type": "clerk",
+          "body": "[otsugi]でお待《ま》ちのお客様《きゃくさま》、どうぞ。"
+        },
+        {
+          "type": "action",
+          "body": "player_places_items"
+        },
+        {
+          "type": "clerk",
+          "body": "[goukei] {{basket_total}}円《えん》になります。"
+        },
+        {
+          "type": "player-choice",
+          "options": [
+            {
+              "label": "a",
+              "text": "はい、[onegai]します",
+              "response_id": "polite"
+            },
+            {
+              "label": "b",
+              "text": "お願《ねが》いします",
+              "response_id": "casual-polite"
+            }
+          ]
+        },
+        {
+          "type": "action",
+          "body": "payment_exchange"
+        },
+        {
+          "type": "clerk",
+          "body": "{{payment_amount}}円《えん》[oazukari]します。"
+        },
+        {
+          "type": "clerk",
+          "body": "{{change_amount}}円《えん》の[okaeshi]です。[receipt]のご利用《りよう》は?"
+        },
+        {
+          "type": "player-choice",
+          "options": [
+            {
+              "label": "a",
+              "text": "[onegai]します",
+              "response_id": "wants_receipt"
+            },
+            {
+              "label": "b",
+              "text": "[daijoubu]です",
+              "response_id": "declines_receipt"
+            }
+          ]
+        },
+        {
+          "type": "clerk-branch",
+          "arg": "wants_receipt",
+          "body": "はい、[receipt]です。"
+        },
+        {
+          "type": "clerk-branch",
+          "arg": "declines_receipt",
+          "body": "かしこまりました。"
+        },
+        {
+          "type": "clerk",
+          "body": "[arigatou]ございました。"
+        },
+        {
+          "type": "exit",
+          "body": "The doors slide open. You are outside the konbini. Briefly."
+        }
+      ]
+    }
+  },
+  "vocab": {
+    "ageabura": {
+      "surface": "揚げ油",
+      "reading": "あげあぶら",
+      "meaning_en": "frying oil",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "揚げる (to deep-fry) + 油 (oil). Native compound.",
+      "korean_parallel": null
+    },
+    "aji": {
+      "surface": "味",
+      "reading": "あじ",
+      "meaning_en": "flavor, taste",
+      "pos": "noun",
+      "jlpt": "N4",
+      "etymology": "Native Japanese word. Also reads ミ in compounds like 意味 (imi, meaning) and 興味 (kyoumi, interest).",
+      "korean_parallel": "맛 (mat) is the native Korean word. 미 (味) appears in Sino-Korean compounds: 의미 (uimi, meaning), 흥미 (heungmi, interest). Parallel layered structure — native word for everyday, Sino reading for compounds."
+    },
+    "allergy": {
+      "surface": "アレルギー",
+      "reading": "あれるぎー",
+      "meaning_en": "allergy, allergen",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "From German Allergie. Arrived in Japanese via medical vocabulary in the early 20th century.",
+      "korean_parallel": "알레르기 (allereugi) — also from German, via similar medical borrowing route."
+    },
+    "arigatou": {
+      "surface": "ありがとう",
+      "reading": "ありがとう",
+      "meaning_en": "thank you",
+      "pos": "expression",
+      "jlpt": "N5",
+      "etymology": "From 有り難い (arigatai, \"difficult to exist\" → rare and precious). Originally Buddhist: a thing so rare it deserves gratitude. The modern thank-you preserves the structure but not the awareness of it.",
+      "korean_parallel": null
+    },
+    "atoaji": {
+      "surface": "後味",
+      "reading": "あとあじ",
+      "meaning_en": "aftertaste",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "後 (after) + 味 (taste). Transparent compound.",
+      "korean_parallel": "뒷맛 (dwitmat) — native compound, 뒤 (after) + 맛 (taste). Same structure in both languages using native morphemes."
+    },
+    "benizake": {
+      "surface": "紅鮭",
+      "reading": "べにざけ",
+      "meaning_en": "sockeye salmon (lit. \"crimson salmon\")",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "紅 (crimson) + 鮭 (salmon). The 紅 reading here is べに (native kun'yomi), not the Sino-Japanese コウ seen in 紅茶 (kōcha, black tea).",
+      "korean_parallel": "연어 (yeoneo) is a native Korean word with no hanja parallel to 鮭. 紅 as hong appears in 홍차 (hongcha, black tea) — same 紅茶 compound."
+    },
+    "chiiki-gentei": {
+      "surface": "地域限定",
+      "reading": "ちいきげんてい",
+      "meaning_en": "region-limited (only available in certain areas)",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "地域 (region) + 限定 (limitation). Marketing term ubiquitous on konbini packaging to signal regional exclusivity.",
+      "korean_parallel": "지역한정 (jiyeok-hanjeong) — exact cognate, same compound, same marketing usage."
+    },
+    "chokusha": {
+      "surface": "直射日光",
+      "reading": "ちょくしゃにっこう",
+      "meaning_en": "direct sunlight",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "直射 (direct emission) + 日光 (sunlight). Standard phrase in storage warnings.",
+      "korean_parallel": "직사광선 (jiksagwangseon) — same construction with 광선 (light rays) instead of 일광. Similar regulatory register."
+    },
+    "choumiryo": {
+      "surface": "調味料",
+      "reading": "ちょうみりょう",
+      "meaning_en": "seasoning, flavor enhancer",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "調 (adjust) + 味 (flavor) + 料 (material). On ingredient lists, often followed by parenthetical specifying the type (e.g. アミノ酸等).",
+      "korean_parallel": "조미료 (jomiryo) — direct cognate, identical usage."
+    },
+    "chui": {
+      "surface": "注意",
+      "reading": "ちゅうい",
+      "meaning_en": "caution, attention",
+      "pos": "noun",
+      "jlpt": "N4",
+      "etymology": "注 (pour, focus) + 意 (intention, mind). \"Pour one's attention.\"",
+      "korean_parallel": "주의 (juui) — direct cognate."
+    },
+    "daijoubu": {
+      "surface": "大丈夫",
+      "reading": "だいじょうぶ",
+      "meaning_en": "okay, no thank you (in konbini context, often means \"no need\")",
+      "pos": "na-adjective",
+      "jlpt": "N5",
+      "etymology": "大 (great) + 丈夫 (sturdy/healthy). Originally meant \"fine, in good order.\" In modern Japanese it has also become a polite way to decline (\"I'm fine without it\") — a source of endless confusion for learners.",
+      "korean_parallel": "대장부 (daejangbu) exists in Korean with the original meaning (a strong man). The Japanese semantic drift to \"okay/no thanks\" did not occur in Korean."
+    },
+    "daizu": {
+      "surface": "大豆",
+      "reading": "だいず",
+      "meaning_en": "soybean",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "大 (large) + 豆 (bean). Listed as an allergen on Japanese packaging.",
+      "korean_parallel": "대두 (daedu) — direct cognate, used in formal/agricultural contexts. Everyday Korean uses native 콩 (kong)."
+    },
+    "denpun": {
+      "surface": "でん粉",
+      "reading": "でんぷん",
+      "meaning_en": "starch",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "澱 (sediment) + 粉 (powder). 澱 is non-jōyō so typically written でん on modern packaging.",
+      "korean_parallel": "전분 (jeonbun) — direct cognate using the same compound."
+    },
+    "eigyouchuu": {
+      "surface": "営業中",
+      "reading": "えいぎょうちゅう",
+      "meaning_en": "currently open, business in progress",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "営業 (business operation) + 中 (middle, during). Standard sign on open shops.",
+      "korean_parallel": "영업중 (yeongeopjung) — direct cognate, identical signage usage."
+    },
+    "energy": {
+      "surface": "エネルギー",
+      "reading": "えねるぎー",
+      "meaning_en": "energy, calories",
+      "pos": "noun",
+      "jlpt": "N5",
+      "etymology": "From German Energie. Japanese scientific vocabulary often took German over English in the Meiji-Shōwa period. Always first line on nutrition panels.",
+      "korean_parallel": "에너지 (eneoji) — from English. A rare case where Japanese took German and Korean took English for the same scientific term."
+    },
+    "fax": {
+      "surface": "ファックス",
+      "reading": "ふぁっくす",
+      "meaning_en": "fax machine, fax (noun and verb)",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "English loanword. Konbini fax services persisted in Japan long after they disappeared elsewhere.",
+      "korean_parallel": "팩스 (paekseu) — also from English, shorter form."
+    },
+    "fukumu": {
+      "surface": "含む",
+      "reading": "ふくむ",
+      "meaning_en": "to contain, include",
+      "pos": "verb (u-verb)",
+      "jlpt": "N3",
+      "etymology": "Native Japanese verb. On allergen labels always appears in the form 〜を含む (contains X).",
+      "korean_parallel": "포함하다 (pohamhada) from 包含 — different verb, similar function. 含 appears in 함유 (hamyu, containing) on Korean ingredient labels."
+    },
+    "genzairyo": {
+      "surface": "原材料名",
+      "reading": "げんざいりょうめい",
+      "meaning_en": "ingredients (regulatory label term)",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "原 (origin) + 材料 (material) + 名 (name). Mandated by Japanese food labeling law.",
+      "korean_parallel": "원재료명 (wonjaeryomyeong) — direct cognate. Korean food labels use the same exact compound."
+    },
+    "gojuuen": {
+      "surface": "50円",
+      "reading": "ごじゅうえん",
+      "meaning_en": "50 yen",
+      "pos": "noun",
+      "jlpt": "N5",
+      "etymology": "五十 (fifty) + 円 (yen). 円 was originally the general term for a round object, borrowed as the currency unit in 1871.",
+      "korean_parallel": null
+    },
+    "gokoiri": {
+      "surface": "5個入り",
+      "reading": "ごこいり",
+      "meaning_en": "pack of 5, 5 pieces included",
+      "pos": "noun",
+      "jlpt": "N4",
+      "etymology": "五 (five) + 個 (piece-counter) + 入り (contained). 入り attaches to numbers to mean \"containing N.\"",
+      "korean_parallel": null
+    },
+    "goukei": {
+      "surface": "合計",
+      "reading": "ごうけい",
+      "meaning_en": "total (amount)",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "合 (combine) + 計 (count). Standard cashier/register vocabulary.",
+      "korean_parallel": "합계 (hapgye) — direct cognate."
+    },
+    "hozon": {
+      "surface": "保存",
+      "reading": "ほぞん",
+      "meaning_en": "storage, preservation",
+      "pos": "noun, verb (する)",
+      "jlpt": "N3",
+      "etymology": "保 (keep, protect) + 存 (exist). \"Keep existing.\" Standard in both packaging warnings and digital context (file save).",
+      "korean_parallel": "보존 (bojon) — direct cognate. Korean uses 저장 (jeojang) for digital file save, 보존 for physical preservation — same split."
+    },
+    "hyouji": {
+      "surface": "表示",
+      "reading": "ひょうじ",
+      "meaning_en": "display, indication",
+      "pos": "noun, verb (する)",
+      "jlpt": "N3",
+      "etymology": "表 (surface, show) + 示 (indicate). Regulatory term; 表示 paired with other nouns forms standardized phrases (栄養成分表示, アレルギー表示).",
+      "korean_parallel": "표시 (pyosi) — direct cognate with identical compound usage."
+    },
+    "inko": {
+      "surface": "インコ",
+      "reading": "いんこ",
+      "meaning_en": "parakeet",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "Written in katakana despite being an older loanword (possibly from Dutch or early Portuguese via earlier trade). Small parrots.",
+      "korean_parallel": "잉꼬 (inkko) — borrowed from Japanese, not directly from a European source."
+    },
+    "irasshaimase": {
+      "surface": "いらっしゃいませ",
+      "reading": "いらっしゃいませ",
+      "meaning_en": "welcome (formal customer greeting)",
+      "pos": "expression",
+      "jlpt": "N4",
+      "etymology": "Honorific imperative of いらっしゃる (to come/go, honorific). The polite imperative -ませ ending is rare outside customer service contexts.",
+      "korean_parallel": "어서오세요 (eoseo oseyo) — functionally equivalent. Korean uses an honorific imperative of 오다 (to come)."
+    },
+    "isshoni": {
+      "surface": "一緒に",
+      "reading": "いっしょに",
+      "meaning_en": "together with",
+      "pos": "adverb",
+      "jlpt": "N5",
+      "etymology": "一 (one) + 緒 (thread/beginning) + に (particle). \"In one thread.\" Often collocates with 食事 for \"together with a meal.\"",
+      "korean_parallel": "같이 (gachi) — native word, different structure."
+    },
+    "jikabiyaki": {
+      "surface": "直火焼",
+      "reading": "じかびやき",
+      "meaning_en": "grilled over direct flame",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "直 (direct) + 火 (fire) + 焼 (grill). 焼 takes the native kun'yomi やき. A packaging/restaurant term signaling flame contact rather than oven or pan cooking.",
+      "korean_parallel": "직화구이 (jikhwa-gui) — exact cognate. 직 (直) + 화 (火) + native 구이 (grilling). Same compound structure up to the native-word tail."
+    },
+    "jushin": {
+      "surface": "受信",
+      "reading": "じゅしん",
+      "meaning_en": "receiving (a transmission)",
+      "pos": "noun, verb (する)",
+      "jlpt": "N2",
+      "etymology": "受 (receive) + 信 (signal, message). Paired with 送信 (soushin, sending).",
+      "korean_parallel": "수신 (susin) — direct cognate, same usage in postal and telecom contexts."
+    },
+    "kaifuugo": {
+      "surface": "開封後",
+      "reading": "かいふうご",
+      "meaning_en": "after opening (a sealed container)",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "開封 (opening a seal) + 後 (after). 封 originally meant \"seal a letter.\" Standard storage warning phrase.",
+      "korean_parallel": "개봉후 (gaebonghu) — direct cognate."
+    },
+    "kaigai": {
+      "surface": "海外",
+      "reading": "かいがい",
+      "meaning_en": "overseas, international",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "海 (sea) + 外 (outside). \"Beyond the sea.\" Japan's historical island perspective preserved in the everyday word for \"international.\"",
+      "korean_parallel": "해외 (haeoe) — direct cognate with identical logic and usage."
+    },
+    "karaage-kun": {
+      "surface": "からあげクン",
+      "reading": "からあげくん",
+      "meaning_en": "Karaage-kun (store-brand fried chicken nuggets)",
+      "pos": "proper noun",
+      "jlpt": "—",
+      "etymology": "唐揚げ (karaage, Chinese-style deep-fried) + クン (kun, a familiar suffix for boys/younger males). A 1986 Lawson product whose name stuck. The クン is why the product feels like a small friend rather than food.",
+      "korean_parallel": null
+    },
+    "katechin": {
+      "surface": "カテキン",
+      "reading": "かてきん",
+      "meaning_en": "catechins (antioxidant compounds in green tea)",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "From English/Latin \"catechin,\" itself from Malay kachu (the plant Acacia catechu). Appears frequently on Japanese tea marketing.",
+      "korean_parallel": "카테킨 (katekin) — also from the same international scientific term."
+    },
+    "kiiro": {
+      "surface": "黄色",
+      "reading": "きいろ",
+      "meaning_en": "yellow",
+      "pos": "noun, na-adjective",
+      "jlpt": "N4",
+      "etymology": "黄 (yellow) + 色 (color). Color names in Japanese often take 色 as a suffix for the noun form.",
+      "korean_parallel": "노랑/노란색 (norang/noransaek) uses a native Korean root. 황 (黃) appears in Sino-Korean compounds like 황금 (hwanggeum, gold) but not in everyday color names."
+    },
+    "kisai": {
+      "surface": "記載",
+      "reading": "きさい",
+      "meaning_en": "recorded, noted (on)",
+      "pos": "noun, verb (する)",
+      "jlpt": "N2",
+      "etymology": "記 (record) + 載 (place upon, include). \"Placed on record.\" Formal/regulatory register.",
+      "korean_parallel": "기재 (gijae) — direct cognate."
+    },
+    "koi": {
+      "surface": "濃い",
+      "reading": "こい",
+      "meaning_en": "strong, concentrated, rich (of flavor or color)",
+      "pos": "i-adjective",
+      "jlpt": "N3",
+      "etymology": "Native Japanese adjective. Antonym: 薄い (usui, weak/thin).",
+      "korean_parallel": "진하다 (jinhada) — native Korean, functionally equivalent. 농 (濃) appears in Sino-Korean compounds like 농도 (nongdo, concentration) but not as a standalone adjective."
+    },
+    "kokunai": {
+      "surface": "国内",
+      "reading": "こくない",
+      "meaning_en": "domestic, within the country",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "国 (country) + 内 (inside). Antonym of 海外.",
+      "korean_parallel": "국내 (guknae) — direct cognate, used identically."
+    },
+    "kokusan": {
+      "surface": "国産",
+      "reading": "こくさん",
+      "meaning_en": "domestic, made in Japan",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "国 (country) + 産 (produced). Extremely productive marketing prefix — 国産牛, 国産野菜, 国産大豆.",
+      "korean_parallel": "국산 (guksan) — direct cognate, used the same way in Korean marketing."
+    },
+    "kokusanchaba": {
+      "surface": "国産茶葉",
+      "reading": "こくさんちゃば",
+      "meaning_en": "domestic tea leaves",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "国産 (domestic) + 茶葉 (tea leaves). 茶葉 combines 茶 (tea) + 葉 (leaf).",
+      "korean_parallel": null
+    },
+    "kokusanmai": {
+      "surface": "国産米",
+      "reading": "こくさんまい",
+      "meaning_en": "domestically-produced rice",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "国産 (domestic) + 米 (rice, on'yomi マイ). Sino-Japanese compound; the everyday word for rice-as-grain is こめ.",
+      "korean_parallel": "국산미 (guksan-mi) exists but less common than 국산쌀 (guksan-ssal) using native 쌀 for rice. Same pattern, different habitual usage."
+    },
+    "kome": {
+      "surface": "米",
+      "reading": "こめ",
+      "meaning_en": "rice (uncooked, as grain or ingredient)",
+      "pos": "noun",
+      "jlpt": "N4",
+      "etymology": "Native kun'yomi こめ for rice-as-grain. The on'yomi マイ/ベイ appears in compounds: 米国 (America), 新米 (new rice), 精米 (polished rice). Cooked rice is a different word: ご飯 (gohan).",
+      "korean_parallel": "쌀 (ssal) is the native Korean word for uncooked rice — no hanja. 미 (米) as a hanja reading appears in compounds: 미국 (America). Both languages preserve a native word for the staple."
+    },
+    "komugi": {
+      "surface": "小麦",
+      "reading": "こむぎ",
+      "meaning_en": "wheat",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "小 (small) + 麦 (barley/grain). \"Small barley\" — older botanical taxonomy.",
+      "korean_parallel": "밀 (mil) is native Korean. 소맥 (somaek) from 小麦 exists but is technical/formal."
+    },
+    "komugiko": {
+      "surface": "小麦粉",
+      "reading": "こむぎこ",
+      "meaning_en": "wheat flour",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "小麦 (wheat) + 粉 (powder).",
+      "korean_parallel": "밀가루 (milgaru) — native compound, 밀 (wheat) + 가루 (powder). Same structure with native morphemes."
+    },
+    "koromo": {
+      "surface": "衣",
+      "reading": "ころも",
+      "meaning_en": "batter, coating (on fried food); also \"clothing\" in classical usage",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "Originally \"clothing,\" now used for the outer coating of food. The image: the food is wearing a garment of batter.",
+      "korean_parallel": null
+    },
+    "koujou": {
+      "surface": "工場",
+      "reading": "こうじょう",
+      "meaning_en": "factory",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "工 (work, craft) + 場 (place). \"Place of work/production.\"",
+      "korean_parallel": "공장 (gongjang) — direct cognate."
+    },
+    "kouon": {
+      "surface": "高温",
+      "reading": "こうおん",
+      "meaning_en": "high temperature",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "高 (high) + 温 (warm/temperature). Standard in storage warnings.",
+      "korean_parallel": "고온 (goon) — direct cognate."
+    },
+    "kouon-tashitsu": {
+      "surface": "高温多湿",
+      "reading": "こうおんたしつ",
+      "meaning_en": "high temperature and humidity (avoid)",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "高温 (high temperature) + 多湿 (much humidity). Four-kanji compound (四字熟語 structure) used specifically for storage warnings.",
+      "korean_parallel": "고온다습 (goondaseup) — direct cognate, identical usage."
+    },
+    "koushinryou": {
+      "surface": "香辛料",
+      "reading": "こうしんりょう",
+      "meaning_en": "spice",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "香 (fragrance) + 辛 (spicy) + 料 (material). \"Fragrant spicy material.\"",
+      "korean_parallel": "향신료 (hyangsinryo) — direct cognate."
+    },
+    "kuni": {
+      "surface": "国",
+      "reading": "くに",
+      "meaning_en": "country",
+      "pos": "noun",
+      "jlpt": "N5",
+      "etymology": "Native kun'yomi for 国. On'yomi コク appears in compounds (国産, 国内, 国民).",
+      "korean_parallel": "나라 (nara) is native Korean. 국 (國/国) appears in Sino-Korean compounds — the same layered pattern as Japanese."
+    },
+    "maigo": {
+      "surface": "迷子",
+      "reading": "まいご",
+      "meaning_en": "lost child, lost (of a person or pet)",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "迷 (lost, confused) + 子 (child). Originally for children, extended to pets in modern usage.",
+      "korean_parallel": "미아 (mia) from 迷兒 uses the same structure. Both languages use the \"lost child\" compound for the concept."
+    },
+    "midori": {
+      "surface": "緑",
+      "reading": "みどり",
+      "meaning_en": "green",
+      "pos": "noun, na-adjective",
+      "jlpt": "N4",
+      "etymology": "Native kun'yomi. Japanese historically classified blue and green together as 青 (ao); 緑 emerged as a distinct color term relatively recently.",
+      "korean_parallel": "녹색 (noksaek) from 緑色 is Sino-Korean. Native 초록 (chorok) and 푸른 (pureun, blue/green) show the same historical color-category mixing."
+    },
+    "mikaketa": {
+      "surface": "見かけた",
+      "reading": "みかけた",
+      "meaning_en": "saw, spotted (past tense of 見かける)",
+      "pos": "verb (past form)",
+      "jlpt": "N3",
+      "etymology": "見る (see) + かける (auxiliary meaning \"happen to\" or \"do briefly\"). \"Happen to see.\" Used in lost-pet notices and witness-seeking contexts.",
+      "korean_parallel": null
+    },
+    "miyagi": {
+      "surface": "宮城県",
+      "reading": "みやぎけん",
+      "meaning_en": "Miyagi Prefecture",
+      "pos": "proper noun",
+      "jlpt": "N3",
+      "etymology": "宮 (shrine/palace) + 城 (castle) + 県 (prefecture). Northeast Honshu. Sendai is its capital.",
+      "korean_parallel": null
+    },
+    "muchakushoku": {
+      "surface": "無着色",
+      "reading": "むちゃくしょく",
+      "meaning_en": "no coloring added",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "無 (without) + 着色 (coloring). The 無 prefix is extremely productive in food marketing: 無糖 (sugar-free), 無添加 (no additives), 無香料 (no fragrance).",
+      "korean_parallel": "무착색 (muchaksaek) — direct cognate. The 무- prefix is equally productive in Korean food marketing."
+    },
+    "mukouryou": {
+      "surface": "無香料",
+      "reading": "むこうりょう",
+      "meaning_en": "no fragrance added",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "無 (without) + 香料 (fragrance/flavoring). Paired frequently with 無着色 in marketing.",
+      "korean_parallel": "무향료 (muhyangryo) — direct cognate."
+    },
+    "nado": {
+      "surface": "等",
+      "reading": "など",
+      "meaning_en": "etc., and others",
+      "pos": "suffix, particle",
+      "jlpt": "N4",
+      "etymology": "On ingredient lists, appears after a category to indicate unspecified members. Written with hiragana なんど in older texts; now typically 等 or など.",
+      "korean_parallel": "등 (deung) from 等 — same kanji, same function, same ingredient-list usage."
+    },
+    "nibai": {
+      "surface": "2倍",
+      "reading": "にばい",
+      "meaning_en": "double, 2x",
+      "pos": "noun",
+      "jlpt": "N4",
+      "etymology": "二 (two) + 倍 (times, multiplier). 倍 as a suffix attaches to numbers to form multipliers.",
+      "korean_parallel": "배 (bae) from 倍 — same kanji, same structure (2배, dubbae)."
+    },
+    "nihyakuen": {
+      "surface": "200円",
+      "reading": "にひゃくえん",
+      "meaning_en": "200 yen",
+      "pos": "noun",
+      "jlpt": "N5",
+      "etymology": "二百 (two hundred) + 円 (yen).",
+      "korean_parallel": null
+    },
+    "oazukari": {
+      "surface": "お預かり",
+      "reading": "おあずかり",
+      "meaning_en": "receiving (money, in formal register)",
+      "pos": "noun (honorific)",
+      "jlpt": "N3",
+      "etymology": "Honorific お- + 預かる (to hold on behalf of). Used specifically in customer-service payment contexts: \"I am receiving your X yen\" rather than \"you gave me X yen.\"",
+      "korean_parallel": null
+    },
+    "ohayameni": {
+      "surface": "お早めに",
+      "reading": "おはやめに",
+      "meaning_en": "promptly, soon (polite)",
+      "pos": "adverb",
+      "jlpt": "N3",
+      "etymology": "Honorific お- + 早め (earlier) + に (adverb particle). Softer than 早く, suitable for packaging instructions.",
+      "korean_parallel": null
+    },
+    "okaeshi": {
+      "surface": "お返し",
+      "reading": "おかえし",
+      "meaning_en": "change, return (polite)",
+      "pos": "noun (honorific)",
+      "jlpt": "N3",
+      "etymology": "Honorific お- + 返し (returning). In transactions means change given back; in social contexts means a return gift.",
+      "korean_parallel": null
+    },
+    "omeshiagari": {
+      "surface": "お召し上がり",
+      "reading": "おめしあがり",
+      "meaning_en": "eating (respectful, honorific)",
+      "pos": "noun/verb (honorific)",
+      "jlpt": "N3",
+      "etymology": "Honorific form of 食べる/飲む. 召す is a classical honorific verb meaning \"to do (various things)\" — eat, wear, call for, ride. On packaging always お召し上がりください.",
+      "korean_parallel": "드시다 (deusida) is the equivalent Korean honorific for eating/drinking."
+    },
+    "ondo": {
+      "surface": "温度",
+      "reading": "おんど",
+      "meaning_en": "temperature",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "温 (warm) + 度 (degree).",
+      "korean_parallel": "온도 (ondo) — direct cognate, identical pronunciation."
+    },
+    "onegai": {
+      "surface": "お願い",
+      "reading": "おねがい",
+      "meaning_en": "request, please",
+      "pos": "noun (honorific)",
+      "jlpt": "N5",
+      "etymology": "Honorific お- + 願い (wish, request). Used as a polite way to agree (\"yes please\") in service exchanges.",
+      "korean_parallel": "부탁 (butak) is the native/Sino-Korean equivalent; different morphology but parallel social function."
+    },
+    "onomi": {
+      "surface": "お飲み",
+      "reading": "おのみ",
+      "meaning_en": "drink (polite stem form)",
+      "pos": "verb (polite stem)",
+      "jlpt": "N3",
+      "etymology": "Honorific お- + 飲み (drink, stem form). Used in instructions (お飲みください, please drink).",
+      "korean_parallel": null
+    },
+    "osusume": {
+      "surface": "おすすめ",
+      "reading": "おすすめ",
+      "meaning_en": "recommendation (also written 御勧め, 御薦め)",
+      "pos": "noun",
+      "jlpt": "N4",
+      "etymology": "Honorific お- + 勧め (recommendation, from 勧める to recommend). Common in restaurant and retail contexts; on packaging often in the negative: \"we do not recommend X.\"",
+      "korean_parallel": "추천 (chucheon) from 推薦 is the Sino-Korean equivalent."
+    },
+    "otsugi": {
+      "surface": "お次",
+      "reading": "おつぎ",
+      "meaning_en": "next (customer), the next one (polite)",
+      "pos": "noun (honorific)",
+      "jlpt": "N4",
+      "etymology": "Honorific お- + 次 (next). Specific to service register when addressing the next person in line.",
+      "korean_parallel": "다음 (daeum) is the native equivalent."
+    },
+    "receipt": {
+      "surface": "レシート",
+      "reading": "れしーと",
+      "meaning_en": "receipt",
+      "pos": "noun",
+      "jlpt": "N5",
+      "etymology": "From English \"receipt.\" Distinct from 領収書 (ryoushuusho), which is a formal receipt with buyer's name for reimbursement or tax purposes. The konbini clerk asks about the former.",
+      "korean_parallel": "영수증 (yeongsujeung) from 領收證 — Korean uses the formal term for both contexts, no common loanword equivalent to レシート."
+    },
+    "recycle": {
+      "surface": "リサイクル",
+      "reading": "りさいくる",
+      "meaning_en": "recycle, recycling",
+      "pos": "noun, verb (する)",
+      "jlpt": "N4",
+      "etymology": "From English \"recycle.\" Always in katakana; 再生 (saisei, rebirth/regeneration) is the native alternative but specialized.",
+      "korean_parallel": "재활용 (jaehwaryong) from 再活用 — Korean uses a Sino-Korean compound (\"reuse\") rather than an English loanword."
+    },
+    "renraku": {
+      "surface": "連絡",
+      "reading": "れんらく",
+      "meaning_en": "contact, get in touch",
+      "pos": "noun, verb (する)",
+      "jlpt": "N4",
+      "etymology": "連 (connect) + 絡 (entwine, link). \"Link up.\"",
+      "korean_parallel": "연락 (yeollak) — direct cognate."
+    },
+    "ryokucha": {
+      "surface": "緑茶",
+      "reading": "りょくちゃ",
+      "meaning_en": "green tea",
+      "pos": "noun",
+      "jlpt": "N4",
+      "etymology": "緑 (green) + 茶 (tea). The Japanese convention separates 緑茶 (green), 紅茶 (black), and 麦茶 (barley tea) by color/material.",
+      "korean_parallel": "녹차 (nokcha) — direct cognate. Same three-way distinction in Korean: 녹차, 홍차, 보리차."
+    },
+    "saikanetsu": {
+      "surface": "再加熱",
+      "reading": "さいかねつ",
+      "meaning_en": "reheating",
+      "pos": "noun, verb (する)",
+      "jlpt": "N2",
+      "etymology": "再 (again) + 加熱 (heating, applying heat). 加熱 combines 加 (add) + 熱 (heat).",
+      "korean_parallel": "재가열 (jaegayeol) — direct cognate."
+    },
+    "sake": {
+      "surface": "鮭",
+      "reading": "さけ",
+      "meaning_en": "salmon",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "Native Japanese word. The kanji 鮭 has 魚 (fish) radical with 圭 (jade tablet) as phonetic component. Colloquial variant しゃけ is common in informal speech and older generations.",
+      "korean_parallel": "연어 (yeoneo) — native Korean word, no hanja bridge. A case where CJKV parallel doesn't apply."
+    },
+    "sanjuuen": {
+      "surface": "30円",
+      "reading": "さんじゅうえん",
+      "meaning_en": "30 yen",
+      "pos": "noun",
+      "jlpt": "N5",
+      "etymology": "三十 (thirty) + 円 (yen).",
+      "korean_parallel": null
+    },
+    "seizousha": {
+      "surface": "製造者",
+      "reading": "せいぞうしゃ",
+      "meaning_en": "manufacturer",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "製造 (manufacture) + 者 (person/entity). For corporate entities; for facilities the term is 製造所.",
+      "korean_parallel": "제조자 (jejoja) — direct cognate."
+    },
+    "seizousho": {
+      "surface": "製造所",
+      "reading": "せいぞうしょ",
+      "meaning_en": "manufacturing facility",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "製造 (manufacture) + 所 (place). Required on food labels when manufactured by a contracted facility.",
+      "korean_parallel": "제조소 (jejoso) — direct cognate."
+    },
+    "sharei": {
+      "surface": "謝礼",
+      "reading": "しゃれい",
+      "meaning_en": "reward, token of thanks",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "謝 (apologize, thank) + 礼 (ceremony, courtesy). A formal thank-you often taking monetary form.",
+      "korean_parallel": "사례 (sarye) — direct cognate, same usage in lost-and-found contexts."
+    },
+    "shishitsu": {
+      "surface": "脂質",
+      "reading": "ししつ",
+      "meaning_en": "fat, lipids",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "脂 (fat, grease) + 質 (substance). Paired with the other three macronutrient terms on every nutrition panel.",
+      "korean_parallel": "지질 (jijil) — direct cognate, same compound."
+    },
+    "shitsumon": {
+      "surface": "質問",
+      "reading": "しつもん",
+      "meaning_en": "question",
+      "pos": "noun, verb (する)",
+      "jlpt": "N4",
+      "etymology": "質 (substance, essence) + 問 (ask). \"Ask about the substance of.\"",
+      "korean_parallel": "질문 (jilmun) — direct cognate."
+    },
+    "shizuoka": {
+      "surface": "静岡県",
+      "reading": "しずおかけん",
+      "meaning_en": "Shizuoka Prefecture",
+      "pos": "proper noun",
+      "jlpt": "N3",
+      "etymology": "静 (quiet) + 岡 (hill) + 県 (prefecture). Central Honshu, south of Mount Fuji. Major tea-producing region.",
+      "korean_parallel": null
+    },
+    "shokuen": {
+      "surface": "食塩",
+      "reading": "しょくえん",
+      "meaning_en": "table salt",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "食 (food, eating) + 塩 (salt). Distinguished from 塩 alone (salt in general) to specify salt intended for consumption.",
+      "korean_parallel": "식염 (sikyeom) — direct cognate, used in regulatory/medical contexts."
+    },
+    "shokuen-soto": {
+      "surface": "食塩相当量",
+      "reading": "しょくえんそうとうりょう",
+      "meaning_en": "salt equivalent",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "食塩 (table salt) + 相当 (equivalent) + 量 (amount). Japan reports sodium as its salt equivalent rather than raw sodium. Multiply sodium by 2.54 to get this figure.",
+      "korean_parallel": "식염상당량 (sikyeom-sangdangnyang) — exact compound cognate. Korean food labels use the same regulatory format."
+    },
+    "shokuji": {
+      "surface": "食事",
+      "reading": "しょくじ",
+      "meaning_en": "meal",
+      "pos": "noun",
+      "jlpt": "N4",
+      "etymology": "食 (eat) + 事 (matter, event). \"The matter of eating.\"",
+      "korean_parallel": "식사 (siksa) — direct cognate using 食事 with different second character reading."
+    },
+    "shoumikigen": {
+      "surface": "賞味期限",
+      "reading": "しょうみきげん",
+      "meaning_en": "best-by date",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "賞味 (appreciate the taste of) + 期限 (time limit). Distinct from 消費期限 (shouhi kigen, safety-critical use-by date). 賞味 implies taste quality, not safety.",
+      "korean_parallel": "유통기한 (yutonggihan, distribution period) is what Korean labels typically show — conceptually similar but different compound."
+    },
+    "sokumen": {
+      "surface": "側面",
+      "reading": "そくめん",
+      "meaning_en": "side surface",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "側 (side) + 面 (face, surface). Standard packaging phrase: 側面に記載 (noted on the side).",
+      "korean_parallel": "측면 (cheukmyeon) — direct cognate."
+    },
+    "soushin": {
+      "surface": "送信",
+      "reading": "そうしん",
+      "meaning_en": "sending (a transmission)",
+      "pos": "noun, verb (する)",
+      "jlpt": "N2",
+      "etymology": "送 (send) + 信 (signal, message). Paired with 受信 (jushin, receiving).",
+      "korean_parallel": "송신 (songsin) — direct cognate."
+    },
+    "tanpakushitsu": {
+      "surface": "たんぱく質",
+      "reading": "たんぱくしつ",
+      "meaning_en": "protein",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "蛋白 (egg white) + 質 (substance). Written たんぱく in hiragana on most modern packaging because 蛋 is non-jōyō. Egg whites were the prototype protein in 19th-century biochemistry.",
+      "korean_parallel": "단백질 (danbaekjil) — identical compound (蛋白質). Same etymology, same reasoning. One of the cleanest CJK cognates you'll find."
+    },
+    "tansuikabutsu": {
+      "surface": "炭水化物",
+      "reading": "たんすいかぶつ",
+      "meaning_en": "carbohydrates",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "炭 (carbon) + 水 (water) + 化 (transform) + 物 (substance). Direct translation of the scientific term \"carbohydrate\" — a late 19th-century Japanese coinage that then traveled back to Chinese and Korean.",
+      "korean_parallel": "탄수화물 (tansuhwamul) — full cognate. Meiji-era Japanese scientific vocabulary is why modern Korean and Chinese scientific terminology often tracks Japanese closely."
+    },
+    "tenin": {
+      "surface": "店員",
+      "reading": "てんいん",
+      "meaning_en": "store clerk, shop employee",
+      "pos": "noun",
+      "jlpt": "N4",
+      "etymology": "店 (shop) + 員 (member, staff).",
+      "korean_parallel": "점원 (jeomwon) — direct cognate."
+    },
+    "toriatsukai": {
+      "surface": "取り扱い",
+      "reading": "とりあつかい",
+      "meaning_en": "handling, treatment (of an item or service)",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "取る (take) + 扱う (handle). Compound verb noun. In service contexts: what the business offers or declines to offer.",
+      "korean_parallel": "취급 (chwigeup) from 取扱 — direct cognate with same business usage."
+    },
+    "toriniku": {
+      "surface": "鶏肉",
+      "reading": "とりにく",
+      "meaning_en": "chicken (meat)",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "鶏 (chicken, the bird) + 肉 (meat). Transparent compound.",
+      "korean_parallel": "닭고기 (dakgogi) — native Korean compound using 닭 (chicken) + 고기 (meat). Same structure with different morphemes."
+    },
+    "vitamin-c": {
+      "surface": "ビタミンC",
+      "reading": "びたみんしー",
+      "meaning_en": "vitamin C",
+      "pos": "noun",
+      "jlpt": "N5",
+      "etymology": "From English \"vitamin.\" On ingredient lists often added as an antioxidant/preservative rather than as a nutritional claim.",
+      "korean_parallel": "비타민C (bitamin-ssi) — same international scientific term."
+    },
+    "yakinori": {
+      "surface": "焼のり",
+      "reading": "やきのり",
+      "meaning_en": "toasted nori seaweed",
+      "pos": "noun",
+      "jlpt": "N3",
+      "etymology": "焼く (to toast/grill) + のり (seaweed sheets). のり typically written in hiragana on packaging though 海苔 exists.",
+      "korean_parallel": "김 (gim) is native Korean. Toasted/seasoned nori is 구운 김. The shared seaweed culture with different names is a good example of parallel-but-independent food traditions."
+    },
+    "yoru": {
+      "surface": "夜",
+      "reading": "よる",
+      "meaning_en": "night",
+      "pos": "noun",
+      "jlpt": "N5",
+      "etymology": "Native kun'yomi. On'yomi ヤ appears in compounds: 夜間 (yakan, nighttime), 深夜 (shin'ya, deep night).",
+      "korean_parallel": "밤 (bam) is native Korean. 야 (夜) appears in Sino-Korean compounds: 심야 (simya, deep night), 야간 (yagan, nighttime) — identical pattern."
+    },
+    "youki": {
+      "surface": "容器",
+      "reading": "ようき",
+      "meaning_en": "container",
+      "pos": "noun",
+      "jlpt": "N2",
+      "etymology": "容 (hold, contain) + 器 (vessel, tool). \"Holding vessel.\"",
+      "korean_parallel": "용기 (yonggi) — direct cognate."
+    }
+  },
+  "ui_strings": {
+    "shelves_label": {
+      "jp": "棚《たな》",
+      "en": "Shelves"
+    },
+    "saved_label": {
+      "jp": "保存《ほぞん》した言葉《ことば》",
+      "en": "Saved words"
+    },
+    "register_label": {
+      "jp": "レジ",
+      "en": "Register"
+    },
+    "board_label": {
+      "jp": "掲示板《けいじばん》",
+      "en": "Bulletin board"
+    },
+    "settings_label": {
+      "jp": "設定《せってい》",
+      "en": "Settings"
+    },
+    "back_label": {
+      "jp": "戻《もど》る",
+      "en": "Back"
+    },
+    "food_aisle_name": {
+      "jp": "食品《しょくひん》",
+      "en": "Food aisle"
+    },
+    "drinks_fridge_name": {
+      "jp": "飲《の》み物《もの》",
+      "en": "Drinks fridge"
+    },
+    "hot_case_name": {
+      "jp": "ホットスナック",
+      "en": "Hot case"
+    },
+    "take_to_register_default": {
+      "jp": "レジへ",
+      "en": "Take to register"
+    },
+    "take_to_register_added": {
+      "jp": "入《い》れました",
+      "en": "Added"
+    },
+    "take_to_register_again": {
+      "jp": "もう一《ひと》つ",
+      "en": "Take another"
+    },
+    "front_label": {
+      "jp": "表《おもて》",
+      "en": "Front"
+    },
+    "back_label_item": {
+      "jp": "裏《うら》",
+      "en": "Back"
+    },
+    "tap_to_continue": {
+      "jp": "タップで進《すす》む",
+      "en": "Tap to continue"
+    },
+    "save_button": {
+      "jp": "保存《ほぞん》",
+      "en": "Save"
+    },
+    "save_confirmed": {
+      "jp": "保存《ほぞん》しました",
+      "en": "Saved"
+    },
+    "close_button": {
+      "jp": "閉《と》じる",
+      "en": "Close"
+    },
+    "korean_prefix": {
+      "jp": "韓《かん》国《こく》語《ご》:",
+      "en": "KR:"
+    },
+    "checkout_button": {
+      "jp": "お会計《かいけい》",
+      "en": "Checkout"
+    },
+    "basket_empty_heading": {
+      "jp": "かごは空《から》です",
+      "en": "Basket is empty"
+    },
+    "total_label": {
+      "jp": "合計《ごうけい》",
+      "en": "Total"
+    },
+    "export_button": {
+      "jp": "書《か》き出《だ》す",
+      "en": "Export"
+    },
+    "clear_all_button": {
+      "jp": "全部《ぜんぶ》消《け》す",
+      "en": "Clear all"
+    },
+    "first_time_greeting": {
+      "jp": "あなたはコンビニの中《なか》にいます。",
+      "en": "You are inside the konbini."
+    },
+    "empty_basket": {
+      "jp_style": "deadpan",
+      "jp": "レジがさびしがっています。何《なに》か買《か》ってください。",
+      "en": "The register is lonely. Buy something."
+    },
+    "empty_saved_words": {
+      "jp_style": "deadpan",
+      "jp": "まだ何《なに》も保存《ほぞん》していません。それはそれでよろしい。",
+      "en": "You have saved nothing. This is defensible."
+    },
+    "empty_board": {
+      "jp": "掲示板《けいじばん》には何《なに》もありません。",
+      "en": "The bulletin board has nothing on it."
+    },
+    "exit_line": {
+      "jp": "自動《じどう》ドアが開《ひら》きます。あなたはコンビニの外《そと》にいます。しばらくの間《あいだ》だけ。",
+      "en": "The doors slide open. You are outside the konbini. Briefly."
+    },
+    "tap_item_hint": {
+      "jp": "商品《しょうひん》をタップ",
+      "en": "Tap an item"
+    },
+    "tap_word_hint": {
+      "jp": "言葉《ことば》をタップ",
+      "en": "Tap a word"
+    },
+    "export_saved_label": {
+      "jp": "保存《ほぞん》した言葉《ことば》を書《か》き出《だ》す",
+      "en": "Export saved words"
+    },
+    "about_label": {
+      "jp": "このコンビニについて",
+      "en": "About this konbini"
+    },
+    "clear_data_label": {
+      "jp": "データを消《け》す",
+      "en": "Clear data"
+    },
+    "clear_data_confirm": {
+      "jp": "本当《ほんとう》に消《け》しますか?",
+      "en": "Really clear?"
+    },
+    "clear_data_yes": {
+      "jp": "はい",
+      "en": "Yes"
+    },
+    "clear_data_no": {
+      "jp": "いいえ",
+      "en": "No"
+    },
+    "about_body": {
+      "jp": "このコンビニは営業《えいぎょう》中《ちゅう》です。いつも営業《えいぎょう》しています。米《こめ》は少《すこ》し寒《さむ》い土地《とち》から来《き》ています。\n\n棚《たな》の上《うえ》のものは、ここにあるという意味《いみ》で存在《そんざい》しています。ほかの場所《ばしょ》に存在《そんざい》するかどうかは、コンビニの関心事《かんしんじ》ではありません。\n\n保存《ほぞん》した言葉《ことば》があれば、書《か》き出《だ》せます。なければ、出《で》ていって構《かま》いません。自動《じどう》ドアは両方向《りょうほうこう》に開《ひら》きます。\n\n— 店長《てんちょう》",
+      "en": "This konbini is open. It has always been open. The rice is from somewhere colder.\n\nEverything on the shelves is real in the sense that it exists here. Whether it exists anywhere else is not the konbini's concern.\n\nIf you have saved words, you may export them. If you have not, you may leave. The doors slide both ways.\n\n— Management"
+    }
+  }
+}

--- a/is/learning/konbini/content/dialogue/checkout-standard.md
+++ b/is/learning/konbini/content/dialogue/checkout-standard.md
@@ -1,0 +1,61 @@
+---
+id: checkout-standard
+trigger: always
+type: linear
+---
+
+## script
+
+::clerk
+[irasshaimase]。
+::
+
+::clerk
+[otsugi]でお待《ま》ちのお客様《きゃくさま》、どうぞ。
+::
+
+::action
+player_places_items
+::
+
+::clerk
+[goukei] {{basket_total}}円《えん》になります。
+::
+
+::player-choice
+a: はい、[onegai]します | polite
+b: お願《ねが》いします | casual-polite
+::
+
+::action
+payment_exchange
+::
+
+::clerk
+{{payment_amount}}円《えん》[oazukari]します。
+::
+
+::clerk
+{{change_amount}}円《えん》の[okaeshi]です。[receipt]のご利用《りよう》は?
+::
+
+::player-choice
+a: [onegai]します | wants_receipt
+b: [daijoubu]です | declines_receipt
+::
+
+::clerk-branch[wants_receipt]
+はい、[receipt]です。
+::
+
+::clerk-branch[declines_receipt]
+かしこまりました。
+::
+
+::clerk
+[arigatou]ございました。
+::
+
+::exit
+The doors slide open. You are outside the konbini. Briefly.
+::

--- a/is/learning/konbini/content/items/karaage-kun-yoru.md
+++ b/is/learning/konbini/content/items/karaage-kun-yoru.md
@@ -1,0 +1,53 @@
+---
+id: karaage-kun-yoru
+category: fried_chicken
+zone: hot_case
+price: 238
+name_jp: からあげクン 夜の味
+name_en: Karaage-kun, night flavor
+weight: 5個
+description_jp: 地域《ちいき》限定《げんてい》。どの夜《よる》かは書《か》かれていない。五個《ごこ》。
+description_en: Regional limited edition. Which night, it does not say. Five pieces.
+---
+
+## front
+
+::banner[地域限定]
+[chiiki-gentei]
+::
+
+::hero
+[karaage-kun]
+[yoru]の[aji]
+::
+
+::section[入数]
+[gokoiri]
+::
+
+::footer
+[ondo]にご[chui]ください
+::
+
+## back
+
+::nutrition[1袋《ふくろ》あたり]
+[energy] | 230kcal
+[tanpakushitsu] | 14.8g
+[shishitsu] | 15.2g
+[tansuikabutsu] | 8.1g
+[shokuen-soto] | 1.4g
+::
+
+::section[[genzairyo]]
+[toriniku]([kokusan])、[koromo]([komugiko]、[denpun]、[shokuen]、[koushinryou])、[ageabura]、[choumiryo](アミノ酸《さん》[nado])
+::
+
+::section[[allergy][hyouji]]
+[komugi]・[toriniku]・[daizu]を[fukumu]
+::
+
+::fineprint
+[ohayameni][omeshiagari]ください
+[saikanetsu]は[osusume]しません
+::

--- a/is/learning/konbini/content/items/onigiri-benizake.md
+++ b/is/learning/konbini/content/items/onigiri-benizake.md
@@ -1,0 +1,50 @@
+---
+id: onigiri-benizake
+category: onigiri
+zone: food_aisle
+price: 168
+name_jp: 紅鮭おにぎり
+name_en: Sockeye salmon onigiri
+weight: 140g
+description_jp: 九月《くがつ》にとれた鮭《さけ》。少し寒《さむ》い土地《とち》の米《こめ》。どちらにも何《なに》も聞《き》かなかった。
+description_en: A salmon caught in September. Rice from a slightly colder place. Neither was asked anything.
+---
+
+## front
+
+::banner[直火焼]
+[jikabiyaki]
+::
+
+::hero
+[benizake]
+おにぎり
+::
+
+::footer
+[kokusanmai]使用 | 140g
+::
+
+## back
+
+::nutrition[1個《こ》あたり]
+[energy] | 180kcal
+[tanpakushitsu] | 4.2g
+[shishitsu] | 1.8g
+[tansuikabutsu] | 36.5g
+[shokuen-soto] | 1.1g
+::
+
+::section[[genzairyo]]
+[kome]([kokusan])、[sake]、[shokuen]、[yakinori]、[choumiryo](アミノ酸《さん》[nado])
+::
+
+::section[[allergy][hyouji]]
+[sake]を[fukumu]
+::
+
+::fineprint
+[chokusha]・[kouon-tashitsu]をさけて[hozon]してください
+[seizousho]: [miyagi]の[koujou]
+[shoumikigen]: [sokumen]に[kisai]
+::

--- a/is/learning/konbini/content/items/tea-koi-ryokucha.md
+++ b/is/learning/konbini/content/items/tea-koi-ryokucha.md
@@ -1,0 +1,55 @@
+---
+id: tea-koi-ryokucha
+category: tea
+zone: drinks_fridge
+price: 151
+name_jp: 濃い緑茶
+name_en: Strong green tea
+weight: 525ml
+description_jp: もっと濃《こ》くしてほしいと言《い》われた。お茶《ちゃ》は同意《どうい》した。瓶《びん》には525ミリリットルの同意《どうい》が入《はい》っている。
+description_en: Asked to be stronger. The tea agreed. The bottle holds 525ml of agreement.
+---
+
+## front
+
+::banner[特徴]
+[mukouryou]・[muchakushoku]
+::
+
+::hero
+[koi][ryokucha]
+::
+
+::section[成分強調]
+[katechin] [nibai]
+::
+
+::footer
+[kokusanchaba] 100% | 525ml
+::
+
+## back
+
+::nutrition[100mlあたり]
+[energy] | 0kcal
+[tanpakushitsu] | 0g
+[shishitsu] | 0g
+[tansuikabutsu] | 0g
+[shokuen-soto] | 0.02g
+[katechin] | 80mg
+::
+
+::section[[genzairyo]]
+[ryokucha]([kokusan])、[vitamin-c]
+::
+
+::section[味わい]
+すっきりとした[atoaji]。[shokuji]と[isshoni]。
+::
+
+::fineprint
+[kaifuugo]は[ohayameni][onomi]ください
+[chokusha]・[kouon]をさけて[hozon]してください
+[seizousha]: [shizuoka]の[koujou]
+[youki]は[recycle]できます
+::

--- a/is/learning/konbini/content/notices/fax-service.md
+++ b/is/learning/konbini/content/notices/fax-service.md
@@ -1,0 +1,26 @@
+---
+id: fax-service
+posted_date: 2026-02-01
+posted_by: 店長《てんちょう》
+notice_type: service
+style: typed
+---
+
+## body
+
+::heading
+[fax]サービスのご案内《あんない》
+::
+
+当店《とうてん》では[fax]の[soushin]・[jushin]を承《うけたまわ》っております。
+
+[kokunai][soushin]: 1枚《まい》 [gojuuen]
+[kaigai][soushin]: 1枚《まい》 [nihyakuen]
+[jushin]: 1枚《まい》 [sanjuuen]
+
+[kaigai]の[soushin]は[kuni]により[toriatsukai]できない場合《ばあい》があります。
+詳《くわ》しくは[tenin]までお尋《たず》ねください。
+
+::footer
+受付《うけつけ》時間《じかん》: [eigyouchuu]
+::

--- a/is/learning/konbini/content/notices/lost-parakeet.md
+++ b/is/learning/konbini/content/notices/lost-parakeet.md
@@ -1,0 +1,26 @@
+---
+id: lost-parakeet
+posted_date: 2026-03-14
+posted_by: 近所《きんじょ》の方《かた》
+notice_type: lost_pet
+style: handwritten
+---
+
+## body
+
+::heading
+お知《し》らせ
+::
+
+[maigo]になりました。
+
+名前《なまえ》: ケイスケ
+種類《しゅるい》: [inko]
+色《いろ》: [kiiro]と[midori]
+特徴《とくちょう》: [shitsumon]でしか話《はな》しません
+
+[mikaketa]方《かた》は[renraku]ください。
+
+::footer
+[sharei]あり
+::

--- a/is/learning/konbini/content/ui/strings.md
+++ b/is/learning/konbini/content/ui/strings.md
@@ -1,0 +1,195 @@
+---
+schema_version: 1
+---
+
+# UI chrome strings
+
+All visible UI text in the konbini. Japanese primary. English gloss provided for screen readers, alt-text, and (optional) toggle for beginners. Furigana rendered via `《...》` notation where needed.
+
+## navigation
+
+### shelves_label
+jp: 棚《たな》
+en: Shelves
+
+### saved_label
+jp: 保存《ほぞん》した言葉《ことば》
+en: Saved words
+
+### register_label
+jp: レジ
+en: Register
+
+### board_label
+jp: 掲示板《けいじばん》
+en: Bulletin board
+
+### settings_label
+jp: 設定《せってい》
+en: Settings
+
+### back_label
+jp: 戻《もど》る
+en: Back
+
+## zones
+
+### food_aisle_name
+jp: 食品《しょくひん》
+en: Food aisle
+
+### drinks_fridge_name
+jp: 飲《の》み物《もの》
+en: Drinks fridge
+
+### hot_case_name
+jp: ホットスナック
+en: Hot case
+
+## item view
+
+### take_to_register_default
+jp: レジへ
+en: Take to register
+
+### take_to_register_added
+jp: 入《い》れました
+en: Added
+
+### take_to_register_again
+jp: もう一《ひと》つ
+en: Take another
+
+### front_label
+jp: 表《おもて》
+en: Front
+
+### back_label_item
+jp: 裏《うら》
+en: Back
+
+### tap_to_continue
+jp: タップで進《すす》む
+en: Tap to continue
+
+## popup
+
+### save_button
+jp: 保存《ほぞん》
+en: Save
+
+### save_confirmed
+jp: 保存《ほぞん》しました
+en: Saved
+
+### close_button
+jp: 閉《と》じる
+en: Close
+
+### korean_prefix
+jp: 韓《かん》国《こく》語《ご》:
+en: "KR:"
+
+## register
+
+### checkout_button
+jp: お会計《かいけい》
+en: Checkout
+
+### basket_empty_heading
+jp: かごは空《から》です
+en: Basket is empty
+
+### total_label
+jp: 合計《ごうけい》
+en: Total
+
+## saved words
+
+### export_button
+jp: 書《か》き出《だ》す
+en: Export
+
+### clear_all_button
+jp: 全部《ぜんぶ》消《け》す
+en: Clear all
+
+## empty states
+
+### first_time_greeting
+jp: あなたはコンビニの中《なか》にいます。
+en: You are inside the konbini.
+
+### empty_basket
+jp_style: deadpan
+jp: レジがさびしがっています。何《なに》か買《か》ってください。
+en: The register is lonely. Buy something.
+
+### empty_saved_words
+jp_style: deadpan
+jp: まだ何《なに》も保存《ほぞん》していません。それはそれでよろしい。
+en: You have saved nothing. This is defensible.
+
+### empty_board
+jp: 掲示板《けいじばん》には何《なに》もありません。
+en: The bulletin board has nothing on it.
+
+### exit_line
+jp: 自動《じどう》ドアが開《ひら》きます。あなたはコンビニの外《そと》にいます。しばらくの間《あいだ》だけ。
+en: The doors slide open. You are outside the konbini. Briefly.
+
+## hints
+
+### tap_item_hint
+jp: 商品《しょうひん》をタップ
+en: Tap an item
+
+### tap_word_hint
+jp: 言葉《ことば》をタップ
+en: Tap a word
+
+## settings
+
+### export_saved_label
+jp: 保存《ほぞん》した言葉《ことば》を書《か》き出《だ》す
+en: Export saved words
+
+### about_label
+jp: このコンビニについて
+en: About this konbini
+
+### clear_data_label
+jp: データを消《け》す
+en: Clear data
+
+### clear_data_confirm
+jp: 本当《ほんとう》に消《け》しますか?
+en: Really clear?
+
+### clear_data_yes
+jp: はい
+en: Yes
+
+### clear_data_no
+jp: いいえ
+en: No
+
+## about page
+
+### about_body
+jp: |
+  このコンビニは営業《えいぎょう》中《ちゅう》です。いつも営業《えいぎょう》しています。米《こめ》は少《すこ》し寒《さむ》い土地《とち》から来《き》ています。
+
+  棚《たな》の上《うえ》のものは、ここにあるという意味《いみ》で存在《そんざい》しています。ほかの場所《ばしょ》に存在《そんざい》するかどうかは、コンビニの関心事《かんしんじ》ではありません。
+
+  保存《ほぞん》した言葉《ことば》があれば、書《か》き出《だ》せます。なければ、出《で》ていって構《かま》いません。自動《じどう》ドアは両方向《りょうほうこう》に開《ひら》きます。
+
+  — 店長《てんちょう》
+en: |
+  This konbini is open. It has always been open. The rice is from somewhere colder.
+
+  Everything on the shelves is real in the sense that it exists here. Whether it exists anywhere else is not the konbini's concern.
+
+  If you have saved words, you may export them. If you have not, you may leave. The doors slide both ways.
+
+  — Management

--- a/is/learning/konbini/content/vocab.md
+++ b/is/learning/konbini/content/vocab.md
@@ -1,0 +1,849 @@
+---
+schema_version: 1
+---
+
+## ageabura
+surface: 揚げ油
+reading: あげあぶら
+meaning_en: frying oil
+pos: noun
+jlpt: N2
+etymology: 揚げる (to deep-fry) + 油 (oil). Native compound.
+korean_parallel: null
+
+## aji
+surface: 味
+reading: あじ
+meaning_en: flavor, taste
+pos: noun
+jlpt: N4
+etymology: Native Japanese word. Also reads ミ in compounds like 意味 (imi, meaning) and 興味 (kyoumi, interest).
+korean_parallel: 맛 (mat) is the native Korean word. 미 (味) appears in Sino-Korean compounds: 의미 (uimi, meaning), 흥미 (heungmi, interest). Parallel layered structure — native word for everyday, Sino reading for compounds.
+
+## allergy
+surface: アレルギー
+reading: あれるぎー
+meaning_en: allergy, allergen
+pos: noun
+jlpt: N3
+etymology: From German Allergie. Arrived in Japanese via medical vocabulary in the early 20th century.
+korean_parallel: 알레르기 (allereugi) — also from German, via similar medical borrowing route.
+
+## arigatou
+surface: ありがとう
+reading: ありがとう
+meaning_en: thank you
+pos: expression
+jlpt: N5
+etymology: From 有り難い (arigatai, "difficult to exist" → rare and precious). Originally Buddhist: a thing so rare it deserves gratitude. The modern thank-you preserves the structure but not the awareness of it.
+korean_parallel: null
+
+## atoaji
+surface: 後味
+reading: あとあじ
+meaning_en: aftertaste
+pos: noun
+jlpt: N2
+etymology: 後 (after) + 味 (taste). Transparent compound.
+korean_parallel: 뒷맛 (dwitmat) — native compound, 뒤 (after) + 맛 (taste). Same structure in both languages using native morphemes.
+
+## benizake
+surface: 紅鮭
+reading: べにざけ
+meaning_en: sockeye salmon (lit. "crimson salmon")
+pos: noun
+jlpt: N2
+etymology: 紅 (crimson) + 鮭 (salmon). The 紅 reading here is べに (native kun'yomi), not the Sino-Japanese コウ seen in 紅茶 (kōcha, black tea).
+korean_parallel: 연어 (yeoneo) is a native Korean word with no hanja parallel to 鮭. 紅 as hong appears in 홍차 (hongcha, black tea) — same 紅茶 compound.
+
+## chiiki-gentei
+surface: 地域限定
+reading: ちいきげんてい
+meaning_en: region-limited (only available in certain areas)
+pos: noun
+jlpt: N2
+etymology: 地域 (region) + 限定 (limitation). Marketing term ubiquitous on konbini packaging to signal regional exclusivity.
+korean_parallel: 지역한정 (jiyeok-hanjeong) — exact cognate, same compound, same marketing usage.
+
+## chokusha
+surface: 直射日光
+reading: ちょくしゃにっこう
+meaning_en: direct sunlight
+pos: noun
+jlpt: N2
+etymology: 直射 (direct emission) + 日光 (sunlight). Standard phrase in storage warnings.
+korean_parallel: 직사광선 (jiksagwangseon) — same construction with 광선 (light rays) instead of 일광. Similar regulatory register.
+
+## choumiryo
+surface: 調味料
+reading: ちょうみりょう
+meaning_en: seasoning, flavor enhancer
+pos: noun
+jlpt: N2
+etymology: 調 (adjust) + 味 (flavor) + 料 (material). On ingredient lists, often followed by parenthetical specifying the type (e.g. アミノ酸等).
+korean_parallel: 조미료 (jomiryo) — direct cognate, identical usage.
+
+## chui
+surface: 注意
+reading: ちゅうい
+meaning_en: caution, attention
+pos: noun
+jlpt: N4
+etymology: 注 (pour, focus) + 意 (intention, mind). "Pour one's attention."
+korean_parallel: 주의 (juui) — direct cognate.
+
+## daijoubu
+surface: 大丈夫
+reading: だいじょうぶ
+meaning_en: okay, no thank you (in konbini context, often means "no need")
+pos: na-adjective
+jlpt: N5
+etymology: 大 (great) + 丈夫 (sturdy/healthy). Originally meant "fine, in good order." In modern Japanese it has also become a polite way to decline ("I'm fine without it") — a source of endless confusion for learners.
+korean_parallel: 대장부 (daejangbu) exists in Korean with the original meaning (a strong man). The Japanese semantic drift to "okay/no thanks" did not occur in Korean.
+
+## daizu
+surface: 大豆
+reading: だいず
+meaning_en: soybean
+pos: noun
+jlpt: N3
+etymology: 大 (large) + 豆 (bean). Listed as an allergen on Japanese packaging.
+korean_parallel: 대두 (daedu) — direct cognate, used in formal/agricultural contexts. Everyday Korean uses native 콩 (kong).
+
+## denpun
+surface: でん粉
+reading: でんぷん
+meaning_en: starch
+pos: noun
+jlpt: N2
+etymology: 澱 (sediment) + 粉 (powder). 澱 is non-jōyō so typically written でん on modern packaging.
+korean_parallel: 전분 (jeonbun) — direct cognate using the same compound.
+
+## eigyouchuu
+surface: 営業中
+reading: えいぎょうちゅう
+meaning_en: currently open, business in progress
+pos: noun
+jlpt: N3
+etymology: 営業 (business operation) + 中 (middle, during). Standard sign on open shops.
+korean_parallel: 영업중 (yeongeopjung) — direct cognate, identical signage usage.
+
+## energy
+surface: エネルギー
+reading: えねるぎー
+meaning_en: energy, calories
+pos: noun
+jlpt: N5
+etymology: From German Energie. Japanese scientific vocabulary often took German over English in the Meiji-Shōwa period. Always first line on nutrition panels.
+korean_parallel: 에너지 (eneoji) — from English. A rare case where Japanese took German and Korean took English for the same scientific term.
+
+## fax
+surface: ファックス
+reading: ふぁっくす
+meaning_en: fax machine, fax (noun and verb)
+pos: noun
+jlpt: N3
+etymology: English loanword. Konbini fax services persisted in Japan long after they disappeared elsewhere.
+korean_parallel: 팩스 (paekseu) — also from English, shorter form.
+
+## fukumu
+surface: 含む
+reading: ふくむ
+meaning_en: to contain, include
+pos: verb (u-verb)
+jlpt: N3
+etymology: Native Japanese verb. On allergen labels always appears in the form 〜を含む (contains X).
+korean_parallel: 포함하다 (pohamhada) from 包含 — different verb, similar function. 含 appears in 함유 (hamyu, containing) on Korean ingredient labels.
+
+## genzairyo
+surface: 原材料名
+reading: げんざいりょうめい
+meaning_en: ingredients (regulatory label term)
+pos: noun
+jlpt: N2
+etymology: 原 (origin) + 材料 (material) + 名 (name). Mandated by Japanese food labeling law.
+korean_parallel: 원재료명 (wonjaeryomyeong) — direct cognate. Korean food labels use the same exact compound.
+
+## gojuuen
+surface: 50円
+reading: ごじゅうえん
+meaning_en: 50 yen
+pos: noun
+jlpt: N5
+etymology: 五十 (fifty) + 円 (yen). 円 was originally the general term for a round object, borrowed as the currency unit in 1871.
+korean_parallel: null
+
+## gokoiri
+surface: 5個入り
+reading: ごこいり
+meaning_en: pack of 5, 5 pieces included
+pos: noun
+jlpt: N4
+etymology: 五 (five) + 個 (piece-counter) + 入り (contained). 入り attaches to numbers to mean "containing N."
+korean_parallel: null
+
+## goukei
+surface: 合計
+reading: ごうけい
+meaning_en: total (amount)
+pos: noun
+jlpt: N3
+etymology: 合 (combine) + 計 (count). Standard cashier/register vocabulary.
+korean_parallel: 합계 (hapgye) — direct cognate.
+
+## hozon
+surface: 保存
+reading: ほぞん
+meaning_en: storage, preservation
+pos: noun, verb (する)
+jlpt: N3
+etymology: 保 (keep, protect) + 存 (exist). "Keep existing." Standard in both packaging warnings and digital context (file save).
+korean_parallel: 보존 (bojon) — direct cognate. Korean uses 저장 (jeojang) for digital file save, 보존 for physical preservation — same split.
+
+## hyouji
+surface: 表示
+reading: ひょうじ
+meaning_en: display, indication
+pos: noun, verb (する)
+jlpt: N3
+etymology: 表 (surface, show) + 示 (indicate). Regulatory term; 表示 paired with other nouns forms standardized phrases (栄養成分表示, アレルギー表示).
+korean_parallel: 표시 (pyosi) — direct cognate with identical compound usage.
+
+## inko
+surface: インコ
+reading: いんこ
+meaning_en: parakeet
+pos: noun
+jlpt: N2
+etymology: Written in katakana despite being an older loanword (possibly from Dutch or early Portuguese via earlier trade). Small parrots.
+korean_parallel: 잉꼬 (inkko) — borrowed from Japanese, not directly from a European source.
+
+## irasshaimase
+surface: いらっしゃいませ
+reading: いらっしゃいませ
+meaning_en: welcome (formal customer greeting)
+pos: expression
+jlpt: N4
+etymology: Honorific imperative of いらっしゃる (to come/go, honorific). The polite imperative -ませ ending is rare outside customer service contexts.
+korean_parallel: 어서오세요 (eoseo oseyo) — functionally equivalent. Korean uses an honorific imperative of 오다 (to come).
+
+## isshoni
+surface: 一緒に
+reading: いっしょに
+meaning_en: together with
+pos: adverb
+jlpt: N5
+etymology: 一 (one) + 緒 (thread/beginning) + に (particle). "In one thread." Often collocates with 食事 for "together with a meal."
+korean_parallel: 같이 (gachi) — native word, different structure.
+
+## jikabiyaki
+surface: 直火焼
+reading: じかびやき
+meaning_en: grilled over direct flame
+pos: noun
+jlpt: N3
+etymology: 直 (direct) + 火 (fire) + 焼 (grill). 焼 takes the native kun'yomi やき. A packaging/restaurant term signaling flame contact rather than oven or pan cooking.
+korean_parallel: 직화구이 (jikhwa-gui) — exact cognate. 직 (直) + 화 (火) + native 구이 (grilling). Same compound structure up to the native-word tail.
+
+## jushin
+surface: 受信
+reading: じゅしん
+meaning_en: receiving (a transmission)
+pos: noun, verb (する)
+jlpt: N2
+etymology: 受 (receive) + 信 (signal, message). Paired with 送信 (soushin, sending).
+korean_parallel: 수신 (susin) — direct cognate, same usage in postal and telecom contexts.
+
+## kaifuugo
+surface: 開封後
+reading: かいふうご
+meaning_en: after opening (a sealed container)
+pos: noun
+jlpt: N2
+etymology: 開封 (opening a seal) + 後 (after). 封 originally meant "seal a letter." Standard storage warning phrase.
+korean_parallel: 개봉후 (gaebonghu) — direct cognate.
+
+## kaigai
+surface: 海外
+reading: かいがい
+meaning_en: overseas, international
+pos: noun
+jlpt: N3
+etymology: 海 (sea) + 外 (outside). "Beyond the sea." Japan's historical island perspective preserved in the everyday word for "international."
+korean_parallel: 해외 (haeoe) — direct cognate with identical logic and usage.
+
+## karaage-kun
+surface: からあげクン
+reading: からあげくん
+meaning_en: Karaage-kun (store-brand fried chicken nuggets)
+pos: proper noun
+jlpt: —
+etymology: 唐揚げ (karaage, Chinese-style deep-fried) + クン (kun, a familiar suffix for boys/younger males). A 1986 Lawson product whose name stuck. The クン is why the product feels like a small friend rather than food.
+korean_parallel: null
+
+## katechin
+surface: カテキン
+reading: かてきん
+meaning_en: catechins (antioxidant compounds in green tea)
+pos: noun
+jlpt: N2
+etymology: From English/Latin "catechin," itself from Malay kachu (the plant Acacia catechu). Appears frequently on Japanese tea marketing.
+korean_parallel: 카테킨 (katekin) — also from the same international scientific term.
+
+## kiiro
+surface: 黄色
+reading: きいろ
+meaning_en: yellow
+pos: noun, na-adjective
+jlpt: N4
+etymology: 黄 (yellow) + 色 (color). Color names in Japanese often take 色 as a suffix for the noun form.
+korean_parallel: 노랑/노란색 (norang/noransaek) uses a native Korean root. 황 (黃) appears in Sino-Korean compounds like 황금 (hwanggeum, gold) but not in everyday color names.
+
+## kisai
+surface: 記載
+reading: きさい
+meaning_en: recorded, noted (on)
+pos: noun, verb (する)
+jlpt: N2
+etymology: 記 (record) + 載 (place upon, include). "Placed on record." Formal/regulatory register.
+korean_parallel: 기재 (gijae) — direct cognate.
+
+## koi
+surface: 濃い
+reading: こい
+meaning_en: strong, concentrated, rich (of flavor or color)
+pos: i-adjective
+jlpt: N3
+etymology: Native Japanese adjective. Antonym: 薄い (usui, weak/thin).
+korean_parallel: 진하다 (jinhada) — native Korean, functionally equivalent. 농 (濃) appears in Sino-Korean compounds like 농도 (nongdo, concentration) but not as a standalone adjective.
+
+## kokunai
+surface: 国内
+reading: こくない
+meaning_en: domestic, within the country
+pos: noun
+jlpt: N3
+etymology: 国 (country) + 内 (inside). Antonym of 海外.
+korean_parallel: 국내 (guknae) — direct cognate, used identically.
+
+## kokusan
+surface: 国産
+reading: こくさん
+meaning_en: domestic, made in Japan
+pos: noun
+jlpt: N3
+etymology: 国 (country) + 産 (produced). Extremely productive marketing prefix — 国産牛, 国産野菜, 国産大豆.
+korean_parallel: 국산 (guksan) — direct cognate, used the same way in Korean marketing.
+
+## kokusanchaba
+surface: 国産茶葉
+reading: こくさんちゃば
+meaning_en: domestic tea leaves
+pos: noun
+jlpt: N2
+etymology: 国産 (domestic) + 茶葉 (tea leaves). 茶葉 combines 茶 (tea) + 葉 (leaf).
+korean_parallel: null
+
+## kokusanmai
+surface: 国産米
+reading: こくさんまい
+meaning_en: domestically-produced rice
+pos: noun
+jlpt: N3
+etymology: 国産 (domestic) + 米 (rice, on'yomi マイ). Sino-Japanese compound; the everyday word for rice-as-grain is こめ.
+korean_parallel: 국산미 (guksan-mi) exists but less common than 국산쌀 (guksan-ssal) using native 쌀 for rice. Same pattern, different habitual usage.
+
+## kome
+surface: 米
+reading: こめ
+meaning_en: rice (uncooked, as grain or ingredient)
+pos: noun
+jlpt: N4
+etymology: Native kun'yomi こめ for rice-as-grain. The on'yomi マイ/ベイ appears in compounds: 米国 (America), 新米 (new rice), 精米 (polished rice). Cooked rice is a different word: ご飯 (gohan).
+korean_parallel: 쌀 (ssal) is the native Korean word for uncooked rice — no hanja. 미 (米) as a hanja reading appears in compounds: 미국 (America). Both languages preserve a native word for the staple.
+
+## komugi
+surface: 小麦
+reading: こむぎ
+meaning_en: wheat
+pos: noun
+jlpt: N3
+etymology: 小 (small) + 麦 (barley/grain). "Small barley" — older botanical taxonomy.
+korean_parallel: 밀 (mil) is native Korean. 소맥 (somaek) from 小麦 exists but is technical/formal.
+
+## komugiko
+surface: 小麦粉
+reading: こむぎこ
+meaning_en: wheat flour
+pos: noun
+jlpt: N3
+etymology: 小麦 (wheat) + 粉 (powder).
+korean_parallel: 밀가루 (milgaru) — native compound, 밀 (wheat) + 가루 (powder). Same structure with native morphemes.
+
+## koromo
+surface: 衣
+reading: ころも
+meaning_en: batter, coating (on fried food); also "clothing" in classical usage
+pos: noun
+jlpt: N2
+etymology: Originally "clothing," now used for the outer coating of food. The image: the food is wearing a garment of batter.
+korean_parallel: null
+
+## koujou
+surface: 工場
+reading: こうじょう
+meaning_en: factory
+pos: noun
+jlpt: N3
+etymology: 工 (work, craft) + 場 (place). "Place of work/production."
+korean_parallel: 공장 (gongjang) — direct cognate.
+
+## kouon
+surface: 高温
+reading: こうおん
+meaning_en: high temperature
+pos: noun
+jlpt: N3
+etymology: 高 (high) + 温 (warm/temperature). Standard in storage warnings.
+korean_parallel: 고온 (goon) — direct cognate.
+
+## kouon-tashitsu
+surface: 高温多湿
+reading: こうおんたしつ
+meaning_en: high temperature and humidity (avoid)
+pos: noun
+jlpt: N2
+etymology: 高温 (high temperature) + 多湿 (much humidity). Four-kanji compound (四字熟語 structure) used specifically for storage warnings.
+korean_parallel: 고온다습 (goondaseup) — direct cognate, identical usage.
+
+## koushinryou
+surface: 香辛料
+reading: こうしんりょう
+meaning_en: spice
+pos: noun
+jlpt: N2
+etymology: 香 (fragrance) + 辛 (spicy) + 料 (material). "Fragrant spicy material."
+korean_parallel: 향신료 (hyangsinryo) — direct cognate.
+
+## kuni
+surface: 国
+reading: くに
+meaning_en: country
+pos: noun
+jlpt: N5
+etymology: Native kun'yomi for 国. On'yomi コク appears in compounds (国産, 国内, 国民).
+korean_parallel: 나라 (nara) is native Korean. 국 (國/国) appears in Sino-Korean compounds — the same layered pattern as Japanese.
+
+## maigo
+surface: 迷子
+reading: まいご
+meaning_en: lost child, lost (of a person or pet)
+pos: noun
+jlpt: N3
+etymology: 迷 (lost, confused) + 子 (child). Originally for children, extended to pets in modern usage.
+korean_parallel: 미아 (mia) from 迷兒 uses the same structure. Both languages use the "lost child" compound for the concept.
+
+## midori
+surface: 緑
+reading: みどり
+meaning_en: green
+pos: noun, na-adjective
+jlpt: N4
+etymology: Native kun'yomi. Japanese historically classified blue and green together as 青 (ao); 緑 emerged as a distinct color term relatively recently.
+korean_parallel: 녹색 (noksaek) from 緑色 is Sino-Korean. Native 초록 (chorok) and 푸른 (pureun, blue/green) show the same historical color-category mixing.
+
+## mikaketa
+surface: 見かけた
+reading: みかけた
+meaning_en: saw, spotted (past tense of 見かける)
+pos: verb (past form)
+jlpt: N3
+etymology: 見る (see) + かける (auxiliary meaning "happen to" or "do briefly"). "Happen to see." Used in lost-pet notices and witness-seeking contexts.
+korean_parallel: null
+
+## miyagi
+surface: 宮城県
+reading: みやぎけん
+meaning_en: Miyagi Prefecture
+pos: proper noun
+jlpt: N3
+etymology: 宮 (shrine/palace) + 城 (castle) + 県 (prefecture). Northeast Honshu. Sendai is its capital.
+korean_parallel: null
+
+## muchakushoku
+surface: 無着色
+reading: むちゃくしょく
+meaning_en: no coloring added
+pos: noun
+jlpt: N2
+etymology: 無 (without) + 着色 (coloring). The 無 prefix is extremely productive in food marketing: 無糖 (sugar-free), 無添加 (no additives), 無香料 (no fragrance).
+korean_parallel: 무착색 (muchaksaek) — direct cognate. The 무- prefix is equally productive in Korean food marketing.
+
+## mukouryou
+surface: 無香料
+reading: むこうりょう
+meaning_en: no fragrance added
+pos: noun
+jlpt: N2
+etymology: 無 (without) + 香料 (fragrance/flavoring). Paired frequently with 無着色 in marketing.
+korean_parallel: 무향료 (muhyangryo) — direct cognate.
+
+## nado
+surface: 等
+reading: など
+meaning_en: etc., and others
+pos: suffix, particle
+jlpt: N4
+etymology: On ingredient lists, appears after a category to indicate unspecified members. Written with hiragana なんど in older texts; now typically 等 or など.
+korean_parallel: 등 (deung) from 等 — same kanji, same function, same ingredient-list usage.
+
+## nibai
+surface: 2倍
+reading: にばい
+meaning_en: double, 2x
+pos: noun
+jlpt: N4
+etymology: 二 (two) + 倍 (times, multiplier). 倍 as a suffix attaches to numbers to form multipliers.
+korean_parallel: 배 (bae) from 倍 — same kanji, same structure (2배, dubbae).
+
+## nihyakuen
+surface: 200円
+reading: にひゃくえん
+meaning_en: 200 yen
+pos: noun
+jlpt: N5
+etymology: 二百 (two hundred) + 円 (yen).
+korean_parallel: null
+
+## oazukari
+surface: お預かり
+reading: おあずかり
+meaning_en: receiving (money, in formal register)
+pos: noun (honorific)
+jlpt: N3
+etymology: Honorific お- + 預かる (to hold on behalf of). Used specifically in customer-service payment contexts: "I am receiving your X yen" rather than "you gave me X yen."
+korean_parallel: null
+
+## ohayameni
+surface: お早めに
+reading: おはやめに
+meaning_en: promptly, soon (polite)
+pos: adverb
+jlpt: N3
+etymology: Honorific お- + 早め (earlier) + に (adverb particle). Softer than 早く, suitable for packaging instructions.
+korean_parallel: null
+
+## okaeshi
+surface: お返し
+reading: おかえし
+meaning_en: change, return (polite)
+pos: noun (honorific)
+jlpt: N3
+etymology: Honorific お- + 返し (returning). In transactions means change given back; in social contexts means a return gift.
+korean_parallel: null
+
+## omeshiagari
+surface: お召し上がり
+reading: おめしあがり
+meaning_en: eating (respectful, honorific)
+pos: noun/verb (honorific)
+jlpt: N3
+etymology: Honorific form of 食べる/飲む. 召す is a classical honorific verb meaning "to do (various things)" — eat, wear, call for, ride. On packaging always お召し上がりください.
+korean_parallel: 드시다 (deusida) is the equivalent Korean honorific for eating/drinking.
+
+## ondo
+surface: 温度
+reading: おんど
+meaning_en: temperature
+pos: noun
+jlpt: N3
+etymology: 温 (warm) + 度 (degree).
+korean_parallel: 온도 (ondo) — direct cognate, identical pronunciation.
+
+## onegai
+surface: お願い
+reading: おねがい
+meaning_en: request, please
+pos: noun (honorific)
+jlpt: N5
+etymology: Honorific お- + 願い (wish, request). Used as a polite way to agree ("yes please") in service exchanges.
+korean_parallel: 부탁 (butak) is the native/Sino-Korean equivalent; different morphology but parallel social function.
+
+## onomi
+surface: お飲み
+reading: おのみ
+meaning_en: drink (polite stem form)
+pos: verb (polite stem)
+jlpt: N3
+etymology: Honorific お- + 飲み (drink, stem form). Used in instructions (お飲みください, please drink).
+korean_parallel: null
+
+## osusume
+surface: おすすめ
+reading: おすすめ
+meaning_en: recommendation (also written 御勧め, 御薦め)
+pos: noun
+jlpt: N4
+etymology: Honorific お- + 勧め (recommendation, from 勧める to recommend). Common in restaurant and retail contexts; on packaging often in the negative: "we do not recommend X."
+korean_parallel: 추천 (chucheon) from 推薦 is the Sino-Korean equivalent.
+
+## otsugi
+surface: お次
+reading: おつぎ
+meaning_en: next (customer), the next one (polite)
+pos: noun (honorific)
+jlpt: N4
+etymology: Honorific お- + 次 (next). Specific to service register when addressing the next person in line.
+korean_parallel: 다음 (daeum) is the native equivalent.
+
+## receipt
+surface: レシート
+reading: れしーと
+meaning_en: receipt
+pos: noun
+jlpt: N5
+etymology: From English "receipt." Distinct from 領収書 (ryoushuusho), which is a formal receipt with buyer's name for reimbursement or tax purposes. The konbini clerk asks about the former.
+korean_parallel: 영수증 (yeongsujeung) from 領收證 — Korean uses the formal term for both contexts, no common loanword equivalent to レシート.
+
+## recycle
+surface: リサイクル
+reading: りさいくる
+meaning_en: recycle, recycling
+pos: noun, verb (する)
+jlpt: N4
+etymology: From English "recycle." Always in katakana; 再生 (saisei, rebirth/regeneration) is the native alternative but specialized.
+korean_parallel: 재활용 (jaehwaryong) from 再活用 — Korean uses a Sino-Korean compound ("reuse") rather than an English loanword.
+
+## renraku
+surface: 連絡
+reading: れんらく
+meaning_en: contact, get in touch
+pos: noun, verb (する)
+jlpt: N4
+etymology: 連 (connect) + 絡 (entwine, link). "Link up."
+korean_parallel: 연락 (yeollak) — direct cognate.
+
+## ryokucha
+surface: 緑茶
+reading: りょくちゃ
+meaning_en: green tea
+pos: noun
+jlpt: N4
+etymology: 緑 (green) + 茶 (tea). The Japanese convention separates 緑茶 (green), 紅茶 (black), and 麦茶 (barley tea) by color/material.
+korean_parallel: 녹차 (nokcha) — direct cognate. Same three-way distinction in Korean: 녹차, 홍차, 보리차.
+
+## saikanetsu
+surface: 再加熱
+reading: さいかねつ
+meaning_en: reheating
+pos: noun, verb (する)
+jlpt: N2
+etymology: 再 (again) + 加熱 (heating, applying heat). 加熱 combines 加 (add) + 熱 (heat).
+korean_parallel: 재가열 (jaegayeol) — direct cognate.
+
+## sake
+surface: 鮭
+reading: さけ
+meaning_en: salmon
+pos: noun
+jlpt: N3
+etymology: Native Japanese word. The kanji 鮭 has 魚 (fish) radical with 圭 (jade tablet) as phonetic component. Colloquial variant しゃけ is common in informal speech and older generations.
+korean_parallel: 연어 (yeoneo) — native Korean word, no hanja bridge. A case where CJKV parallel doesn't apply.
+
+## sanjuuen
+surface: 30円
+reading: さんじゅうえん
+meaning_en: 30 yen
+pos: noun
+jlpt: N5
+etymology: 三十 (thirty) + 円 (yen).
+korean_parallel: null
+
+## seizousha
+surface: 製造者
+reading: せいぞうしゃ
+meaning_en: manufacturer
+pos: noun
+jlpt: N2
+etymology: 製造 (manufacture) + 者 (person/entity). For corporate entities; for facilities the term is 製造所.
+korean_parallel: 제조자 (jejoja) — direct cognate.
+
+## seizousho
+surface: 製造所
+reading: せいぞうしょ
+meaning_en: manufacturing facility
+pos: noun
+jlpt: N2
+etymology: 製造 (manufacture) + 所 (place). Required on food labels when manufactured by a contracted facility.
+korean_parallel: 제조소 (jejoso) — direct cognate.
+
+## sharei
+surface: 謝礼
+reading: しゃれい
+meaning_en: reward, token of thanks
+pos: noun
+jlpt: N2
+etymology: 謝 (apologize, thank) + 礼 (ceremony, courtesy). A formal thank-you often taking monetary form.
+korean_parallel: 사례 (sarye) — direct cognate, same usage in lost-and-found contexts.
+
+## shishitsu
+surface: 脂質
+reading: ししつ
+meaning_en: fat, lipids
+pos: noun
+jlpt: N2
+etymology: 脂 (fat, grease) + 質 (substance). Paired with the other three macronutrient terms on every nutrition panel.
+korean_parallel: 지질 (jijil) — direct cognate, same compound.
+
+## shitsumon
+surface: 質問
+reading: しつもん
+meaning_en: question
+pos: noun, verb (する)
+jlpt: N4
+etymology: 質 (substance, essence) + 問 (ask). "Ask about the substance of."
+korean_parallel: 질문 (jilmun) — direct cognate.
+
+## shizuoka
+surface: 静岡県
+reading: しずおかけん
+meaning_en: Shizuoka Prefecture
+pos: proper noun
+jlpt: N3
+etymology: 静 (quiet) + 岡 (hill) + 県 (prefecture). Central Honshu, south of Mount Fuji. Major tea-producing region.
+korean_parallel: null
+
+## shokuen
+surface: 食塩
+reading: しょくえん
+meaning_en: table salt
+pos: noun
+jlpt: N3
+etymology: 食 (food, eating) + 塩 (salt). Distinguished from 塩 alone (salt in general) to specify salt intended for consumption.
+korean_parallel: 식염 (sikyeom) — direct cognate, used in regulatory/medical contexts.
+
+## shokuen-soto
+surface: 食塩相当量
+reading: しょくえんそうとうりょう
+meaning_en: salt equivalent
+pos: noun
+jlpt: N2
+etymology: 食塩 (table salt) + 相当 (equivalent) + 量 (amount). Japan reports sodium as its salt equivalent rather than raw sodium. Multiply sodium by 2.54 to get this figure.
+korean_parallel: 식염상당량 (sikyeom-sangdangnyang) — exact compound cognate. Korean food labels use the same regulatory format.
+
+## shokuji
+surface: 食事
+reading: しょくじ
+meaning_en: meal
+pos: noun
+jlpt: N4
+etymology: 食 (eat) + 事 (matter, event). "The matter of eating."
+korean_parallel: 식사 (siksa) — direct cognate using 食事 with different second character reading.
+
+## shoumikigen
+surface: 賞味期限
+reading: しょうみきげん
+meaning_en: best-by date
+pos: noun
+jlpt: N2
+etymology: 賞味 (appreciate the taste of) + 期限 (time limit). Distinct from 消費期限 (shouhi kigen, safety-critical use-by date). 賞味 implies taste quality, not safety.
+korean_parallel: 유통기한 (yutonggihan, distribution period) is what Korean labels typically show — conceptually similar but different compound.
+
+## sokumen
+surface: 側面
+reading: そくめん
+meaning_en: side surface
+pos: noun
+jlpt: N2
+etymology: 側 (side) + 面 (face, surface). Standard packaging phrase: 側面に記載 (noted on the side).
+korean_parallel: 측면 (cheukmyeon) — direct cognate.
+
+## soushin
+surface: 送信
+reading: そうしん
+meaning_en: sending (a transmission)
+pos: noun, verb (する)
+jlpt: N2
+etymology: 送 (send) + 信 (signal, message). Paired with 受信 (jushin, receiving).
+korean_parallel: 송신 (songsin) — direct cognate.
+
+## tanpakushitsu
+surface: たんぱく質
+reading: たんぱくしつ
+meaning_en: protein
+pos: noun
+jlpt: N2
+etymology: 蛋白 (egg white) + 質 (substance). Written たんぱく in hiragana on most modern packaging because 蛋 is non-jōyō. Egg whites were the prototype protein in 19th-century biochemistry.
+korean_parallel: 단백질 (danbaekjil) — identical compound (蛋白質). Same etymology, same reasoning. One of the cleanest CJK cognates you'll find.
+
+## tansuikabutsu
+surface: 炭水化物
+reading: たんすいかぶつ
+meaning_en: carbohydrates
+pos: noun
+jlpt: N2
+etymology: 炭 (carbon) + 水 (water) + 化 (transform) + 物 (substance). Direct translation of the scientific term "carbohydrate" — a late 19th-century Japanese coinage that then traveled back to Chinese and Korean.
+korean_parallel: 탄수화물 (tansuhwamul) — full cognate. Meiji-era Japanese scientific vocabulary is why modern Korean and Chinese scientific terminology often tracks Japanese closely.
+
+## tenin
+surface: 店員
+reading: てんいん
+meaning_en: store clerk, shop employee
+pos: noun
+jlpt: N4
+etymology: 店 (shop) + 員 (member, staff).
+korean_parallel: 점원 (jeomwon) — direct cognate.
+
+## toriatsukai
+surface: 取り扱い
+reading: とりあつかい
+meaning_en: handling, treatment (of an item or service)
+pos: noun
+jlpt: N2
+etymology: 取る (take) + 扱う (handle). Compound verb noun. In service contexts: what the business offers or declines to offer.
+korean_parallel: 취급 (chwigeup) from 取扱 — direct cognate with same business usage.
+
+## toriniku
+surface: 鶏肉
+reading: とりにく
+meaning_en: chicken (meat)
+pos: noun
+jlpt: N3
+etymology: 鶏 (chicken, the bird) + 肉 (meat). Transparent compound.
+korean_parallel: 닭고기 (dakgogi) — native Korean compound using 닭 (chicken) + 고기 (meat). Same structure with different morphemes.
+
+## vitamin-c
+surface: ビタミンC
+reading: びたみんしー
+meaning_en: vitamin C
+pos: noun
+jlpt: N5
+etymology: From English "vitamin." On ingredient lists often added as an antioxidant/preservative rather than as a nutritional claim.
+korean_parallel: 비타민C (bitamin-ssi) — same international scientific term.
+
+## yakinori
+surface: 焼のり
+reading: やきのり
+meaning_en: toasted nori seaweed
+pos: noun
+jlpt: N3
+etymology: 焼く (to toast/grill) + のり (seaweed sheets). のり typically written in hiragana on packaging though 海苔 exists.
+korean_parallel: 김 (gim) is native Korean. Toasted/seasoned nori is 구운 김. The shared seaweed culture with different names is a good example of parallel-but-independent food traditions.
+
+## yoru
+surface: 夜
+reading: よる
+meaning_en: night
+pos: noun
+jlpt: N5
+etymology: Native kun'yomi. On'yomi ヤ appears in compounds: 夜間 (yakan, nighttime), 深夜 (shin'ya, deep night).
+korean_parallel: 밤 (bam) is native Korean. 야 (夜) appears in Sino-Korean compounds: 심야 (simya, deep night), 야간 (yagan, nighttime) — identical pattern.
+
+## youki
+surface: 容器
+reading: ようき
+meaning_en: container
+pos: noun
+jlpt: N2
+etymology: 容 (hold, contain) + 器 (vessel, tool). "Holding vessel."
+korean_parallel: 용기 (yonggi) — direct cognate.

--- a/is/learning/konbini/index.html
+++ b/is/learning/konbini/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="icon" type="image/png" href="/img/a3.png" />
+    <link rel="apple-touch-icon" href="/img/a3.png" />
+    <title>コンビニ</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&family=IBM+Plex+Mono:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./styles.css" />
+    <script src="../../../analytics.js" defer></script>
+  </head>
+  <body>
+    <header class="chrome" aria-label="navigation">
+      <a class="chrome-brand" href="#/" aria-label="shelves">
+        <span class="chrome-brand-jp">コンビニ</span>
+      </a>
+      <nav class="chrome-nav" id="chrome-nav"></nav>
+    </header>
+
+    <main id="app" class="app" aria-live="polite"></main>
+
+    <div
+      id="popup"
+      class="popup"
+      role="dialog"
+      aria-modal="true"
+      aria-hidden="true"
+    ></div>
+    <div
+      id="popup-scrim"
+      class="popup-scrim"
+      aria-hidden="true"
+    ></div>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/is/learning/konbini/spec/konbini-spec-deltas.md
+++ b/is/learning/konbini/spec/konbini-spec-deltas.md
@@ -1,0 +1,199 @@
+# Konbini Spec Deltas — Japanese-First World
+
+This document records corrections to `konbini-mvp-spec-v2.md` and `konbini-content-templates.md` made during the final pre-build content review. These deltas take precedence over the original spec where they conflict. Claude Code should treat these as authoritative.
+
+---
+
+## Core correction: The konbini is Japanese
+
+Original spec conflated "English-speaking user" with "app has English UI." Wrong. A real konbini's signs, packaging, clerk dialogue, and printed notices are all in Japanese. The user is a Japanese learner using the app for immersion, so the world must be Japanese. English appears only in learner-facing explanations (vocab popup meaning field, About page, exit line).
+
+This changes several things across content, UI, and parser.
+
+---
+
+## 1. Bilingual item descriptions
+
+Item frontmatter now has two description fields, not one:
+
+```yaml
+description_jp: 九月《くがつ》にとれた鮭《さけ》。少し寒《さむ》い土地《とち》の米《こめ》。どちらにも何《なに》も聞《き》かなかった。
+description_en: A salmon caught in September. Rice from a slightly colder place. Neither was asked anything.
+```
+
+**Rendering:** Japanese shown primary. English shown below in smaller muted text (e.g., `font-size: 13px; color: var(--color-text-tertiary); font-style: italic`). The English is gloss, not title.
+
+**Flash behavior unchanged:** full-screen flash on item entry, ~1.5s, both JP and EN visible during the flash.
+
+---
+
+## 2. Furigana via `《》` notation
+
+Content files may include furigana markup on any kanji word that isn't a `[word-id]`:
+
+```
+九月《くがつ》  →  <ruby>九月<rt>くがつ</rt></ruby>
+土地《とち》    →  <ruby>土地<rt>とち</rt></ruby>
+```
+
+**Parser rule:** Any `[漢字]+《[ひらがな]+》` sequence converts to ruby HTML at build time. This is orthogonal to `[word-id]` tap markers. A single word can be either a tap target (uses vocab.md's reading field for furigana) or plain furigana-annotated text, not both.
+
+**For `[word-id]` tap markers:** the parser auto-generates ruby from the vocab entry's `reading` field. No author burden. Example: `[benizake]` → `<ruby>紅鮭<rt>べにざけ</rt></ruby>` with tap-target styling applied.
+
+**MVP behavior:** furigana always visible. A v2 settings toggle can hide it globally via CSS (`.hide-furigana rt { display: none; }`). Don't build the toggle now.
+
+---
+
+## 3. UI strings file (new file type)
+
+New directory: `content/ui/`. Contains `strings.md` holding every UI-chrome string in JP primary / EN gloss format.
+
+**Parser reads** `content/ui/strings.md` and makes strings available via a typed accessor:
+
+```typescript
+getUIString(key: string): { jp: string, en: string }
+```
+
+**Rendering convention:** Japanese always primary in the UI. English gloss shown only where it aids accessibility (aria-label, title attributes, screen-reader text). No bilingual display in the UI itself except for the About page (which is authorial voice).
+
+**Exception — exit line.** The post-checkout exit line is English-only intentionally. It's the leave-the-fiction moment. JP version in the strings file can be null or identical to EN.
+
+Schema of `strings.md`:
+```markdown
+## key_name
+jp: Japanese text with 《ふりがな》
+en: English gloss
+
+## key_name_with_style
+jp_style: deadpan
+jp: ...
+en: ...
+```
+
+The `jp_style` field is optional metadata (for CSS class hooks on specifically styled strings like empty-state deadpan copy).
+
+---
+
+## 4. Dialogue: all choices valid, clerk branches on response
+
+Replaces the `correct` / `wrong-register` labels from the original template. Player choices are now all valid Japanese responses with different social registers. Clerk responds slightly differently based on which was chosen.
+
+New block type: `::clerk-branch[response_id]` — a clerk line that only renders if the previous `::player-choice` selected the option tagged with that `response_id`.
+
+Example:
+```markdown
+::player-choice
+a: [onegai]します | wants_receipt
+b: [daijoubu]です | declines_receipt
+::
+
+::clerk-branch[wants_receipt]
+はい、[receipt]です。
+::
+
+::clerk-branch[declines_receipt]
+かしこまりました。
+::
+```
+
+**Parser rule:** `::clerk-branch[id]` blocks must have their `id` matching a response tag from the immediately preceding `::player-choice`. Orphan branches fail the build.
+
+**Rendering:** After the player taps an option, only the matching `::clerk-branch` blocks render in sequence. Other branches are skipped. Linear flow continues after.
+
+**Parser convenience:** the `| response_id` tags on choices may include `polite`, `casual-polite`, `wants_receipt`, `declines_receipt`, etc. — these are free-form strings at the author's discretion.
+
+---
+
+## 5. Vocabulary popup rendering — furigana in surface
+
+The popup's surface-form display should show furigana via ruby:
+
+```
+<ruby>紅鮭<rt>べにざけ</rt></ruby>
+```
+
+Rather than two separate fields as originally spec'd (surface + reading). The `reading` field in vocab.md is still used — it becomes the ruby annotation. Showing reading separately below is redundant and the popup becomes lighter.
+
+**Popup fields remain:**
+- Surface (with ruby furigana)
+- JLPT level + POS (small, muted)
+- English meaning
+- Etymology (when present)
+- Korean parallel (when present, prefixed `韓国語:` per UI strings file)
+
+Buttons use Japanese labels from UI strings file (`保存` / `閉じる`).
+
+---
+
+## 6. Parser rule additions summary
+
+Adding to the existing 7 error rules:
+
+- **Unresolved `《ふりがな》` markup:** If furigana notation is malformed (e.g., unmatched `《` or `》`), fail with specific error.
+- **Orphan `::clerk-branch` blocks:** A clerk-branch with no matching preceding player-choice response_id fails the build.
+- **Missing UI string keys:** If the app references a UI string key that doesn't exist in `content/ui/strings.md`, fail. (This requires a list of known keys — Claude Code should enumerate them from code references during build.)
+
+Existing warnings remain; no new warnings needed.
+
+---
+
+## 7. Frontmatter field changes
+
+**Items:**
+- `description` → split into `description_jp` (required) and `description_en` (required)
+- Other fields unchanged.
+
+**Notices:** unchanged (already mostly Japanese, just verify no English bleed).
+
+**Dialogue:** unchanged.
+
+**Vocab:** unchanged.
+
+**UI strings:** new file, schema defined in section 3 above.
+
+---
+
+## 8. Specific content decisions finalized
+
+**About page:** four-stanza Japanese version in `content/ui/strings.md` under `about_body`. English version also there for accessibility. Signed 「店長」(store manager) — replaces "— Management" which was my earlier English draft.
+
+**Empty state JP rewrites:** deadpan register preserved. The translations are not literal — "それはそれでよろしい" is a more natural Japanese deadpan for "this is defensible" than a direct translation would be.
+
+**Exit line remains English-only.** Intentional. The moment you leave the konbini is when English returns.
+
+---
+
+## 9. What did NOT change
+
+- Payment rounding rule (next ¥1000; next ¥500 if ≤ ¥500)
+- Take-to-register flow (add and stay)
+- First-item-tap flash (full-screen, 1.5s)
+- LocalStorage schema
+- Out-of-scope list
+- Tech stack
+- Build order
+
+---
+
+## Handoff order
+
+1. Read `konbini-mvp-spec-v2.md` (the spec)
+2. Read `konbini-content-templates.md` (template contract)
+3. Read this deltas document — apply these corrections over the spec/templates
+4. Read `claude-code-prompt.md` (build instructions)
+5. Content bundle in `konbini-content/` or `konbini-content-day-one.tar.gz`
+
+Total new/changed file types the parser handles:
+- items, notices, dialogue, vocab (original 4)
+- ui/strings.md (new)
+
+Total block types the parser handles:
+- `::banner`, `::hero`, `::footer`, `::nutrition`, `::section`, `::fineprint` (items)
+- `::heading`, `::body` (notices, implicit)
+- `::clerk`, `::player-choice`, `::clerk-branch`, `::action`, `::exit` (dialogue)
+
+Total markup conventions:
+- `[word-id]` — tap target, auto-furigana from vocab entry
+- `《ふりがな》` — manual furigana on any preceding kanji word
+- `{{placeholder}}` — runtime substitution in dialogue
+- `| tag` — response_id on player choice options

--- a/is/learning/konbini/styles.css
+++ b/is/learning/konbini/styles.css
@@ -1,0 +1,932 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+:root {
+  --paper: #f4f2ec;
+  --paper-card: #fbfaf5;
+  --paper-card-alt: #f0ede5;
+  --ink: #1c1c1a;
+  --ink-muted: #55544f;
+  --ink-soft: #8a8882;
+  --ink-ghost: #adaba4;
+  --rule: #ccc8bd;
+  --rule-soft: #e2ded3;
+  --accent: #5a3a22;
+  --warn: #8a3a1a;
+  --radius: 2px;
+  --font-jp: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+}
+
+html {
+  font-size: 17px;
+}
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-jp);
+  font-weight: 400;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+
+/* ── chrome ── */
+
+.chrome {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  background: var(--paper);
+  border-bottom: 1px solid var(--rule);
+  padding: 0.6rem 1.1rem;
+  gap: 1rem;
+}
+
+.chrome-brand {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+}
+
+.chrome-brand-jp {
+  font-size: 1.05rem;
+}
+
+.chrome-nav {
+  display: flex;
+  gap: 0.2rem;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.chrome-nav::-webkit-scrollbar {
+  display: none;
+}
+
+.chrome-nav a {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.7rem;
+  border-radius: var(--radius);
+  color: var(--ink-muted);
+  font-size: 0.92rem;
+  white-space: nowrap;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.chrome-nav a:hover {
+  color: var(--ink);
+}
+
+.chrome-nav a.is-active {
+  color: var(--ink);
+  background: var(--paper-card);
+  border: 1px solid var(--rule-soft);
+}
+
+/* ── app frame ── */
+
+.app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1.4rem 1.1rem 4rem;
+}
+
+.app-heading {
+  margin: 0 0 0.2rem;
+  font-size: 1.55rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.app-sublede {
+  margin: 0 0 1.6rem;
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 1rem;
+  color: var(--ink-muted);
+  font-size: 0.9rem;
+}
+
+.back-link::before {
+  content: "←";
+  margin-right: 0.4em;
+}
+
+.back-link:hover {
+  color: var(--ink);
+}
+
+/* ── furigana baseline ── */
+
+ruby {
+  ruby-align: center;
+}
+
+ruby rt {
+  font-size: 0.55em;
+  font-weight: 400;
+  color: var(--ink-soft);
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+/* tappable word */
+.word {
+  cursor: pointer;
+  padding: 0 0.05em;
+  border-bottom: 1px dotted var(--ink-ghost);
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.word:hover,
+.word:focus-visible {
+  background: rgba(90, 58, 34, 0.06);
+  border-bottom-color: var(--accent);
+  outline: none;
+}
+
+.word rt {
+  color: var(--accent);
+  opacity: 0.8;
+}
+
+/* ── shelves ── */
+
+.zone {
+  margin: 0 0 2.2rem;
+}
+
+.zone-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.7rem;
+  margin-bottom: 0.8rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.zone-head h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 500;
+}
+
+.zone-head .zone-gloss {
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.shelf {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.9rem;
+}
+
+.item-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 150px;
+  padding: 0.9rem 1rem 0.85rem;
+  background: var(--paper-card);
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius);
+  transition: border-color 120ms ease, transform 120ms ease;
+}
+
+.item-card:hover {
+  border-color: var(--rule);
+  transform: translateY(-1px);
+}
+
+.item-card-name {
+  margin: 0 0 0.35rem;
+  font-size: 1.02rem;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.item-card-gloss {
+  margin: 0;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.item-card-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-top: 0.7rem;
+  padding-top: 0.55rem;
+  border-top: 1px dashed var(--rule-soft);
+}
+
+.item-card-price {
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  letter-spacing: 0.02em;
+}
+
+.item-card-weight {
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+/* ── item detail ── */
+
+.item-detail {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.item-header h1 {
+  margin: 0 0 0.35rem;
+  font-size: 1.6rem;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.item-desc-jp {
+  margin: 0 0 0.3rem;
+  font-size: 1.02rem;
+  line-height: 1.7;
+}
+
+.item-desc-en {
+  margin: 0;
+  color: var(--ink-soft);
+  font-style: italic;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.package {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 840px) {
+  .package {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.package-face {
+  position: relative;
+  padding: 1.1rem 1.2rem 1.2rem;
+  background: var(--paper-card);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+}
+
+.package-face--back {
+  background: var(--paper-card-alt);
+}
+
+.face-tag {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.9rem;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.block {
+  margin: 0 0 0.85rem;
+}
+
+.block:last-child {
+  margin-bottom: 0;
+}
+
+/* block: banner */
+.block-banner {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  background: var(--accent);
+  color: var(--paper);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.block-banner-arg {
+  margin-right: 0.5em;
+  font-weight: 500;
+}
+
+/* block: hero */
+.block-hero {
+  font-size: 1.3rem;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+/* block: footer (item) */
+.block-footer {
+  color: var(--ink-muted);
+  font-size: 0.88rem;
+}
+
+/* block: section */
+.block-section-arg {
+  margin: 0 0 0.35rem;
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.block-section-body {
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+/* block: nutrition */
+.block-nutrition {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.6rem 0.75rem;
+  background: rgba(0, 0, 0, 0.02);
+  border: 1px solid var(--rule-soft);
+}
+
+.block-nutrition-caption {
+  margin-bottom: 0.35rem;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.block-nutrition-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.15rem 0;
+  font-size: 0.9rem;
+  border-bottom: 1px dotted var(--rule-soft);
+}
+
+.block-nutrition-row:last-child {
+  border-bottom: 0;
+}
+
+.block-nutrition-row-right {
+  font-family: var(--font-mono);
+  color: var(--ink-muted);
+}
+
+/* block: fineprint */
+.block-fineprint {
+  padding-top: 0.6rem;
+  border-top: 1px dashed var(--rule-soft);
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+  line-height: 1.6;
+}
+
+.block-fineprint p {
+  margin: 0 0 0.2rem;
+}
+
+.block-fineprint p:last-child {
+  margin-bottom: 0;
+}
+
+/* ── notices (board) ── */
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.notice-card {
+  padding: 1rem 1.1rem;
+  background: var(--paper-card);
+  border: 1px solid var(--rule-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius);
+}
+
+.notice-card--handwritten {
+  font-family: "Yu Mincho", "Hiragino Mincho ProN", var(--font-jp);
+}
+
+.notice-card h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.notice-card-meta {
+  margin: 0 0 0.5rem;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+}
+
+.notice-card-body {
+  font-size: 0.9rem;
+  line-height: 1.65;
+}
+
+.notice-card-body p {
+  margin: 0 0 0.3rem;
+}
+
+/* ── popup (vocab) ── */
+
+.popup-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(28, 28, 26, 0.38);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms ease;
+  z-index: 20;
+}
+
+.popup-scrim.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.popup {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -46%);
+  width: min(440px, calc(100vw - 1.8rem));
+  max-height: calc(100vh - 3rem);
+  overflow-y: auto;
+  padding: 1.2rem 1.3rem 1.1rem;
+  background: var(--paper-card);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.18);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 160ms ease, transform 160ms ease;
+  z-index: 21;
+}
+
+.popup.is-open {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, -50%);
+}
+
+.popup-surface {
+  margin: 0 0 0.35rem;
+  font-size: 1.65rem;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.popup-surface rt {
+  color: var(--ink-muted);
+  font-size: 0.5em;
+}
+
+.popup-meta {
+  margin: 0 0 0.8rem;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.popup-meaning {
+  margin: 0 0 0.8rem;
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.popup-etym,
+.popup-korean {
+  margin: 0 0 0.7rem;
+  padding-top: 0.55rem;
+  border-top: 1px dashed var(--rule-soft);
+  color: var(--ink-muted);
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+
+.popup-korean::before {
+  content: "韓国語: ";
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-right: 0.2em;
+}
+
+.popup-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--rule-soft);
+}
+
+.popup-btn {
+  padding: 0.4rem 0.95rem;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  color: var(--ink);
+  font-size: 0.88rem;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.popup-btn:hover {
+  background: var(--paper);
+  border-color: var(--ink-muted);
+}
+
+.popup-btn--primary {
+  background: var(--ink);
+  color: var(--paper-card);
+  border-color: var(--ink);
+}
+
+.popup-btn--primary:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--paper-card);
+}
+
+.popup-btn--primary.is-saved {
+  background: var(--paper-card);
+  color: var(--ink-muted);
+  border-color: var(--rule);
+}
+
+/* ── empty / deadpan states ── */
+
+.empty {
+  padding: 2rem 1rem;
+  color: var(--ink-muted);
+  text-align: center;
+  border: 1px dashed var(--rule);
+  border-radius: var(--radius);
+}
+
+.empty--deadpan {
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+/* ── chrome nav badge ── */
+
+.chrome-nav-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.4em;
+  height: 1.4em;
+  margin-left: 0.45em;
+  padding: 0 0.35em;
+  background: var(--ink);
+  color: var(--paper);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  line-height: 1;
+}
+
+/* ── item CTA ── */
+
+.item-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 0.9rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--rule-soft);
+}
+
+.item-actions-price {
+  font-family: var(--font-mono);
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.15rem;
+  background: var(--ink);
+  color: var(--paper);
+  border: 1px solid var(--ink);
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.cta:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.cta.is-added {
+  background: var(--paper-card);
+  color: var(--ink-muted);
+  border-color: var(--rule);
+}
+
+.cta--primary {
+  padding: 0.75rem 1.4rem;
+  font-size: 1rem;
+}
+
+/* ── register / basket ── */
+
+.basket {
+  list-style: none;
+  margin: 0 0 1.2rem;
+  padding: 0;
+  border-top: 1px solid var(--rule-soft);
+}
+
+.basket-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.basket-row-name {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.basket-row-jp {
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.basket-row-en {
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+}
+
+.basket-row-price {
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  color: var(--ink-muted);
+}
+
+.basket-row-count {
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+}
+
+.basket-row-remove {
+  width: 1.9rem;
+  height: 1.9rem;
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  color: var(--ink-muted);
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.basket-row-remove:hover {
+  background: var(--paper-card);
+  color: var(--ink);
+  border-color: var(--ink-muted);
+}
+
+.basket-total {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.9rem 0;
+  border-top: 2px solid var(--ink);
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 1rem;
+}
+
+.basket-total-label {
+  font-size: 1rem;
+}
+
+.basket-total-amount {
+  font-family: var(--font-mono);
+  font-size: 1.25rem;
+  letter-spacing: 0.02em;
+}
+
+.basket-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* ── checkout ── */
+
+.checkout {
+  max-width: 620px;
+  margin: 0 auto;
+}
+
+.checkout-transcript {
+  display: grid;
+  gap: 0.9rem;
+  margin-bottom: 1.4rem;
+}
+
+.turn {
+  max-width: 80%;
+  padding: 0.75rem 1rem;
+  background: var(--paper-card);
+  border: 1px solid var(--rule-soft);
+  border-radius: var(--radius);
+  line-height: 1.65;
+}
+
+.turn p {
+  margin: 0;
+}
+
+.turn-label {
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 0.2rem;
+}
+
+.turn-clerk {
+  align-self: flex-start;
+  margin-right: auto;
+  border-left: 3px solid var(--accent);
+}
+
+.turn-player {
+  margin-left: auto;
+  background: var(--ink);
+  color: var(--paper-card);
+  border-color: var(--ink);
+  text-align: right;
+}
+
+.turn-player .turn-label {
+  color: var(--ink-ghost);
+}
+
+.turn-action {
+  align-self: center;
+  max-width: 100%;
+  background: transparent;
+  border: 0;
+  border-top: 1px dashed var(--rule);
+  border-bottom: 1px dashed var(--rule);
+  border-radius: 0;
+  padding: 0.4rem 0;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  text-align: center;
+}
+
+.turn-exit {
+  align-self: center;
+  max-width: 100%;
+  background: transparent;
+  border: 0;
+  font-size: 1.05rem;
+  color: var(--ink-muted);
+  text-align: center;
+  padding-top: 1.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.checkout-prompt {
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem 0 2rem;
+}
+
+.tap-continue {
+  padding: 0.6rem 1.2rem;
+  background: transparent;
+  border: 1px dashed var(--ink-muted);
+  border-radius: var(--radius);
+  color: var(--ink-muted);
+  font-size: 0.9rem;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+.tap-continue:hover {
+  color: var(--ink);
+  border-color: var(--ink);
+}
+
+.choices {
+  display: grid;
+  gap: 0.55rem;
+  width: 100%;
+  max-width: 480px;
+}
+
+.choice {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+  padding: 0.75rem 1rem;
+  background: var(--paper-card);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  text-align: left;
+  line-height: 1.55;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.choice:hover {
+  background: var(--paper);
+  border-color: var(--ink-muted);
+}
+
+.choice-label {
+  min-width: 1.25em;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
+.choice-text {
+  font-size: 0.98rem;
+}
+
+/* ── small screens ── */
+
+@media (max-width: 520px) {
+  html {
+    font-size: 16px;
+  }
+  .app {
+    padding: 1rem 0.85rem 3rem;
+  }
+  .chrome {
+    padding: 0.55rem 0.85rem;
+  }
+  .shelf {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- New vanilla-JS SPA at `/is/learning/konbini/` — a Japanese-first konbini immersion environment for personal language-learning practice.
- Custom markdown block DSL (`::banner`, `::hero`, `::nutrition`, `::clerk-branch`, etc.) + `《ふりがな》` notation + `[word-id]` tap markers resolved against a 94-entry `vocab.md`.
- `_scripts/build_konbini.py` parses `content/*.md` → `content.json`; the client fetches it at runtime.

## Scope
- Shelves (grouped by zone), item detail (front/back package faces), board + individual notices, saved-words view (localStorage), About page.
- Branching checkout dialogue with `::clerk-branch[id]` response filtering, `{{basket_total}}` / `{{payment_amount}}` / `{{change_amount}}` substitution, spec-compliant rounding (next ¥1000; next ¥500 if ≤ ¥500).
- Vocab popup: surface+ruby, JLPT/POS, meaning, etymology, Korean parallel, save to localStorage.

## Not linked
Not referenced from anywhere on the site (per request). Reachable only via direct URL: `https://ajin.im/is/learning/konbini/`.

## Test plan
- [x] Shelves render at mobile (375), tablet (768), desktop (1280)
- [x] Item detail (front/back) renders with all block types and `《》` + `[word-id]` furigana
- [x] Vocab popup opens on tap, saves to localStorage, persists across reloads
- [x] Basket: add, remove, count badge in nav
- [x] Checkout: full transcript (¥574 → pay ¥1000 / change ¥426), both branches (wants_receipt / declines_receipt), low-total path (¥151 → pay ¥500 / change ¥349)
- [x] Exit clears basket and returns to shelves
- [x] Console is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)