### PR TITLE
Avian District portal: add map, stats, Coo excerpt; redesign service cards

### DIFF
--- a/is/writing/avian-district/index.html
+++ b/is/writing/avian-district/index.html
@@ -12,8 +12,8 @@
 <link rel="icon" type="image/png" sizes="32x32" href="./favicon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@300;400&family=Source+Serif+4:ital,wght@0,400;1,400&display=swap">
-<script src="../../../analytics.js" defer></script>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@300;400&family=Source+Serif+4:ital,wght@0,400;1,400&display=swap">
+  <script src="../../../analytics.js" defer></script>
 <style>
 *,*::before,*::after{box-sizing:border-box}
 
@@ -26,6 +26,7 @@
   --page-bg: #e8e6e1;
   --surface: #f4f2ed;
   --surface-alt: #eceae4;
+  --surface-deep: #ddd9cf;
   --ink: #1a1a18;
   --ink-light: #33332e;
   --ink-faded: #5a5a52;
@@ -35,7 +36,34 @@
   --link: #1d4a6a;
   --link-hover: #0f3048;
   --card-border: #b8b4a8;
+  /* Two controlled accents — already present in map hotspots.
+     Read as "ink stamps" / "filing labels," not "decoration." */
+  --ink-stamp: #7a3614;        /* rust/oxblood — active, flagged, regulated */
+  --ink-archive: #3a5a64;      /* deep teal — system, informational, archival */
+  --ink-stamp-tint: rgba(122,54,20,0.08);
+  --ink-archive-tint: rgba(58,90,100,0.08);
+
+  /* Category keys for service cards. Desaturated, period-appropriate.
+     Used only as 2px top hairline + faint label color shift. */
+  --cat-judicial: #4a5d6e;     /* slate, court-blue cousin */
+  --cat-media:    #6b6258;     /* newsprint warm gray */
+  --cat-community:#5a6b58;     /* moss, restrained */
+  --cat-licensed: #7a3614;     /* ink-stamp red, regulated */
 }
+
+/* Subtle paper grain on the page background only.
+   Surfaces (cards, letter, notice) stay clean — documents on a desk. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.55;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.10  0 0 0 0 0.10  0 0 0 0 0.09  0 0 0 0.045 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+}
+body > * { position: relative; z-index: 1; }
 
 html { font-size: 16px; }
 
@@ -80,28 +108,6 @@ a:hover { color: var(--link-hover); }
   font-family: "IBM Plex Mono", monospace;
 }
 
-.notice-box {
-  background: var(--notice-bg);
-  border: 1px solid var(--notice-border);
-  border-left: 3px solid var(--notice-accent);
-  padding: 0.55rem 0.8rem;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.75rem;
-  line-height: 1.5;
-  color: var(--ink-light);
-  margin-top: 0.8rem;
-}
-
-.notice-label {
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font-size: 0.6rem;
-  display: block;
-  margin-bottom: 0.15rem;
-  color: var(--ink-ghost);
-}
-
 .title-section {
   background: var(--surface);
   border-bottom: 1px solid var(--rule);
@@ -136,10 +142,11 @@ a:hover { color: var(--link-hover); }
 
 .clerk-letter {
   margin: 1.4rem 0;
-  padding: 1rem 1.2rem;
+  padding: 1.1rem 1.4rem 1.2rem;
   background: var(--surface);
   border: 1px solid var(--rule);
-  border-left: 3px solid var(--rule-heavy);
+  border-left: 4px solid var(--ink-light);
+  box-shadow: 0 1px 0 rgba(26,26,24,0.04);
 }
 
 .clerk-letter-head {
@@ -179,6 +186,440 @@ a:hover { color: var(--link-hover); }
   border-bottom: 2px solid var(--rule-heavy);
 }
 
+.map-sub {
+  margin: -0.45rem 0 0.75rem;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-ghost);
+}
+
+.district-map-shell {
+  border: 1px solid var(--rule);
+  background: var(--surface);
+  padding: 0.75rem;
+  position: relative;
+}
+
+.district-map-wrap {
+  position: relative;
+  border: 1px solid var(--card-border);
+  background: #e8e4d2;
+  overflow: hidden;
+}
+
+.district-map {
+  display: block;
+  width: 100%;
+  height: auto;
+  touch-action: manipulation;
+  user-select: none;
+}
+
+.map-graticule {
+  stroke: rgba(138,135,126,0.22);
+  stroke-width: 0.7;
+}
+
+.map-boundary {
+  fill: #d2cdb5;
+  stroke: #8a877e;
+  stroke-width: 2;
+}
+
+.map-green {
+  fill: rgba(129,142,104,0.18);
+  stroke: rgba(129,142,104,0.24);
+  stroke-width: 1;
+}
+
+.map-water {
+  fill: rgba(126,145,154,0.18);
+  stroke: rgba(126,145,154,0.36);
+  stroke-width: 1;
+}
+
+.map-road {
+  fill: none;
+  stroke: #b8b4a8;
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.map-road-secondary {
+  fill: none;
+  stroke: rgba(122,119,110,0.56);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 6 7;
+}
+
+.map-path {
+  fill: none;
+  stroke: rgba(122,119,110,0.48);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-dasharray: 3 6;
+}
+
+.map-feature {
+  fill: rgba(244,242,237,0.42);
+  stroke: rgba(138,135,126,0.35);
+  stroke-width: 1;
+}
+
+.map-label {
+  font-family: "Source Serif 4", Georgia, serif;
+  font-style: italic;
+  font-size: 13px;
+  fill: #4f4d47;
+  paint-order: stroke;
+  stroke: rgba(232,228,210,0.9);
+  stroke-width: 4;
+  stroke-linejoin: round;
+  pointer-events: none;
+}
+
+.map-label-small {
+  font-size: 11px;
+  fill: #66635b;
+}
+
+.map-road-label {
+  font-family: "Source Serif 4", Georgia, serif;
+  font-style: italic;
+  font-size: 12px;
+  fill: #6a665d;
+  paint-order: stroke;
+  stroke: rgba(232,228,210,0.9);
+  stroke-width: 4;
+  pointer-events: none;
+}
+
+.hotspot {
+  cursor: pointer;
+  outline: none;
+}
+
+.hotspot-hit {
+  fill: transparent;
+  pointer-events: all;
+}
+
+.hotspot-dot {
+  fill: rgba(184,84,32,0.72);
+  stroke: #7a3614;
+  stroke-width: 1.5;
+  transition: r 0.16s ease, fill 0.16s ease, stroke-width 0.16s ease;
+}
+
+.hotspot-zero {
+  fill: rgba(244,242,237,0.58);
+  stroke: #88887e;
+  stroke-width: 1.7;
+}
+
+.hotspot:hover .hotspot-dot,
+.hotspot:focus .hotspot-dot,
+.hotspot.is-active .hotspot-dot {
+  fill: rgba(184,84,32,0.9);
+  stroke-width: 2.4;
+}
+
+.hotspot:focus .hotspot-ring,
+.hotspot.is-active .hotspot-ring {
+  opacity: 1;
+}
+
+.hotspot-ring {
+  fill: none;
+  stroke: rgba(244,242,237,0.95);
+  stroke-width: 4;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.map-control-label {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  fill: #5a5a52;
+}
+
+.map-compass line,
+.map-compass path,
+.map-scale line {
+  stroke: #5a5a52;
+  stroke-width: 1.2;
+  stroke-linecap: round;
+}
+
+.map-popup {
+  position: fixed;
+  z-index: 90;
+  width: min(270px, calc(100vw - 28px));
+  padding: 0.75rem 0.85rem 0.8rem;
+  background: rgba(244,242,237,0.98);
+  border: 1px solid var(--rule-heavy);
+  color: var(--ink);
+  box-shadow: 0 6px 18px rgba(26,26,24,0.14);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(3px);
+  transition: opacity 0.12s ease, transform 0.12s ease, visibility 0.12s;
+}
+
+.map-popup.is-visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.map-popup-close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.35rem;
+  border: 0;
+  background: transparent;
+  color: var(--ink-ghost);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.2rem;
+}
+
+.map-popup-close:hover,
+.map-popup-close:focus {
+  color: var(--ink);
+}
+
+.map-popup-category {
+  margin: 0 1.4rem 0.2rem 0;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-ghost);
+}
+
+.map-popup-title {
+  margin: 0 0 0.18rem;
+  font-family: "Source Serif 4", Georgia, serif;
+  font-style: italic;
+  font-size: 0.98rem;
+  line-height: 1.25;
+  color: var(--ink);
+}
+
+.map-popup-stats {
+  margin: 0 0 0.45rem;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.68rem;
+  color: var(--ink-faded);
+}
+
+.map-popup-note {
+  margin: 0;
+  font-family: "Source Serif 4", Georgia, serif;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--ink-light);
+}
+
+.map-legend {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+  align-items: center;
+  margin-top: 0.6rem;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.68rem;
+  color: var(--ink-faded);
+}
+
+.legend-scale {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  white-space: nowrap;
+}
+
+.legend-dot {
+  display: inline-block;
+  border-radius: 50%;
+  background: rgba(184,84,32,0.72);
+  border: 1.5px solid #7a3614;
+}
+
+.legend-small { width: 8px; height: 8px; }
+.legend-medium { width: 12px; height: 12px; }
+.legend-large { width: 16px; height: 16px; }
+.legend-zero {
+  width: 12px;
+  height: 12px;
+  background: transparent;
+  border-color: #88887e;
+}
+
+.map-source {
+  color: var(--ink-ghost);
+  white-space: nowrap;
+}
+
+.map-footnote {
+  margin: 0.45rem 0 0;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.62rem;
+  line-height: 1.5;
+  color: var(--ink-ghost);
+}
+
+/* ─────────────────────────────────────────────────
+   District at a Glance — civic stat panel
+   3×2 grid; hairline rules between cells (table-style).
+   Numbers in Plex Sans light; labels in Plex Mono uppercase.
+   ───────────────────────────────────────────────── */
+.stat-panel {
+  border: 1px solid var(--rule);
+  background: var(--surface);
+  margin-bottom: 0.4rem;
+}
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+.stat-cell {
+  padding: 1.1rem 1.1rem 1rem;
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  position: relative;
+}
+.stat-cell:nth-child(3n) { border-right: none; }
+.stat-cell:nth-child(n+4) { /* bottom row */ border-bottom: none; }
+.stat-num {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-weight: 300;
+  font-size: 2.6rem;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  margin-bottom: 0.5rem;
+  display: inline-block;
+}
+.stat-num.is-zero { color: var(--ink-faded); }
+.stat-label {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.62rem;
+  line-height: 1.45;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-faded);
+}
+.stat-foot {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  color: var(--ink-ghost);
+  text-transform: uppercase;
+  padding: 0.55rem 1.1rem;
+  border-top: 1px solid var(--rule-heavy);
+  background: var(--surface-alt);
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.stat-foot .stat-period { color: var(--ink-faded); }
+
+/* ─────────────────────────────────────────────────
+   From the Municipal Coo — excerpt block
+   Heavy double rules top + bottom; serif italic headline.
+   ───────────────────────────────────────────────── */
+.coo-excerpt {
+  margin: 1.2rem 0 0.4rem;
+  padding: 1.4rem 0.4rem 1.5rem;
+  border-top: 2px solid var(--ink-light);
+  border-bottom: 2px solid var(--ink-light);
+  position: relative;
+}
+.coo-excerpt::before,
+.coo-excerpt::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--ink-light);
+}
+.coo-excerpt::before { top: 4px; }
+.coo-excerpt::after  { bottom: 4px; }
+.coo-masthead {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-ghost);
+  margin-bottom: 0.85rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+.coo-masthead .coo-edition { color: var(--ink-faded); }
+.coo-headline {
+  font-family: "Source Serif 4", Georgia, serif;
+  font-style: italic;
+  font-weight: 400;
+  font-size: 1.5rem;
+  line-height: 1.25;
+  color: var(--ink);
+  margin: 0 0 0.7rem;
+  text-wrap: balance;
+  letter-spacing: -0.005em;
+}
+.coo-body {
+  font-family: "Source Serif 4", Georgia, serif;
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: var(--ink-light);
+  margin: 0 0 0.9rem;
+  max-width: 56ch;
+  text-wrap: pretty;
+}
+.coo-link {
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  text-decoration: none;
+  color: var(--link);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.coo-link:hover { color: var(--link-hover); }
+.coo-link .arrow {
+  font-family: "IBM Plex Mono", monospace;
+  transition: transform 0.15s ease;
+}
+.coo-link:hover .arrow { transform: translateX(2px); }
+
+/* ─────────────────────────────────────────────────
+   Service cards — bumped to system level.
+   - 2px top hairline keyed to category (--cat-*)
+   - Mono category label, slightly louder
+   - Ordinance reference in mono (typographic mark, civic register)
+   - Trailing "→" cue indicates navigation without competing with stats above
+   ───────────────────────────────────────────────── */
 .services-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -186,43 +627,91 @@ a:hover { color: var(--link-hover); }
 }
 
 .service-card {
+  position: relative;
   border: 1px solid var(--card-border);
+  border-top: 2px solid var(--cat-color, var(--rule-heavy));
   background: var(--surface);
-  padding: 0.9rem 1rem;
+  padding: 0.95rem 1.1rem 1.05rem;
   text-decoration: none;
   color: inherit;
-  display: block;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 0.35rem;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
 }
+
+.service-card[data-cat="judicial"]  { --cat-color: var(--cat-judicial); }
+.service-card[data-cat="media"]     { --cat-color: var(--cat-media); }
+.service-card[data-cat="community"] { --cat-color: var(--cat-community); }
+.service-card[data-cat="licensed"]  { --cat-color: var(--cat-licensed); }
 
 .service-card:hover {
   border-color: var(--rule-heavy);
-  box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+  border-top-color: var(--cat-color);
+  box-shadow: 0 1px 0 rgba(26,26,24,0.06), 0 4px 14px -8px rgba(26,26,24,0.18);
+}
+
+.service-card .card-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
 }
 
 .service-card .card-category {
+  font-family: "IBM Plex Mono", monospace;
   font-size: 0.6rem;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.12em;
+  color: var(--cat-color, var(--ink-ghost));
+  margin: 0;
+}
+
+.service-card .card-ref {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
   color: var(--ink-ghost);
-  margin-bottom: 0.2rem;
 }
 
 .service-card .card-title {
-  font-size: 0.95rem;
+  font-size: 0.98rem;
   font-weight: 600;
   color: var(--link);
-  margin-bottom: 0.3rem;
+  margin: 0.05rem 0 0.15rem;
+  line-height: 1.3;
+  letter-spacing: -0.005em;
 }
 
-.service-card:hover .card-title {
-  color: var(--link-hover);
-}
+.service-card:hover .card-title { color: var(--link-hover); }
 
 .service-card .card-desc {
   font-size: 0.78rem;
   color: var(--ink-faded);
-  line-height: 1.5;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.service-card .card-cue {
+  margin-top: 0.4rem;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-ghost);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.service-card .card-cue .arrow {
+  transition: transform 0.15s ease;
+  color: var(--ink-faded);
+}
+
+.service-card:hover .card-cue .arrow {
+  transform: translateX(3px);
+  color: var(--ink);
 }
 
 .service-card.full-width {
@@ -334,6 +823,35 @@ a:hover { color: var(--link-hover); }
   .site-footer { grid-template-columns: 1fr; gap: 0.8rem; }
   .title-section h1 { font-size: 1.4rem; }
   .header-util { display: none; }
+  .district-map-shell { padding: 0.5rem; }
+  .map-label,
+  .map-road-label { display: none; }
+  .map-label-small,
+  .map-road-label.secondary-label { display: none; }
+  .hotspot-hit { r: 36px; }
+  .map-legend { align-items: flex-start; flex-direction: column; }
+  .map-source { white-space: normal; }
+
+  /* Stat panel — fall to 2 cols on tablet, 1 col under 420px */
+  .stat-grid { grid-template-columns: 1fr 1fr; }
+  .stat-cell { border-right: 1px solid var(--rule); border-bottom: 1px solid var(--rule); }
+  .stat-cell:nth-child(3n) { border-right: 1px solid var(--rule); }
+  .stat-cell:nth-child(2n) { border-right: none; }
+  .stat-cell:nth-child(n+5) { border-bottom: none; }
+  .stat-num { font-size: 2.2rem; }
+
+  .coo-headline { font-size: 1.2rem; }
+  .coo-body { font-size: 0.88rem; }
+  .coo-masthead { flex-direction: column; gap: 0.1rem; align-items: flex-start; }
+
+  .clerk-letter { padding: 1rem 1.05rem 1.1rem; }
+}
+
+@media (max-width: 420px) {
+  .stat-grid { grid-template-columns: 1fr; }
+  .stat-cell { border-right: none !important; border-bottom: 1px solid var(--rule) !important; }
+  .stat-cell:last-child { border-bottom: none !important; }
+  .stat-num { font-size: 2rem; }
 }
 
 .form-trigger {
@@ -487,10 +1005,6 @@ a:hover { color: var(--link-hover); }
   <div class="title-section-inner">
     <h1>Avian Municipal District</h1>
     <p class="title-sub">Official portal · Services, notices, and public records</p>
-    <div class="notice-box">
-      <span class="notice-label">District Notice</span>
-      Quiet hours compliance review in progress (<a href="/is/writing/nest-court/" target="_blank" style="color:inherit;text-decoration:underline">AMNC-2026-011A</a>). Residents of Municipal Oak are reminded that 6:29 AM is before 6:30 AM.
-    </div>
   </div>
 </div>
 
@@ -505,33 +1019,99 @@ a:hover { color: var(--link-hover); }
     <div class="sig">— T. Nuthatch, Clerk of Court</div>
   </div>
 
+  <div class="section-heading">District at a Glance</div>
+
+  <div class="stat-panel" aria-label="District statistics">
+    <div class="stat-grid">
+      <div class="stat-cell">
+        <div class="stat-num">7</div>
+        <div class="stat-label">Broken hearts</div>
+      </div>
+      <div class="stat-cell">
+        <div class="stat-num">12</div>
+        <div class="stat-label">Self-help books,<br>drainage pipe</div>
+      </div>
+      <div class="stat-cell">
+        <div class="stat-num">1</div>
+        <div class="stat-label">Public argument</div>
+      </div>
+      <div class="stat-cell">
+        <div class="stat-num">1</div>
+        <div class="stat-label">Unclaimed vine</div>
+      </div>
+      <div class="stat-cell">
+        <div class="stat-num is-zero">0</div>
+        <div class="stat-label">Reconciliations</div>
+      </div>
+      <div class="stat-cell">
+        <div class="stat-num">1</div>
+        <div class="stat-label">Fax, not operational</div>
+      </div>
+    </div>
+    <div class="stat-foot">
+      <span>Source: Clerk's Office</span>
+      <span class="stat-period">Counts updated as observed</span>
+    </div>
+  </div>
+
+  <section class="coo-excerpt" aria-label="From the Municipal Coo">
+    <div class="coo-masthead">
+      <span>From the Municipal Coo</span>
+    </div>
+    <h3 class="coo-headline">Third Bench Occupant Identified; Says He Is &ldquo;Between Situations.&rdquo;</h3>
+    <p class="coo-body">The Coo's reporting matches the Clerk's Office's records. The Clerk's Office has nothing further to add at this time and notes that "nothing further to add" is itself a record.</p>
+    <a class="coo-link" href="/is/writing/bird-coo/" target="_blank">
+      <span class="arrow">→</span> Read the full edition
+    </a>
+  </section>
+
   <div class="section-heading">District Services</div>
 
   <div class="services-grid">
-    <a class="service-card" href="/is/writing/nest-court/" target="_blank">
-      <div class="card-category">Judicial</div>
+    <a class="service-card" data-cat="judicial" href="/is/writing/nest-court/" target="_blank">
+      <div class="card-meta">
+        <span class="card-category">Judicial</span>
+        <span class="card-ref">Ord. 14.7(b)</span>
+      </div>
       <div class="card-title">Nest Court — eCourt Public Portal</div>
       <div class="card-desc">Case filings, hearing schedules, rulings, and docket records. Public access under Ordinance 14.7(b). Spectators reviewing active cases are asked to refrain from editorial commentary in the queue. Recent proceedings with public gallery assessments are available for review.</div>
+      <div class="card-cue"><span>eCourt portal</span><span class="arrow">→</span></div>
     </a>
-    <a class="service-card" href="/is/writing/bird-coo/" target="_blank">
-      <div class="card-category">Media</div>
+    <a class="service-card" data-cat="media" href="/is/writing/bird-coo/" target="_blank">
+      <div class="card-meta">
+        <span class="card-category">Media</span>
+        <span class="card-ref">Indep. publication</span>
+      </div>
       <div class="card-title">The Municipal Coo</div>
       <div class="card-desc">The district's newspaper of record. Published weekly. Court coverage, community letters, classifieds, and licensed practitioner advertising. The Coo operates independently of the Clerk's Office and has been reminded of this whenever it publishes something the Clerk's Office would have preferred it didn't.</div>
+      <div class="card-cue"><span>Weekly edition</span><span class="arrow">→</span></div>
     </a>
-    <a class="service-card" href="/is/writing/secondnest/" target="_blank">
-      <div class="card-category">Community</div>
+    <a class="service-card" data-cat="community" href="/is/writing/secondnest/" target="_blank">
+      <div class="card-meta">
+        <span class="card-category">Community</span>
+        <span class="card-ref">Not endorsed</span>
+      </div>
       <div class="card-title">SecondNest</div>
       <div class="card-desc">Community personals platform. The Clerk's Office does not operate, endorse, or moderate SecondNest. Residents who recognise someone on the platform are encouraged to mind their business.</div>
+      <div class="card-cue"><span>External platform</span><span class="arrow">→</span></div>
     </a>
-    <a class="service-card" href="/is/writing/perch-chat/" target="_blank">
-      <div class="card-category">Community</div>
+    <a class="service-card" data-cat="community" href="/is/writing/perch-chat/" target="_blank">
+      <div class="card-meta">
+        <span class="card-category">Community</span>
+        <span class="card-ref">Clerk-maintained</span>
+      </div>
       <div class="card-title">The Perch — Community Chat</div>
       <div class="card-desc">District messaging platform maintained by the Clerk's Office for municipal coordination. The Clerk's Office is aware most messages are not about municipal coordination. Maintenance continues on principle.</div>
+      <div class="card-cue"><span>Messaging platform</span><span class="arrow">→</span></div>
     </a>
-    <a class="service-card full-width" href="/is/writing/karen-hawk/" target="_blank">
-      <div class="card-category">Licensed Practitioner</div>
+    <a class="service-card" data-cat="licensed" href="/is/writing/karen-hawk/" target="_blank">
+      <div class="card-meta">
+        <span class="card-category">Licensed Practitioner</span>
+        <span class="card-ref">Reg. 02 · Family law</span>
+      </div>
       <div class="card-title">Karen Hawk, Attorney at Law</div>
       <div class="card-desc">Family law. Eighteen years. The Clerk's Office processes her filings more frequently than any other practitioner's. This is not an endorsement. It is a volume observation.</div>
+      <div class="card-cue"><span>Practitioner listing</span><span class="arrow">→</span></div>
     </a>
   </div>
 
@@ -575,6 +1155,124 @@ a:hover { color: var(--link-hover); }
       <div class="notice-text">The Clerk's Office is not a mediation service, a counselling resource, or a venue for continuing arguments that began at home. The front window is for filings. Visiting hours ended in 2024.</div>
     </li>
   </ul>
+
+  <div class="section-heading">District Map</div>
+  <p class="map-sub">Activity by location · Quarterly · Hover or tap a marker</p>
+
+  <section class="district-map-shell" aria-label="District Map">
+    <div class="district-map-wrap" id="districtMapWrap">
+      <svg class="district-map" id="districtMap" viewBox="0 0 860 430" role="img" aria-labelledby="districtMapTitle districtMapDesc">
+        <title id="districtMapTitle">Avian Municipal District activity map</title>
+        <desc id="districtMapDesc">A Clerk's Office map showing public activity by location across Municipal Oak, Sycamore Lane, Birch Court, Municipal Park, South Ridge, and eastern infrastructure.</desc>
+
+        <rect width="860" height="430" fill="#e8e4d2"></rect>
+
+        <g aria-hidden="true">
+          <path class="map-graticule" d="M120 0V430 M240 0V430 M360 0V430 M480 0V430 M600 0V430 M720 0V430"></path>
+          <path class="map-graticule" d="M0 80H860 M0 160H860 M0 240H860 M0 320H860 M0 400H860"></path>
+        </g>
+
+        <path class="map-boundary" d="M94 128 C122 86 198 72 286 88 C356 58 472 68 558 102 C630 86 726 116 776 184 C820 244 796 318 714 350 C620 389 522 392 434 366 C346 404 230 386 154 324 C92 272 62 190 94 128 Z"></path>
+
+        <path class="map-green" d="M92 264 C134 232 205 234 258 270 C296 296 304 344 256 367 C200 392 132 354 102 318 C88 300 78 282 92 264 Z"></path>
+        <path class="map-green" d="M382 292 C432 262 512 276 548 318 C566 342 546 366 498 372 C438 380 382 350 376 320 C374 308 374 300 382 292 Z"></path>
+        <ellipse class="map-water" cx="485" cy="326" rx="46" ry="18" transform="rotate(-10 485 326)"></ellipse>
+        <path class="map-feature" d="M350 246 L430 250 L428 292 L348 288 Z"></path>
+        <path class="map-feature" d="M692 224 C738 218 776 238 790 270 C758 286 714 288 680 268 C678 250 682 236 692 224 Z"></path>
+
+        <path class="map-road" d="M142 211 C218 186 303 191 384 201 C474 211 552 193 626 190"></path>
+        <path class="map-road-secondary" d="M626 190 C645 172 670 151 716 132"></path>
+        <path class="map-path" d="M410 205 C404 240 422 286 462 321"></path>
+        <path class="map-path" d="M354 204 C314 232 260 285 214 333"></path>
+        <path class="map-path" d="M626 190 C662 212 694 226 733 245"></path>
+
+        <text class="map-road-label" x="238" y="178">Sycamore Lane</text>
+        <text class="map-road-label" x="656" y="160" transform="rotate(-28 656 160)">Birch Court</text>
+        <text class="map-label" x="370" y="164">Municipal Oak</text>
+        <text class="map-label map-label-small" x="407" y="348">Municipal Park</text>
+        <text class="map-label map-label-small" x="150" y="354">South Ridge</text>
+        <text class="map-label map-label-small secondary-label" x="686" y="216">Bldg. C East</text>
+        <text class="map-label map-label-small secondary-label" x="344" y="282">Parking Lot</text>
+
+        <g class="map-compass" aria-hidden="true" transform="translate(775 58)">
+          <circle cx="0" cy="0" r="22" fill="rgba(244,242,237,0.45)" stroke="#8a877e" stroke-width="1"></circle>
+          <path d="M0 -16 L5 3 L0 0 L-5 3 Z" fill="#5a5a52" stroke="none"></path>
+          <line x1="0" y1="5" x2="0" y2="15"></line>
+          <text class="map-control-label" x="-4" y="-25">N</text>
+        </g>
+
+        <g class="map-scale" aria-hidden="true" transform="translate(64 374)">
+          <line x1="0" y1="0" x2="112" y2="0"></line>
+          <line x1="0" y1="-6" x2="0" y2="6"></line>
+          <line x1="56" y1="-6" x2="56" y2="6"></line>
+          <line x1="112" y1="-6" x2="112" y2="6"></line>
+          <text class="map-control-label" x="0" y="22">0</text>
+          <text class="map-control-label" x="47" y="22">50</text>
+          <text class="map-control-label" x="94" y="22">100 wingspans</text>
+        </g>
+
+        <g class="hotspot" id="hotspot-municipal-oak" data-hotspot-id="municipalOak" tabindex="0" role="button" aria-label="14 Municipal Oak, Judicial, Filings: 4">
+          <circle class="hotspot-hit" cx="410" cy="195" r="24"></circle>
+          <circle class="hotspot-ring" cx="410" cy="195" r="19"></circle>
+          <circle class="hotspot-dot" cx="410" cy="195" r="15"></circle>
+        </g>
+        <g class="hotspot" id="hotspot-sycamore-lot" data-hotspot-id="sycamoreLot" tabindex="0" role="button" aria-label="14 Sycamore Lane, Lot 7, Residential, Filings: 1">
+          <circle class="hotspot-hit" cx="555" cy="205" r="22"></circle>
+          <circle class="hotspot-ring" cx="555" cy="205" r="15"></circle>
+          <circle class="hotspot-dot" cx="555" cy="205" r="10"></circle>
+        </g>
+        <g class="hotspot" id="hotspot-birch-22" data-hotspot-id="birch22" tabindex="0" role="button" aria-label="22 Birch Court, Residential, Filings: 0">
+          <circle class="hotspot-hit" cx="690" cy="150" r="22"></circle>
+          <circle class="hotspot-ring" cx="690" cy="150" r="14"></circle>
+          <circle class="hotspot-dot hotspot-zero" cx="690" cy="150" r="9"></circle>
+        </g>
+        <g class="hotspot" id="hotspot-birch-sycamore" data-hotspot-id="birchSycamore" tabindex="0" role="button" aria-label="Birch / Sycamore Intersection, Public, Filings: 1">
+          <circle class="hotspot-hit" cx="625" cy="190" r="22"></circle>
+          <circle class="hotspot-ring" cx="625" cy="190" r="15"></circle>
+          <circle class="hotspot-dot" cx="625" cy="190" r="10"></circle>
+        </g>
+        <g class="hotspot" id="hotspot-third-bench" data-hotspot-id="thirdBench" tabindex="0" role="button" aria-label="Municipal Park, Third Bench, Public, Filings: 1">
+          <circle class="hotspot-hit" cx="450" cy="325" r="22"></circle>
+          <circle class="hotspot-ring" cx="450" cy="325" r="15"></circle>
+          <circle class="hotspot-dot" cx="450" cy="325" r="10"></circle>
+        </g>
+        <g class="hotspot" id="hotspot-drainage-pipe" data-hotspot-id="drainagePipe" tabindex="0" role="button" aria-label="Drainage Pipe, Building C East, Infrastructure, Filings: 1">
+          <circle class="hotspot-hit" cx="735" cy="245" r="22"></circle>
+          <circle class="hotspot-ring" cx="735" cy="245" r="15"></circle>
+          <circle class="hotspot-dot" cx="735" cy="245" r="10"></circle>
+        </g>
+        <g class="hotspot" id="hotspot-south-ridge" data-hotspot-id="southRidge" tabindex="0" role="button" aria-label="South Ridge, Infrastructure, Filings: 0">
+          <circle class="hotspot-hit" cx="220" cy="330" r="22"></circle>
+          <circle class="hotspot-ring" cx="220" cy="330" r="14"></circle>
+          <circle class="hotspot-dot hotspot-zero" cx="220" cy="330" r="9"></circle>
+        </g>
+        <g class="hotspot" id="hotspot-parking-lot" data-hotspot-id="parkingLot" tabindex="0" role="button" aria-label="Parking Lot South, Public, Filings: 1">
+          <circle class="hotspot-hit" cx="390" cy="270" r="22"></circle>
+          <circle class="hotspot-ring" cx="390" cy="270" r="15"></circle>
+          <circle class="hotspot-dot" cx="390" cy="270" r="10"></circle>
+        </g>
+      </svg>
+    </div>
+
+    <div class="map-legend" aria-label="Map legend">
+      <div class="legend-scale">
+        <span class="legend-item"><span class="legend-dot legend-small"></span>Small dot · 1</span>
+        <span class="legend-item"><span class="legend-dot legend-medium"></span>Medium dot · 2-3</span>
+        <span class="legend-item"><span class="legend-dot legend-large"></span>Large dot · 4+</span>
+        <span class="legend-item"><span class="legend-dot legend-zero"></span>Hollow circle · 0</span>
+      </div>
+      <div class="map-source">Source: Clerk's Office</div>
+    </div>
+    <p class="map-footnote">Activity reflects formal filings and public records as of Spring 2026. Observations are recorded separately and do not appear on this map.</p>
+  </section>
+
+  <div class="map-popup" id="districtMapPopup" role="status" aria-live="polite">
+    <button type="button" class="map-popup-close" id="districtMapPopupClose" aria-label="Close map popup">&times;</button>
+    <div class="map-popup-category" id="districtMapPopupCategory"></div>
+    <div class="map-popup-title" id="districtMapPopupTitle"></div>
+    <div class="map-popup-stats" id="districtMapPopupStats"></div>
+    <p class="map-popup-note" id="districtMapPopupNote"></p>
+  </div>
 
   <div class="section-heading">Frequently Requested Information</div>
 
@@ -736,6 +1434,199 @@ a:hover { color: var(--link-hover); }
 </div>
 
 <script>
+var districtMapHotspots = {
+  municipalOak: {
+    category: 'Judicial',
+    name: '14 Municipal Oak',
+    filings: 4,
+    note: "Clerk's Office, Court, and Perch & Perch. Active filings."
+  },
+  sycamoreLot: {
+    category: 'Residential',
+    name: '14 Sycamore Lane, Lot 7',
+    filings: 1,
+    note: 'Subject of AMNC-2026-007B. Ruling issued.'
+  },
+  birch22: {
+    category: 'Residential',
+    name: '22 Birch Court',
+    filings: 0,
+    note: 'Frequently observed. Never filed against.'
+  },
+  birchSycamore: {
+    category: 'Public',
+    name: 'Birch / Sycamore Intersection',
+    filings: 1,
+    note: "One unclaimed vine. Removed to Clerk's drawer."
+  },
+  thirdBench: {
+    category: 'Public',
+    name: 'Municipal Park, Third Bench',
+    filings: 1,
+    note: 'Three regular occupants. None have filed paperwork.'
+  },
+  drainagePipe: {
+    category: 'Infrastructure',
+    name: 'Drainage Pipe, Bldg. C (East)',
+    filings: 1,
+    note: 'Self-help books available. Pickup only.'
+  },
+  southRidge: {
+    category: 'Infrastructure',
+    name: 'South Ridge',
+    filings: 0,
+    note: 'Material source. No registered residents.'
+  },
+  parkingLot: {
+    category: 'Public',
+    name: 'Parking Lot (South)',
+    filings: 1,
+    note: 'Telephone wire status under review.'
+  }
+};
+
+var districtMapState = {
+  activeElement: null,
+  sticky: false
+};
+
+function initDistrictMap() {
+  var map = document.getElementById('districtMap');
+  var popup = document.getElementById('districtMapPopup');
+  if (!map || !popup) return;
+
+  var categoryEl = document.getElementById('districtMapPopupCategory');
+  var titleEl = document.getElementById('districtMapPopupTitle');
+  var statsEl = document.getElementById('districtMapPopupStats');
+  var noteEl = document.getElementById('districtMapPopupNote');
+  var closeBtn = document.getElementById('districtMapPopupClose');
+  var canHover = window.matchMedia && window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+  var hotspots = Array.prototype.slice.call(map.querySelectorAll('.hotspot'));
+
+  function showPopup(element, sticky) {
+    var id = element.getAttribute('data-hotspot-id');
+    var data = districtMapHotspots[id];
+    if (!data) return;
+
+    hotspots.forEach(function(node) {
+      node.classList.toggle('is-active', node === element);
+      node.setAttribute('aria-expanded', node === element ? 'true' : 'false');
+    });
+
+    categoryEl.textContent = data.category;
+    titleEl.textContent = data.name;
+    statsEl.textContent = 'Filings: ' + data.filings;
+    noteEl.textContent = data.note;
+    popup.classList.add('is-visible');
+    districtMapState.activeElement = element;
+    districtMapState.sticky = Boolean(sticky);
+
+    window.requestAnimationFrame(function() {
+      positionMapPopup(element);
+    });
+  }
+
+  function hidePopup(force) {
+    if (districtMapState.sticky && !force) return;
+    popup.classList.remove('is-visible');
+    hotspots.forEach(function(node) {
+      node.classList.remove('is-active');
+      node.setAttribute('aria-expanded', 'false');
+    });
+    districtMapState.activeElement = null;
+    districtMapState.sticky = false;
+  }
+
+  function toggleSticky(element) {
+    if (districtMapState.sticky && districtMapState.activeElement === element) {
+      hidePopup(true);
+      return;
+    }
+    showPopup(element, true);
+  }
+
+  hotspots.forEach(function(element) {
+    element.setAttribute('aria-haspopup', 'true');
+    element.setAttribute('aria-expanded', 'false');
+    element.addEventListener('click', function(event) {
+      event.preventDefault();
+      event.stopPropagation();
+      toggleSticky(element);
+    });
+    element.addEventListener('keydown', function(event) {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleSticky(element);
+      }
+    });
+    element.addEventListener('focus', function() {
+      if (!districtMapState.sticky) showPopup(element, false);
+    });
+    element.addEventListener('blur', function() {
+      if (!districtMapState.sticky) hidePopup(false);
+    });
+    if (canHover) {
+      element.addEventListener('pointerenter', function() {
+        if (!districtMapState.sticky) showPopup(element, false);
+      });
+      element.addEventListener('pointerleave', function() {
+        if (!districtMapState.sticky) hidePopup(false);
+      });
+    }
+  });
+
+  closeBtn.addEventListener('click', function(event) {
+    event.stopPropagation();
+    var active = districtMapState.activeElement;
+    hidePopup(true);
+    if (active) active.focus();
+  });
+
+  document.addEventListener('pointerdown', function(event) {
+    if (!districtMapState.sticky) return;
+    var path = event.composedPath ? event.composedPath() : [];
+    if (path.indexOf(popup) !== -1 || path.indexOf(districtMapState.activeElement) !== -1) return;
+    hidePopup(true);
+  }, true);
+
+  document.addEventListener('keydown', function(event) {
+    if (event.key === 'Escape' && popup.classList.contains('is-visible')) {
+      var active = districtMapState.activeElement;
+      hidePopup(true);
+      if (active) active.focus();
+    }
+  });
+
+  window.addEventListener('resize', function() {
+    if (districtMapState.activeElement && popup.classList.contains('is-visible')) {
+      positionMapPopup(districtMapState.activeElement);
+    }
+  });
+}
+
+function positionMapPopup(anchor) {
+  var popup = document.getElementById('districtMapPopup');
+  if (!popup || !anchor) return;
+
+  var margin = 14;
+  var anchorRect = anchor.getBoundingClientRect();
+  var popupRect = popup.getBoundingClientRect();
+  var left = anchorRect.left + anchorRect.width / 2 + margin;
+  var top = anchorRect.top - popupRect.height - margin;
+
+  if (left + popupRect.width > window.innerWidth - margin) {
+    left = anchorRect.left - popupRect.width - margin;
+  }
+  if (top < margin) {
+    top = anchorRect.bottom + margin;
+  }
+
+  left = Math.max(margin, Math.min(left, window.innerWidth - popupRect.width - margin));
+  top = Math.max(margin, Math.min(top, window.innerHeight - popupRect.height - margin));
+  popup.style.left = left + 'px';
+  popup.style.top = top + 'px';
+}
+
 function openNoiseForm() {
   document.getElementById('noiseOverlay').classList.add('open');
   document.body.style.overflow = 'hidden';
@@ -763,6 +1654,8 @@ function handleNoiseSubmit() {
     document.getElementById('noiseRejection').scrollIntoView({ behavior: 'smooth', block: 'center' });
   }, 1200);
 }
+
+initDistrictMap();
 </script>
 
 </body>

--- a/is/writing/karen-hawk/index.html
+++ b/is/writing/karen-hawk/index.html
@@ -1001,19 +1001,15 @@
               <div class="seal-subtitle">Solo practitioner</div>
             </div>
           </div>
-          <div class="availability-badge">Available now</div>
         </div>
 
         <div class="consult-card">
-          <p class="mini-label">Office</p>
-          <p>11 Municipal Oak, Suite 4<br>Sycamore District</p>
+          <ul class="consult-points">
+            <li>Eighteen years in family law, including nest abandonment and pair-bond disputes.</li>
+            <li>Evening and weekend hours for birds who cannot be seen leaving during the day.</li>
+            <li>Consultations are confidential and do not obligate you to file before you know what the branch is worth.</li>
+          </ul>
         </div>
-
-        <ul class="consult-points">
-          <li>Eighteen years in family law, including nest abandonment and emergency filings.</li>
-          <li>Evening and weekend appointments for birds who only become honest after dusk.</li>
-          <li>Consultations are confidential and do not obligate you to file.</li>
-        </ul>
       </aside>
     </header>
 


### PR DESCRIPTION
## Summary
- Adds an interactive **District Map** (8 SVG hotspots, hover/click popups, legend, scale, compass) — all hotspots match `bird-universe/02-registry.md`.
- Adds **District at a Glance** stat panel (3×2 civic register) and a **From the Municipal Coo** excerpt block pointing at the real April 21, 2026 lead.
- Redesigns service cards: 4 category color keys, ordinance refs, navigation cues. Karen Hawk no longer full-width.
- Adds paper-grain texture, new CSS variable system (`--ink-stamp`, `--ink-archive`, category keys), heavier clerk-letter treatment.
- Removes the top "District Notice" box (intentional) and its orphaned CSS.

## Canon hygiene
- Dropped fake Coo masthead (`Vol. XII · No. 14`) — the Coo uses dated mastheads, not Volume/Number.
- Replaced placeholder headline with the actual April 21 published lead.
- Removed inline em dash + `.coo-dash` style.

## Test plan
- [ ] Visit `/is/writing/avian-district/` — page renders without console errors.
- [ ] Map: hover or tap each of the 8 hotspots; popup shows category, name, filings, note.
- [ ] Mobile (375px): stats grid collapses to 1 column; map labels hidden; hotspot hit area enlarged.
- [ ] All 5 bird-site links work and open in new tab (nest-court, bird-coo, secondnest, perch-chat, karen-hawk).
- [ ] Noise complaint form modal opens, accepts input, returns the rejection card on submit.
- [ ] `_scripts/bird-universe/check_bird_universe_links.py` passes (already verified locally + by pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)