### PR TITLE
Add breathing room to deadend

### DIFF
--- a/is/writing/small/deadend/index.html
+++ b/is/writing/small/deadend/index.html
@@ -33,14 +33,14 @@
     max-width: 720px;
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 28px;
   }
 
   /* tighter visual groups */
   .group {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 14px;
   }
 
   /* --- Header --- */
@@ -110,7 +110,7 @@
   #diagnose {
     display: none;
     flex-direction: column;
-    gap: 10px;
+    gap: 26px;
   }
   #diagnose.visible { display: flex; }
 
@@ -130,13 +130,13 @@
   #distortions {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
+    gap: 10px;
   }
 
   .distortion {
     font-size: 11px;
     color: #888;
-    padding: 5px 9px;
+    padding: 8px 12px;
     border: 1px solid #2a2a2a;
     cursor: pointer;
     position: relative;
@@ -231,13 +231,13 @@
   .submit-btn:disabled { color: #2a2a2a; cursor: not-allowed; background: transparent; }
 
   #refute-prompt {
-    font-size: 12px;
+    font-size: 13px;
     color: #c8a878;
     font-style: italic;
-    line-height: 1.5;
+    line-height: 1.6;
     letter-spacing: 0.2px;
-    padding: 0 2px 4px;
-    min-height: 18px;
+    padding: 4px 2px;
+    min-height: 20px;
     opacity: 0;
     transition: opacity 0.2s;
   }


### PR DESCRIPTION
## Summary
- Looser spacing throughout — frame, diagnose, group gaps all increased
- Roomier chips (more padding, larger gaps between them)
- Slightly larger refute prompt with looser line-height

## Test plan
- [x] Desktop: layout feels open, not crammed
- [x] Mobile: chips wrap with spacing intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)