### PR TITLE
Update running templates so Strava rebuilds stop reverting design

### DIFF
--- a/_scripts/build_root.py
+++ b/_scripts/build_root.py
@@ -196,6 +196,7 @@ def build(check_only: bool = False) -> None:
     total_km_fmt = f"{total_km:,}"
     remaining_km = MOON_KM - total_km
     remaining_fmt = f"{remaining_km:,}"
+    moon_pct_fmt = f"{round(total_km / MOON_KM * 100, 1)}"
     earth = earth_prose(total_km)
     earth_mult = earth_multiplier(total_km)
 
@@ -215,6 +216,7 @@ def build(check_only: bool = False) -> None:
         "{{running_earth_prose}}": earth,
         "{{running_earth_multiplier}}": earth_mult,
         "{{running_moon_remaining}}": remaining_fmt,
+        "{{running_moon_pct}}": moon_pct_fmt,
         "{{reading_current}}": reading_current_html,
         "{{reading_year}}": reading_year_str,
         "{{learning}}": learning,

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
 <main>
 
   <div class="stanza">
-    <div class="line"><span class="prefix">ajin.im is</span> <span class="verb">running to the moon</span></div>
+    <div class="line"><span class="prefix">ajin.im is</span> <span class="verb"><a href="/is/running">running</a></span></div>
     <div class="detail">
       ~75,280 km running since 2009, nearly twice around earth.<br>
       309,120 km left until the moon.

--- a/is/running/index.html
+++ b/is/running/index.html
@@ -107,27 +107,60 @@
     letter-spacing: 0.02em;
   }
 
-  /* prose sections */
-  .prose {
-    color: var(--text-soft);
-    font-size: 1rem;
-    line-height: 1.7;
-    margin-bottom: 2.2rem;
+  /* trail: earth → runner → moon */
+  .trail {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 1.4rem 0 0.6rem;
   }
 
-  .prose.first { animation: fade 0.9s ease-out 0.4s both; }
-  .prose.second { animation: fade 0.9s ease-out 0.55s both; }
+  .trail .endpoint {
+    font-size: 1.35rem;
+    line-height: 1;
+    flex-shrink: 0;
+    filter: saturate(0.85);
+  }
 
-  .prose p { margin-bottom: 1rem; }
-  .prose p:last-child { margin-bottom: 0; }
-
-  .prose .em { color: var(--text); font-style: italic; }
-
-  .divider {
-    width: 40px;
+  .trail .track {
+    position: relative;
+    flex: 1;
     height: 1px;
     background: var(--rule);
-    margin: 2.8rem 0;
+  }
+
+  .trail .track-fill {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: var(--progress);
+    background: linear-gradient(to right, transparent, rgba(232, 224, 208, 0.4));
+    animation: trail-fill 1.8s cubic-bezier(0.4, 0, 0.2, 1) 1s both;
+  }
+
+  .trail .runner {
+    position: absolute;
+    top: 50%;
+    left: var(--progress);
+    font-size: 1.15rem;
+    line-height: 1;
+    transform: translate(-50%, -50%) scaleX(-1);
+    animation: trail-runner 1.8s cubic-bezier(0.4, 0, 0.2, 1) 1s both,
+               trail-bob 1.4s ease-in-out 2.9s infinite;
+  }
+
+  @keyframes trail-fill {
+    from { width: 0; }
+    to   { width: var(--progress); }
+  }
+
+  @keyframes trail-runner {
+    from { left: 0; }
+    to   { left: var(--progress); }
+  }
+
+  @keyframes trail-bob {
+    0%, 100% { transform: translate(-50%, -50%) scaleX(-1); }
+    50%      { transform: translate(-50%, -78%) scaleX(-1); }
   }
 
   @keyframes fade {
@@ -140,8 +173,9 @@
     .title { font-size: 1.18rem; margin-bottom: 2.5rem; }
     .stat-value { font-size: 1.2rem; min-width: 6rem; }
     .stat-label { font-size: 0.88rem; }
-    .prose { font-size: 0.96rem; }
-    .divider { margin: 2.2rem 0; }
+    .trail { gap: 0.55rem; padding: 1.1rem 0 0.5rem; }
+    .trail .endpoint { font-size: 1.2rem; }
+    .trail .runner { font-size: 1rem; }
   }
 </style>
 </head>
@@ -166,29 +200,17 @@
       <div class="stat-value">309,120 km</div>
       <div class="stat-label">to the moon</div>
     </div>
+
+    <div class="trail" style="--progress: 19.6%" role="img" aria-label="19.6% of the way to the moon">
+      <span class="endpoint" aria-hidden="true">🌍</span>
+      <div class="track">
+        <div class="track-fill"></div>
+        <span class="runner" aria-hidden="true">🏃</span>
+      </div>
+      <span class="endpoint" aria-hidden="true">🌕</span>
+    </div>
+
     <div class="updated">updated daily</div>
-  </div>
-
-  <div class="divider"></div>
-
-  <div class="prose first">
-    <p>
-      The <span class="em">common swift</span> spends almost its entire life in the air. Over a lifetime it covers roughly two million miles, about four round trips to the moon.
-    </p>
-    <p>
-      One trip is enough for me.
-    </p>
-  </div>
-
-  <div class="divider"></div>
-
-  <div class="prose second">
-    <p>
-      I've been running at least 10 km a day since 2009, and 15 km since 2017. I don't always wear the watch, so the numbers above aren't exact.
-    </p>
-    <p>
-      The earth is 40,075 km around. The moon is 384,400 km from here. If I keep going, I should make it.
-    </p>
   </div>
 
 </main>

--- a/templates/root.html
+++ b/templates/root.html
@@ -167,7 +167,7 @@
 <main>
 
   <div class="stanza">
-    <div class="line"><span class="prefix">ajin.im is</span> <span class="verb">running to the moon</span></div>
+    <div class="line"><span class="prefix">ajin.im is</span> <span class="verb"><a href="/is/running">running</a></span></div>
     <div class="detail">
       ~{{running_total_km}} km running since {{running_since}}, {{running_earth_prose}}.<br>
       {{running_moon_remaining}} km left until the moon.

--- a/templates/running.html
+++ b/templates/running.html
@@ -107,27 +107,60 @@
     letter-spacing: 0.02em;
   }
 
-  /* prose sections */
-  .prose {
-    color: var(--text-soft);
-    font-size: 1rem;
-    line-height: 1.7;
-    margin-bottom: 2.2rem;
+  /* trail: earth → runner → moon */
+  .trail {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 1.4rem 0 0.6rem;
   }
 
-  .prose.first { animation: fade 0.9s ease-out 0.4s both; }
-  .prose.second { animation: fade 0.9s ease-out 0.55s both; }
+  .trail .endpoint {
+    font-size: 1.35rem;
+    line-height: 1;
+    flex-shrink: 0;
+    filter: saturate(0.85);
+  }
 
-  .prose p { margin-bottom: 1rem; }
-  .prose p:last-child { margin-bottom: 0; }
-
-  .prose .em { color: var(--text); font-style: italic; }
-
-  .divider {
-    width: 40px;
+  .trail .track {
+    position: relative;
+    flex: 1;
     height: 1px;
     background: var(--rule);
-    margin: 2.8rem 0;
+  }
+
+  .trail .track-fill {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: var(--progress);
+    background: linear-gradient(to right, transparent, rgba(232, 224, 208, 0.4));
+    animation: trail-fill 1.8s cubic-bezier(0.4, 0, 0.2, 1) 1s both;
+  }
+
+  .trail .runner {
+    position: absolute;
+    top: 50%;
+    left: var(--progress);
+    font-size: 1.15rem;
+    line-height: 1;
+    transform: translate(-50%, -50%) scaleX(-1);
+    animation: trail-runner 1.8s cubic-bezier(0.4, 0, 0.2, 1) 1s both,
+               trail-bob 1.4s ease-in-out 2.9s infinite;
+  }
+
+  @keyframes trail-fill {
+    from { width: 0; }
+    to   { width: var(--progress); }
+  }
+
+  @keyframes trail-runner {
+    from { left: 0; }
+    to   { left: var(--progress); }
+  }
+
+  @keyframes trail-bob {
+    0%, 100% { transform: translate(-50%, -50%) scaleX(-1); }
+    50%      { transform: translate(-50%, -78%) scaleX(-1); }
   }
 
   @keyframes fade {
@@ -140,8 +173,9 @@
     .title { font-size: 1.18rem; margin-bottom: 2.5rem; }
     .stat-value { font-size: 1.2rem; min-width: 6rem; }
     .stat-label { font-size: 0.88rem; }
-    .prose { font-size: 0.96rem; }
-    .divider { margin: 2.2rem 0; }
+    .trail { gap: 0.55rem; padding: 1.1rem 0 0.5rem; }
+    .trail .endpoint { font-size: 1.2rem; }
+    .trail .runner { font-size: 1rem; }
   }
 </style>
 </head>
@@ -166,29 +200,17 @@
       <div class="stat-value">{{running_moon_remaining}} km</div>
       <div class="stat-label">to the moon</div>
     </div>
+
+    <div class="trail" style="--progress: {{running_moon_pct}}%" role="img" aria-label="{{running_moon_pct}}% of the way to the moon">
+      <span class="endpoint" aria-hidden="true">🌍</span>
+      <div class="track">
+        <div class="track-fill"></div>
+        <span class="runner" aria-hidden="true">🏃</span>
+      </div>
+      <span class="endpoint" aria-hidden="true">🌕</span>
+    </div>
+
     <div class="updated">updated daily</div>
-  </div>
-
-  <div class="divider"></div>
-
-  <div class="prose first">
-    <p>
-      The <span class="em">common swift</span> spends almost its entire life in the air. Over a lifetime it covers roughly two million miles, about four round trips to the moon.
-    </p>
-    <p>
-      One trip is enough for me.
-    </p>
-  </div>
-
-  <div class="divider"></div>
-
-  <div class="prose second">
-    <p>
-      I've been running at least 10 km a day since 2009, and 15 km since 2017. I don't always wear the watch, so the numbers above aren't exact.
-    </p>
-    <p>
-      The earth is 40,075 km around. The moon is 384,400 km from here. If I keep going, I should make it.
-    </p>
   </div>
 
 </main>


### PR DESCRIPTION
## Summary

The running pages have a long-standing issue: design changes have been applied to rendered HTML files (`index.html`, `is/running/index.html`) but not to the templates they're built from (`templates/root.html`, `templates/running.html`). Every Strava stats refresh runs `_scripts/build_root.py` and silently regenerates the rendered files from the templates — reverting the design intent each time.

This fixes the source of truth so future stats updates preserve the design.

## What was being lost on each rebuild

- **PR #54** linked the homepage `running` verb to `/is/running`. Each Strava update reverted to plain text "running to the moon".
- **PR #52** added the earth-to-moon trail visualization to `/is/running/`. Each Strava update wiped it.
- **PR #53** trimmed the running page prose. Reverted.
- **PR #58** removed "If I keep going, I should make it." Reverted by the very next stats update (commit 82dca1f, 2026-05-08).

## Changes

- `templates/root.html`: homepage `running` verb is now a link, matching the `writing` verb pattern. Verb text is just `running` (the "to the moon" framing lives on the destination page, where it belongs).
- `templates/running.html`: trail visualization (🌍 → 🏃 → 🌕) added with `{{running_moon_pct}}` driving the runner's position. Prose paragraphs and the closer line removed.
- `_scripts/build_root.py`: new `running_moon_pct = round(total_km / MOON_KM * 100, 1)` computation and `{{running_moon_pct}}` substitution token.
- `index.html` and `is/running/index.html` regenerated from the updated templates.

## Test plan

- [x] `python3 _scripts/build_root.py` runs cleanly
- [x] `index.html` line 170: `running` verb is a link to `/is/running`
- [x] `is/running/index.html` has the trail viz with progress = 19.6% (= 75,280 / 384,400 × 100)
- [x] No prose paragraphs or "If I keep going" line in `is/running/index.html`
- [x] Bird-universe + identifier validators pass on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)