### PR TITLE
Update reading + auto-rebuild root on stats.md changes

### DIFF
--- a/.github/workflows/rebuild-root-on-stats.yml
+++ b/.github/workflows/rebuild-root-on-stats.yml
@@ -1,0 +1,51 @@
+name: Rebuild root pages when stats.md changes
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "content/stats.md"
+      - "templates/root.html"
+      - "templates/running.html"
+      - "_scripts/build_root.py"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Rebuild index + running pages
+        run: python3 _scripts/build_root.py
+
+      - name: Check for changes
+        id: changes
+        run: |
+          git add index.html is/running/index.html
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit rebuilt pages
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Rebuild root pages from stats.md"
+
+      - name: Push rebuilt pages
+        if: steps.changes.outputs.changed == 'true'
+        run: git push

--- a/content/stats.md
+++ b/content/stats.md
@@ -9,8 +9,8 @@ since_year: 2009
 # Earth circumference: 40,075 km. Moon distance: 384,400 km.
 
 ## reading_current
-- The Knockout Queen — Rufi Thorpe
-- Elon Musk — Walter Isaacson
+- Nobody's Fool — Richard Russo
+- An Immense World — Ed Yong
 
 ## reading_year
 - Butter — Asako Yuzuki
@@ -19,6 +19,8 @@ since_year: 2009
 - Intimacies — Katie Kitamura
 - Real World — Natsuo Kirino
 - Woman Running in the Mountains — Yoko Tawada
+- The Knockout Queen — Rufi Thorpe
+- Elon Musk — Walter Isaacson
 - SPQR — Mary Beard (paused)
 
 ## learning

--- a/index.html
+++ b/index.html
@@ -177,10 +177,10 @@
   <div class="stanza">
     <div class="line"><span class="prefix">ajin.im is</span> <span class="verb">reading</span></div>
     <div class="detail">
-      <span class="work-title">The Knockout Queen</span> by Rufi Thorpe.<br>
-      <span class="work-title">Elon Musk</span> by Walter Isaacson.
+      <span class="work-title">Nobody's Fool</span> by Richard Russo.<br>
+      <span class="work-title">An Immense World</span> by Ed Yong.
       <div class="also">
-        also this year: Butter, Piglet, The Vegetarian, Intimacies, Real World, Woman Running in the Mountains. SPQR, paused.
+        also this year: Butter, Piglet, The Vegetarian, Intimacies, Real World, Woman Running in the Mountains, The Knockout Queen, Elon Musk. SPQR, paused.
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Move Knockout Queen and Elon Musk to also-this-year; currently reading Nobody's Fool (Russo) and An Immense World (Yong)
- Add workflow that auto-rebuilds index.html and is/running/index.html whenever content/stats.md (or related templates/build script) changes on master — so book updates from github.com web UI auto-publish without local tooling

## Test plan
- [x] `python3 _scripts/build_root.py` succeeds, regenerates index.html
- [x] Pre-push hooks pass
- [ ] After merge, edit content/stats.md via github.com web UI and confirm workflow rebuilds index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)