### PR TITLE
Make label tool's typing step optional

### DIFF
--- a/is/writing/small/label/index.html
+++ b/is/writing/small/label/index.html
@@ -178,6 +178,8 @@
   .option-button:focus-visible,
   .another-label:focus-visible,
   .reactive-answer:focus-visible,
+  .reactive-skip:focus-visible,
+  .reactive-next:focus-visible,
   .final-answer:focus-visible {
     outline: 3px solid rgba(255,107,91,0.24);
     outline-offset: 3px;
@@ -255,7 +257,7 @@
   }
 
   .reactive-question {
-    margin: 0 0 56px;
+    margin: 0 0 32px;
     color: var(--navy);
     font-size: 26px;
     font-weight: 700;
@@ -263,17 +265,13 @@
     line-height: 1.3;
   }
 
-  .input-wrapper {
-    padding: 18px 22px;
-    border: 2px solid var(--coral);
-    border-radius: 10px;
-    background: var(--paper);
-    box-shadow: 0 0 0 5px var(--coral-light);
-  }
-
   .reactive-answer {
+    display: block;
     width: 100%;
+    margin: 0 0 32px;
+    padding: 6px 0;
     border: 0;
+    border-bottom: 1.5px dashed #e0d4c8;
     outline: 0;
     background: transparent;
     color: var(--text);
@@ -282,8 +280,46 @@
     font-weight: 500;
   }
 
+  .reactive-answer:focus {
+    border-bottom-color: var(--coral);
+    border-bottom-style: solid;
+  }
+
   .reactive-answer::placeholder {
-    color: var(--text-faint);
+    color: var(--text-light);
+    font-weight: 400;
+    font-style: italic;
+  }
+
+  .reactive-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+  }
+
+  .reactive-skip,
+  .reactive-next {
+    display: inline-block;
+    padding: 8px 16px;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--coral-deep);
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 600;
+    transition: background 0.18s ease;
+  }
+
+  .reactive-skip {
+    color: var(--text-muted);
+  }
+
+  .reactive-skip:hover,
+  .reactive-skip:focus-visible,
+  .reactive-next:hover,
+  .reactive-next:focus-visible {
+    background: var(--coral-soft);
   }
 
   .final-header {
@@ -990,10 +1026,13 @@
     const question = item.questions[selected.questionIndex];
 
     renderCard(`
+      <p class="micro-instruction">Answer if you want, or sit with it.</p>
       <p class="reactive-statement">${escapeHtml(item.statement)}</p>
       <h1 class="reactive-question">${escapeHtml(question)}</h1>
-      <div class="input-wrapper">
-        <input class="reactive-answer" type="text" autocomplete="off" inputmode="text">
+      <input class="reactive-answer" type="text" autocomplete="off" enterkeyhint="done" placeholder="…" aria-label="Your answer">
+      <div class="reactive-actions">
+        <button class="reactive-skip" type="button">sit with it</button>
+        <button class="reactive-next" type="button">answer it &rarr;</button>
       </div>
     `, false);
 
@@ -1002,6 +1041,12 @@
     input.addEventListener('keydown', (event) => {
       if (event.key !== 'Enter') return;
       event.preventDefault();
+      submitReactiveAnswer(input.value);
+    });
+    document.querySelector('.reactive-skip').addEventListener('click', () => {
+      submitReactiveAnswer('');
+    });
+    document.querySelector('.reactive-next').addEventListener('click', () => {
       submitReactiveAnswer(input.value);
     });
   }


### PR DESCRIPTION
## Summary
- Replaces the coral search-bar input on the label tool's reactive screen with a softer dashed-underline writing line that matches the final screen's writing surface
- Adds an italic micro-instruction at the top: "Answer if you want, or sit with it."
- Adds two equal-weight ghost buttons — \`sit with it\` (skips with empty answer) and \`answer it →\` (submits typed value); Enter still works
- Adds \`enterkeyhint="done"\` and \`aria-label\` for mobile keyboard / a11y polish

## Why
Original UX forced typing to advance, but offered no instruction, no placeholder, and no visible submit button — user had to discover Enter. Worse, many of the questions ("Whose box?", "Pride, or relief?") read as provocations, not blanks-to-fill. The thesis at the end says "Questions stay open" — the old screen contradicted that by demanding an answer to advance. New design makes typing optional and gives explicit permission to leave a question open.

## Test plan
- [ ] Pick any label, pick a question, confirm the reactive screen shows instruction + statement + question + dashed input + two buttons
- [ ] Type something + Enter → advances to next statement
- [ ] Type something + click \`answer it\` → advances and stores text
- [ ] Click \`sit with it\` (with or without text typed) → advances with empty answer
- [ ] After 6 statements, final screen still shows triplets correctly with skipped answers as \`(empty)\` placeholder
- [ ] Mobile (375px): buttons fit on one row, input full width
- [ ] Returning to a partially-completed label resumes at the right statement

🤖 Generated with [Claude Code](https://claude.com/claude-code)