### PR TITLE
Karen Hawk: tighten hero panel + revise consult-points copy

### DIFF
--- a/is/writing/karen-hawk/index.html
+++ b/is/writing/karen-hawk/index.html
@@ -1001,19 +1001,15 @@
               <div class="seal-subtitle">Solo practitioner</div>
             </div>
           </div>
-          <div class="availability-badge">Available now</div>
         </div>
 
         <div class="consult-card">
-          <p class="mini-label">Office</p>
-          <p>11 Municipal Oak, Suite 4<br>Sycamore District</p>
+          <ul class="consult-points">
+            <li>Eighteen years in family law, including nest abandonment and pair-bond disputes.</li>
+            <li>Evening and weekend hours for birds who cannot be seen leaving during the day.</li>
+            <li>Consultations are confidential and do not obligate you to file before you know what the branch is worth.</li>
+          </ul>
         </div>
-
-        <ul class="consult-points">
-          <li>Eighteen years in family law, including nest abandonment and emergency filings.</li>
-          <li>Evening and weekend appointments for birds who only become honest after dusk.</li>
-          <li>Consultations are confidential and do not obligate you to file.</li>
-        </ul>
       </aside>
     </header>
 


### PR DESCRIPTION
## Summary
- Remove OFFICE address sub-card from the hero right panel (address remains in the footer).
- Remove "Available now" availability badge — its copper dot duplicated the consult-points bullet dots.
- Wrap consult-points in a white card so the bullets have a surface to sit on (the panel was looking text-heavy after the OFFICE card was removed).
- Revise the three consult-points bullets in a sharper voice (pair-bond disputes; cannot be seen leaving during the day; before you know what the branch is worth).

## Notes for potential revert
The badge and OFFICE card were pure removals — restoring them is straightforward from the prior file version. The bullet copy revisions are independent of the layout changes and can be kept or reverted on their own.

## Test plan
- [ ] Visit `/is/writing/karen-hawk/` on desktop — hero right panel reads as: seal/title block + white card with three bullets, no badge, no separate office card.
- [ ] Mobile (375px) — panel still stacks under the hero copy without overflow.
- [ ] Footer still shows the office address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)