### PR TITLE
Reshape writing house, tier Small Ware, refresh loose page

### DIFF
--- a/creative-house.css
+++ b/creative-house.css
@@ -369,6 +369,10 @@ footer {
   color: var(--text);
 }
 
+.house-footer-aside {
+  margin-left: auto;
+}
+
 .writing-house .house-stage {
   position: relative;
 }

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ajin im</title>
+<meta name="description" content="Ajin Im — running, reading, learning, writing. A creative house at /is/writing/ including the Bureau of Interior Conditions and the Avian Municipal District.">
 <link rel="icon" type="image/png" href="/img/a1.png">
 <link rel="apple-touch-icon" href="/img/a1.png">
 <script src="/analytics.js" defer></script>

--- a/is/running/index.html
+++ b/is/running/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ajin.im is running</title>
+<meta name="description" content="Ajin Im's running log — about 75,000 km since 2009, tracked toward earth-to-moon mileage.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;1,8..60,400&family=IBM+Plex+Mono:wght@300;400&display=swap" rel="stylesheet">

--- a/is/writing/bird-docket/index.html
+++ b/is/writing/bird-docket/index.html
@@ -37,7 +37,7 @@
         <div class="bird-directory-list">
           <article class="bird-directory-entry">
             <h2>
-              <a href="../avian-district/index.html" target="_blank" rel="noreferrer noopener">Avian Municipal District</a>
+              <a href="/is/writing/avian-district/" target="_blank" rel="noreferrer noopener">Avian Municipal District</a>
               <span class="bird-directory-kind">Official portal</span>
             </h2>
             <p>Clerk-maintained district portal for services, notices, public records, and the official version of events.</p>
@@ -45,7 +45,7 @@
 
           <article class="bird-directory-entry">
             <h2>
-              <a href="../nest-court/index.html" target="_blank" rel="noreferrer noopener">Avian Municipal Nest Court</a>
+              <a href="/is/writing/nest-court/" target="_blank" rel="noreferrer noopener">Avian Municipal Nest Court</a>
               <span class="bird-directory-kind">Court portal</span>
             </h2>
             <p>Case lookup, filings, and calendars. The municipal belief that a portal improves morale.</p>
@@ -53,7 +53,7 @@
 
           <article class="bird-directory-entry">
             <h2>
-              <a href="../perch-chat/index.html" target="_blank" rel="noreferrer noopener">The Perch</a>
+              <a href="/is/writing/perch-chat/" target="_blank" rel="noreferrer noopener">The Perch</a>
               <span class="bird-directory-kind">District service</span>
             </h2>
             <p>Community chat maintained by the Clerk's Office. For municipal coordination purposes.</p>
@@ -61,7 +61,7 @@
 
           <article class="bird-directory-entry">
             <h2>
-              <a href="../karen-hawk/index.html" target="_blank" rel="noreferrer noopener">Karen Hawk, Attorney at Law</a>
+              <a href="/is/writing/karen-hawk/" target="_blank" rel="noreferrer noopener">Karen Hawk, Attorney at Law</a>
               <span class="bird-directory-kind">Licensed practitioner</span>
             </h2>
             <p>Solo practice for nest abandonment, no-perch orders, and the hour after a bird says they need space.</p>
@@ -69,7 +69,7 @@
 
           <article class="bird-directory-entry">
             <h2>
-              <a href="../secondnest/index.html" target="_blank" rel="noreferrer noopener">SecondNest</a>
+              <a href="/is/writing/secondnest/" target="_blank" rel="noreferrer noopener">SecondNest</a>
               <span class="bird-directory-kind">New</span>
             </h2>
             <p>Text-based personals for district residents. Free. No photos. For birds who know better now.</p>
@@ -77,7 +77,7 @@
 
           <article class="bird-directory-entry">
             <h2>
-              <a href="../bird-coo/index.html" target="_blank" rel="noreferrer noopener">The Municipal Coo</a>
+              <a href="/is/writing/bird-coo/" target="_blank" rel="noreferrer noopener">The Municipal Coo</a>
               <span class="bird-directory-kind">Newspaper</span>
             </h2>
             <p>Local notices, public embarrassment, classifieds, and the weather as reported by rumor. Published weekly.</p>
@@ -85,7 +85,7 @@
 
           <article class="bird-directory-entry">
             <h2>
-              <a href="../nest-court-proceedings/index.html" target="_blank" rel="noreferrer noopener">Proceedings Registry</a>
+              <a href="/is/writing/nest-court-proceedings/" target="_blank" rel="noreferrer noopener">Proceedings Registry</a>
               <span class="bird-directory-kind">Court records</span>
             </h2>
             <p>What was said, what was struck, and what somehow entered the record anyway.</p>

--- a/is/writing/comedy/farewell-to-the-pen-that-just-fell-behind-the-desk/index.html
+++ b/is/writing/comedy/farewell-to-the-pen-that-just-fell-behind-the-desk/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/png" href="/img/a3.png" />
     <link rel="apple-touch-icon" href="/img/a3.png" />
     <title>Farewell to the Pen That Just Fell Behind The Desk | ajin.im/is/writing/comedy</title>
-    <meta name="description" content="I just can’t even" />
+    <meta name="description" content="I just can’t even. A short comedy piece by Ajin Im." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/is/writing/comedy/i-would-hurt-a-fly/index.html
+++ b/is/writing/comedy/i-would-hurt-a-fly/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/png" href="/img/a3.png" />
     <link rel="apple-touch-icon" href="/img/a3.png" />
     <title>I Would Hurt a Fly | ajin.im/is/writing/comedy</title>
-    <meta name="description" content="Emotionally that is" />
+    <meta name="description" content="Emotionally that is. A short comedy piece by Ajin Im." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/is/writing/comedy/step-on-me-please/index.html
+++ b/is/writing/comedy/step-on-me-please/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/png" href="/img/a3.png" />
     <link rel="apple-touch-icon" href="/img/a3.png" />
     <title>Step on Me Please | ajin.im/is/writing/comedy</title>
-    <meta name="description" content="Step on Me Please" />
+    <meta name="description" content="Step on Me Please. A short comedy piece by Ajin Im." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/is/writing/desk/index.html
+++ b/is/writing/desk/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/img/a3.png" />
     <link rel="apple-touch-icon" href="/img/a3.png" />
-    <title>Moved to loose pieces</title>
+    <title>Moved to loose pages</title>
     <meta http-equiv="refresh" content="0; url=/is/writing/loose/" />
     <link rel="canonical" href="https://ajin.im/is/writing/loose/" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -19,12 +19,12 @@
   <body class="archive-page">
     <main class="archive-shell">
       <header class="archive-head">
-        <a class="back-link" href="/is/writing/loose/">Continue to loose pieces</a>
+        <a class="back-link" href="/is/writing/loose/">Continue to loose pages</a>
         <p class="path-mark">ajin.im wrote desk</p>
-        <h1 class="sentence">The desk became loose pieces.</h1>
+        <h1 class="sentence">The desk became loose pages.</h1>
         <p class="archive-intro">
-          Old links still land somewhere sensible. Essays, comedy, and other stray
-          writing live at <a href="/is/writing/loose/">ajin.im/is/writing/loose</a>.
+          Old links still land somewhere sensible. Essays and older comedy live at
+          <a href="/is/writing/loose/">ajin.im/is/writing/loose</a>.
         </p>
       </header>
     </main>

--- a/is/writing/essays/every-few-years/index.html
+++ b/is/writing/essays/every-few-years/index.html
@@ -264,7 +264,7 @@
 
 <!-- ============= BACK LINK ============= -->
 <nav class="essay-back">
-  <a href="/is/writing/loose/">&larr; Back to loose pieces</a>
+  <a href="/is/writing/loose/">&larr; Back to loose pages</a>
 </nav>
 
 <!-- ============= HERO ============= -->

--- a/is/writing/index.html
+++ b/is/writing/index.html
@@ -24,11 +24,11 @@
     <main class="house-stage">
       <header class="house-lede">
         <p class="path-mark">ajin.im/is/writing</p>
-        <p class="house-whisper"><span class="pulse-count">Four</span> rooms lit tonight.</p>
+        <p class="house-whisper"><span class="pulse-count">Three</span> rooms lit tonight.</p>
       </header>
 
       <section class="house-frame" aria-label="Creative rooms">
-        <div class="house-grid" data-room-count="4" style="--desk-grid-rows: 7;">
+        <div class="house-grid" data-room-count="3" style="--desk-grid-rows: 7;">
           <a
             class="room room-featured"
             href="https://propagandaformyself.xyz"
@@ -48,7 +48,7 @@
             class="room"
             href="./avian-district/index.html"
             data-room="birds"
-            style="--room-index: 1; --desk-col-start: 1; --desk-col-span: 6; --desk-row-start: 5; --desk-row-span: 3; --desk-min-height: 15rem;"
+            style="--room-index: 1; --desk-col-start: 1; --desk-col-span: 12; --desk-row-start: 5; --desk-row-span: 3; --desk-min-height: 15rem;"
           >
             <div class="room-copy">
               <p class="room-kicker">Room <span class="room-number"></span> / Active</p>
@@ -58,23 +58,10 @@
           </a>
 
           <a
-            class="room"
-            href="/is/writing/loose/"
-            data-room="loose"
-            style="--room-index: 2; --desk-col-start: 7; --desk-col-span: 6; --desk-row-start: 5; --desk-row-span: 3; --desk-min-height: 15rem;"
-          >
-            <div class="room-copy">
-              <p class="room-kicker">Room <span class="room-number"></span> / Live</p>
-              <h2>Loose pieces</h2>
-              <span class="room-meta">ajin.im/is/writing/loose</span>
-            </div>
-          </a>
-
-          <a
             class="room room-wide"
             href="/is/writing/small/"
             data-room="small-ware"
-            style="--room-index: 3; --desk-col-start: 8; --desk-col-span: 5; --desk-row-start: 1; --desk-row-span: 4; --desk-min-height: 23rem;"
+            style="--room-index: 2; --desk-col-start: 8; --desk-col-span: 5; --desk-row-start: 1; --desk-row-span: 4; --desk-min-height: 23rem;"
           >
             <div class="room-copy">
               <p class="room-kicker">Room <span class="room-number"></span> / Live</p>
@@ -90,6 +77,7 @@
         <p class="house-footer-line">
           <a href="mailto:contact@ajin.im">contact@ajin.im</a>
           <span>· Seoul</span>
+          <a class="house-footer-aside" href="/is/writing/loose/">more writing &rarr;</a>
         </p>
       </footer>
     </main>

--- a/is/writing/loose/index.html
+++ b/is/writing/loose/index.html
@@ -8,7 +8,7 @@
     <title>ajin.im/is/writing/loose</title>
     <meta
       name="description"
-      content="Essays, comedy, and other stray writing by Ajin Im."
+      content="Loose pages by Ajin Im &mdash; essays in the present voice and a comedy archive from the Medium years (2022&ndash;2023)."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -57,16 +57,15 @@
       <header class="archive-head">
         <a class="back-link" href="/is/writing/">Back to the house</a>
         <p class="path-mark">ajin.im is writing loose</p>
-        <h1 class="sentence">Loose pieces, sharing one surface.</h1>
+        <h1 class="sentence">Loose pages &mdash; essays &amp; older comedy.</h1>
         <p class="archive-intro">
-          Essays, comedy, and other stray writing. Essays are ongoing; most comedy pieces
-          are from the Medium years (2022&ndash;2023).
+          Essays in the present voice. The comedy is from the Medium years (2022&ndash;2023).
         </p>
       </header>
 
       <section class="archive-grid">
         <article class="archive-panel archive-panel-wide">
-          <h2 class="panel-title">Loose pieces</h2>
+          <h2 class="panel-title">Essays</h2>
 
           <div class="archive-list">
 

--- a/is/writing/nest-court-proceedings-pigeon/index.html
+++ b/is/writing/nest-court-proceedings-pigeon/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>District v. Pigeon — Gallery Assessment</title>
+<meta name="description" content="Avian Municipal Nest Court — District v. Pigeon (J.) (AMNC-2024-119A). A gallery assessment of the proceedings.">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='45' fill='none' stroke='%231B2A3D' stroke-width='4'/><circle cx='50' cy='50' r='38' fill='none' stroke='%23B8963E' stroke-width='2'/><path d='M30 62C36 52 42 48 50 48C58 48 64 52 70 62C64 72 58 76 50 76C42 76 36 72 30 62Z' fill='none' stroke='%231B2A3D' stroke-width='3'/><ellipse cx='44' cy='58' rx='4' ry='5' fill='none' stroke='%231B2A3D' stroke-width='2'/><ellipse cx='56' cy='58' rx='4' ry='5' fill='none' stroke='%231B2A3D' stroke-width='2'/></svg>">
 <style>
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400&family=Source+Serif+4:ital,wght@0,400;0,500;1,400&family=IBM+Plex+Sans:wght@300;400;500&display=swap');

--- a/is/writing/nest-court-proceedings-starling/index.html
+++ b/is/writing/nest-court-proceedings-starling/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Starling v. Starling — Gallery Assessment</title>
+<meta name="description" content="Avian Municipal Nest Court — Starling v. Starling (AMNC-2025-022C). A gallery assessment of the proceedings.">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='45' fill='none' stroke='%231B2A3D' stroke-width='4'/><circle cx='50' cy='50' r='38' fill='none' stroke='%23B8963E' stroke-width='2'/><path d='M30 62C36 52 42 48 50 48C58 48 64 52 70 62C64 72 58 76 50 76C42 76 36 72 30 62Z' fill='none' stroke='%231B2A3D' stroke-width='3'/><ellipse cx='44' cy='58' rx='4' ry='5' fill='none' stroke='%231B2A3D' stroke-width='2'/><ellipse cx='56' cy='58' rx='4' ry='5' fill='none' stroke='%231B2A3D' stroke-width='2'/></svg>">
 <style>
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400&family=Source+Serif+4:ital,wght@0,400;0,500;1,400&family=IBM+Plex+Sans:wght@300;400;500&display=swap');

--- a/is/writing/nest-court-proceedings/index.html
+++ b/is/writing/nest-court-proceedings/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Dove v. Dove — Gallery Assessment</title>
+<meta name="description" content="Avian Municipal Nest Court — Dove v. Dove (AMNC-2026-007B). A gallery assessment of the proceedings.">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='45' fill='none' stroke='%231B2A3D' stroke-width='4'/><circle cx='50' cy='50' r='38' fill='none' stroke='%23B8963E' stroke-width='2'/><path d='M30 62C36 52 42 48 50 48C58 48 64 52 70 62C64 72 58 76 50 76C42 76 36 72 30 62Z' fill='none' stroke='%231B2A3D' stroke-width='3'/><ellipse cx='44' cy='58' rx='4' ry='5' fill='none' stroke='%231B2A3D' stroke-width='2'/><ellipse cx='56' cy='58' rx='4' ry='5' fill='none' stroke='%231B2A3D' stroke-width='2'/></svg>">
 <style>
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400&family=Source+Serif+4:ital,wght@0,400;0,500;1,400&family=IBM+Plex+Sans:wght@300;400;500&display=swap');

--- a/is/writing/nest-court/index.html
+++ b/is/writing/nest-court/index.html
@@ -932,7 +932,7 @@
           </tr>
           <tr class="docket-row active-case" data-case="AMNC-2026-007B">
             <td><span class="case-link">AMNC-2026-007B</span></td>
-            <td><a href="../nest-court-proceedings/" class="case-caption-link" target="_blank"><strong>Dove v. Dove</strong></a></td>
+            <td><a href="/is/writing/nest-court-proceedings/" class="case-caption-link" target="_blank"><strong>Dove v. Dove</strong></a></td>
             <td>Nest Abandonment</td>
             <td>Feb 12, 2026</td>
             <td><span class="status-badge status-active">Active</span></td>
@@ -953,14 +953,14 @@
           </tr>
           <tr class="docket-row" data-case="AMNC-2025-022C">
             <td><span class="case-link">AMNC-2025-022C</span></td>
-            <td><a href="../nest-court-proceedings-starling/" class="case-caption-link" target="_blank">Starling v. Starling</a></td>
+            <td><a href="/is/writing/nest-court-proceedings-starling/" class="case-caption-link" target="_blank">Starling v. Starling</a></td>
             <td>Egg Custody</td>
             <td>Jun 02, 2025</td>
             <td><span class="status-badge status-closed">Closed</span></td>
           </tr>
           <tr class="docket-row" data-case="AMNC-2024-119A">
             <td><span class="case-link">AMNC-2024-119A</span></td>
-            <td><a href="../nest-court-proceedings-pigeon/" class="case-caption-link" target="_blank">Avian Mun. Dist. v. Pigeon (J.)</a></td>
+            <td><a href="/is/writing/nest-court-proceedings-pigeon/" class="case-caption-link" target="_blank">Avian Mun. Dist. v. Pigeon (J.)</a></td>
             <td>Noise / Nuisance</td>
             <td>Dec 14, 2024</td>
             <td><span class="status-badge status-closed">Closed</span></td>
@@ -1555,7 +1555,7 @@
 
         </div><!-- /filings-list dove -->
         <div class="panel-actions">
-          <a href="../nest-court-proceedings/" class="btn-gallery" target="_blank">View Gallery Assessment &rarr;</a>
+          <a href="/is/writing/nest-court-proceedings/" class="btn-gallery" target="_blank">View Gallery Assessment &rarr;</a>
         </div>
       </div>
 
@@ -1955,7 +1955,7 @@
 
         </div><!-- /filings-list starling -->
         <div class="panel-actions">
-          <a href="../nest-court-proceedings-starling/" class="btn-gallery" target="_blank">View Gallery Assessment &rarr;</a>
+          <a href="/is/writing/nest-court-proceedings-starling/" class="btn-gallery" target="_blank">View Gallery Assessment &rarr;</a>
         </div>
       </div>
 
@@ -2083,7 +2083,7 @@
 
         </div><!-- /filings-list pigeon -->
         <div class="panel-actions">
-          <a href="../nest-court-proceedings-pigeon/" class="btn-gallery" target="_blank">View Gallery Assessment &rarr;</a>
+          <a href="/is/writing/nest-court-proceedings-pigeon/" class="btn-gallery" target="_blank">View Gallery Assessment &rarr;</a>
         </div>
       </div>
 

--- a/is/writing/secondnest/index.html
+++ b/is/writing/secondnest/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>SecondNest</title>
+<meta name="description" content="SecondNest — text-based personals for residents of the Avian Municipal District. Free. No photos. For birds who know better now.">
 <link rel="icon" type="image/png" sizes="32x32" href="./favicon.png">
 <style>
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;1,400&family=Courier+Prime:ital,wght@0,400;0,700;1,400&family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;1,300;1,400&display=swap');

--- a/is/writing/small/deadend/index.html
+++ b/is/writing/small/deadend/index.html
@@ -6,6 +6,7 @@
 <link rel="icon" type="image/png" href="/img/a3.png" >
 <link rel="apple-touch-icon" href="/img/a3.png" >
 <title>deadend</title>
+<meta name="description" content="deadend — a small tool for getting out of a thought that goes nowhere.">
 <script src="../../../../analytics.js" defer></script>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/is/writing/small/index.html
+++ b/is/writing/small/index.html
@@ -26,17 +26,17 @@
       </header>
 
       <section class="house-frame" aria-label="Small Ware">
-        <div class="house-grid" data-room-count="5" style="--desk-grid-rows: 12;">
+        <div class="house-grid" data-room-count="5" style="--desk-grid-rows: 9;">
           <a
-            class="room"
+            class="room room-featured"
             href="https://debugu.xyz"
             target="_blank"
             rel="noreferrer noopener"
             data-room="debugu"
-            style="--room-index: 0; --desk-col-start: 1; --desk-col-span: 6; --desk-row-start: 1; --desk-row-span: 4; --desk-min-height: 23rem;"
+            style="--room-index: 0; --desk-col-start: 1; --desk-col-span: 12; --desk-row-start: 1; --desk-row-span: 4; --desk-min-height: 24rem;"
           >
             <div class="room-copy">
-              <p class="room-kicker">Tool <span class="room-number"></span> / Live</p>
+              <p class="room-kicker">Tool <span class="room-number"></span> / Featured</p>
               <h2>debug::u</h2>
               <span class="room-meta">a diagnostic console for what you're feeling.</span>
             </div>
@@ -44,27 +44,14 @@
 
           <a
             class="room"
-            href="/is/writing/small/deadend/"
-            data-room="deadend"
-            style="--room-index: 1; --desk-col-start: 7; --desk-col-span: 6; --desk-row-start: 1; --desk-row-span: 4; --desk-min-height: 23rem;"
+            href="/is/writing/small/questions/"
+            data-room="questions"
+            style="--room-index: 1; --desk-col-start: 1; --desk-col-span: 6; --desk-row-start: 5; --desk-row-span: 3; --desk-min-height: 16rem;"
           >
             <div class="room-copy">
               <p class="room-kicker">Tool <span class="room-number"></span> / Live</p>
-              <h2>deadend</h2>
-              <span class="room-meta">for getting out of your thought that goes nowhere.</span>
-            </div>
-          </a>
-
-          <a
-            class="room"
-            href="/is/writing/small/label/"
-            data-room="label"
-            style="--room-index: 2; --desk-col-start: 1; --desk-col-span: 6; --desk-row-start: 5; --desk-row-span: 4; --desk-min-height: 23rem;"
-          >
-            <div class="room-copy">
-              <p class="room-kicker">Tool <span class="room-number"></span> / Live</p>
-              <h2>label</h2>
-              <span class="room-meta">for taking apart the labels you give yourself.</span>
+              <h2>who's asking</h2>
+              <span class="room-meta">spot the tell — questions or observations, real or wearing a mask.</span>
             </div>
           </a>
 
@@ -72,7 +59,7 @@
             class="room"
             href="/is/writing/small/qol-or-inflation/"
             data-room="qol-or-inflation"
-            style="--room-index: 3; --desk-col-start: 7; --desk-col-span: 6; --desk-row-start: 5; --desk-row-span: 4; --desk-min-height: 23rem;"
+            style="--room-index: 2; --desk-col-start: 7; --desk-col-span: 6; --desk-row-start: 5; --desk-row-span: 3; --desk-min-height: 16rem;"
           >
             <div class="room-copy">
               <p class="room-kicker">Tool <span class="room-number"></span> / Live</p>
@@ -83,14 +70,27 @@
 
           <a
             class="room"
-            href="/is/writing/small/questions/"
-            data-room="questions"
-            style="--room-index: 4; --desk-col-start: 1; --desk-col-span: 12; --desk-row-start: 9; --desk-row-span: 4; --desk-min-height: 23rem;"
+            href="/is/writing/small/label/"
+            data-room="label"
+            style="--room-index: 3; --desk-col-start: 1; --desk-col-span: 6; --desk-row-start: 8; --desk-row-span: 2; --desk-min-height: 10rem;"
           >
             <div class="room-copy">
-              <p class="room-kicker">Tool <span class="room-number"></span> / Live</p>
-              <h2>who's asking</h2>
-              <span class="room-meta">spot the tell — questions or observations, real or wearing a mask.</span>
+              <p class="room-kicker">Tool <span class="room-number"></span> / Quiet</p>
+              <h2>label</h2>
+              <span class="room-meta">for taking apart the labels you give yourself.</span>
+            </div>
+          </a>
+
+          <a
+            class="room"
+            href="/is/writing/small/deadend/"
+            data-room="deadend"
+            style="--room-index: 4; --desk-col-start: 7; --desk-col-span: 6; --desk-row-start: 8; --desk-row-span: 2; --desk-min-height: 10rem;"
+          >
+            <div class="room-copy">
+              <p class="room-kicker">Tool <span class="room-number"></span> / Quiet</p>
+              <h2>deadend</h2>
+              <span class="room-meta">for getting out of your thought that goes nowhere.</span>
             </div>
           </a>
         </div>

--- a/is/writing/small/qol-or-inflation/index.html
+++ b/is/writing/small/qol-or-inflation/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Quality of Life, or Inflation?</title>
+<meta name="description" content="Quality of life, or inflation? A small tool for sorting real upgrades from creeping baselines.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -881,7 +882,7 @@
 </section>
 
 <footer>
-  <p>A thinking aid, not a measurement. — <a href="https://ajin.im/is/writing/small/">small ware</a></p>
+  <p>A thinking aid, not a measurement. — <a href="/is/writing/small/">small ware</a></p>
 </footer>
 
 </div>


### PR DESCRIPTION
## Summary

- **/is/writing/** trimmed to 3 lit rooms (BIC, AMD, Small Ware). Loose demoted from a room tile to a quiet `more writing →` footer link, right-pinned opposite the identity stamp.
- **AMD** widened to the full bottom band; whisper updated to "Three rooms lit tonight."
- **/is/writing/small/** gained a Featured / Live / Quiet hierarchy:
  - Featured: `debug::u` (full-width top)
  - Live: `who's asking` + `qol or inflation`
  - Quiet: `label` + `deadend` (compact bottom pair)
- **/is/writing/loose/** reframed: renamed from "Loose pieces, sharing one surface" to **"Loose pages — essays & older comedy"** with an explicit subtitle and a clear "Essays" section header. URL preserved at `/loose/` so existing links still work; downstream copy updated on the every-few-years essay back-link and the desk redirect stub.
- **Mechanical hygiene** ridden along: 11 relative paths in bird-docket and nest-court converted to root-relative; meta descriptions added to homepage, /is/running/, secondnest, 3 nest-court-proceedings galleries, qol-or-inflation, deadend; 3 short comedy descriptions extended past the 20-char threshold; qol-or-inflation footer link converted from absolute to root-relative.

## Test plan

- [x] Bird-universe link validator passes (10 registry entries OK)
- [x] Identifier linter passes (14 cases registered, 0 warnings)
- [x] /is/writing/ renders 3 rooms with AMD spanning the bottom band
- [x] /is/writing/small/ renders Featured / Live / Quiet hierarchy correctly
- [x] /is/writing/loose/ renders new H1 + subtitle + "Essays" section header
- [x] Footer link `more writing →` pinned right at desktop width
- [x] Bird-docket renders with all 7 directory entries linked correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)