### PR TITLE
Rename 'small tools' category to 'Patches'

### DIFF
--- a/is/writing/index.html
+++ b/is/writing/index.html
@@ -78,7 +78,7 @@
           >
             <div class="room-copy">
               <p class="room-kicker">Room <span class="room-number"></span> / Live</p>
-              <h2>Small tools</h2>
+              <h2>Patches</h2>
               <span class="room-meta">ajin.im/is/writing/small</span>
             </div>
           </a>

--- a/is/writing/small/deadend/index.html
+++ b/is/writing/small/deadend/index.html
@@ -383,7 +383,7 @@
       <div id="reset">reset</div>
     </div>
 
-    <a id="back-link" href="/is/writing/small/">&larr; small tools</a>
+    <a id="back-link" href="/is/writing/small/">&larr; patches</a>
   </div>
 
   <script>

--- a/is/writing/small/index.html
+++ b/is/writing/small/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/png" href="/img/a3.png" />
     <link rel="apple-touch-icon" href="/img/a3.png" />
     <title>ajin.im/is/writing/small</title>
-    <meta name="description" content="Small tools for big questions." />
+    <meta name="description" content="Patches for big questions." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -22,10 +22,10 @@
       <header class="house-lede">
         <a class="back-link" href="/is/writing/">Back to the house</a>
         <p class="path-mark">ajin.im/is/writing/small</p>
-        <p class="house-whisper">Small tools for big questions.</p>
+        <p class="house-whisper">Patches for big questions.</p>
       </header>
 
-      <section class="house-frame" aria-label="Small tools">
+      <section class="house-frame" aria-label="Patches">
         <div class="house-grid" data-room-count="3" style="--desk-grid-rows: 4;">
           <a
             class="room"

--- a/is/writing/small/qol-or-inflation/index.html
+++ b/is/writing/small/qol-or-inflation/index.html
@@ -881,7 +881,7 @@
 </section>
 
 <footer>
-  <p>A thinking aid, not a measurement. — <a href="https://ajin.im/is/writing/small/">small tools</a></p>
+  <p>A thinking aid, not a measurement. — <a href="https://ajin.im/is/writing/small/">patches</a></p>
 </footer>
 
 </div>


### PR DESCRIPTION
## Summary
Display-name rename only. URL `/is/writing/small/` is unchanged so existing links and bookmarks keep working.

Updated:
- Writing house room title: "Small tools" → "Patches"
- /small/ shelf: whisper, meta description, aria-label
- deadend back link: "← small tools" → "← patches"
- qol-or-inflation footer link: "small tools" → "patches"

The room-meta on the writing house still shows `ajin.im/is/writing/small` since that's the actual URL.

## Test plan
- [x] Writing house shows "Patches" room
- [x] /small/ shelf shows "Patches for big questions."
- [x] deadend back link goes to /small/ with text "← patches"
- [x] qol-or-inflation footer link goes to /small/ with text "patches"

🤖 Generated with [Claude Code](https://claude.com/claude-code)