### PR TITLE
Add /is/reading/ and /is/learning/; trim homepage stanzas

### DIFF
--- a/_scripts/build_root.py
+++ b/_scripts/build_root.py
@@ -17,9 +17,13 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 ROOT_TEMPLATE_PATH = ROOT / "templates" / "root.html"
 RUNNING_TEMPLATE_PATH = ROOT / "templates" / "running.html"
+READING_TEMPLATE_PATH = ROOT / "templates" / "reading.html"
+LEARNING_TEMPLATE_PATH = ROOT / "templates" / "learning.html"
 STATS_PATH = ROOT / "content" / "stats.md"
 INDEX_PATH = ROOT / "index.html"
 RUNNING_INDEX_PATH = ROOT / "is" / "running" / "index.html"
+READING_INDEX_PATH = ROOT / "is" / "reading" / "index.html"
+LEARNING_INDEX_PATH = ROOT / "is" / "learning" / "index.html"
 
 EARTH_KM = 40075
 MOON_KM = 384400
@@ -225,6 +229,8 @@ def build(check_only: bool = False) -> None:
     targets: list[tuple[Path, Path]] = [
         (ROOT_TEMPLATE_PATH, INDEX_PATH),
         (RUNNING_TEMPLATE_PATH, RUNNING_INDEX_PATH),
+        (READING_TEMPLATE_PATH, READING_INDEX_PATH),
+        (LEARNING_TEMPLATE_PATH, LEARNING_INDEX_PATH),
     ]
 
     print(f"running: {total_km_fmt} km since {since_year} — {earth} ({earth_mult}) — {remaining_fmt} km left")

--- a/index.html
+++ b/index.html
@@ -65,7 +65,6 @@
   .stanza:nth-child(1) { animation-delay: 0.1s; }
   .stanza:nth-child(2) { animation-delay: 0.25s; }
   .stanza:nth-child(3) { animation-delay: 0.4s; }
-  .stanza:nth-child(4) { animation-delay: 0.55s; }
 
   @keyframes fade {
     from { opacity: 0; transform: translateY(6px); }
@@ -104,14 +103,6 @@
 
   .detail .em {
     color: var(--text);
-  }
-
-  .also {
-    margin-top: 0.45rem;
-    color: var(--text-faint);
-    font-size: 0.86rem;
-    line-height: 1.6;
-    font-style: italic;
   }
 
   .detail a, .works a {
@@ -179,16 +170,6 @@
     <div class="detail">
       <span class="work-title">Nobody's Fool</span> by Richard Russo.<br>
       <span class="work-title">An Immense World</span> by Ed Yong.
-      <div class="also">
-        also this year: Butter, Piglet, The Vegetarian, Intimacies, Real World, Woman Running in the Mountains, The Knockout Queen, Elon Musk. SPQR, paused.
-      </div>
-    </div>
-  </div>
-
-  <div class="stanza">
-    <div class="line"><span class="prefix">ajin.im is</span> <span class="verb">learning</span></div>
-    <div class="detail">
-      Japanese since 2025. Chinese, this year.
     </div>
   </div>
 

--- a/is/learning/index.html
+++ b/is/learning/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ajin.im is learning</title>
+<meta name="description" content="Languages Ajin Im is learning, and self-made study tools.">
+<link rel="icon" type="image/png" href="/img/a1.png">
+<link rel="apple-touch-icon" href="/img/a1.png">
+<script src="/analytics.js" defer></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;1,8..60,400&family=IBM+Plex+Mono:wght@300;400&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #1a1612;
+    --text: #e8e0d0;
+    --text-soft: #8a7f70;
+    --text-faint: #6a6055;
+    --accent: #c9a876;
+    --accent-soft: rgba(201, 168, 118, 0.25);
+    --rule: rgba(138, 127, 112, 0.18);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Source Serif 4', Georgia, serif;
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
+  }
+
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.85 0 0 0 0 0.78 0 0 0 0 0.66 0 0 0 0.06 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    opacity: 0.4;
+    mix-blend-mode: overlay;
+    z-index: 1;
+  }
+
+  main {
+    position: relative;
+    z-index: 2;
+    max-width: 560px;
+    margin: 0 auto;
+    padding: 10vh 8vw 8vh;
+  }
+
+  .title {
+    font-size: 1.35rem;
+    font-weight: 400;
+    letter-spacing: -0.005em;
+    margin-bottom: 3rem;
+    color: var(--text);
+    animation: fade 0.9s ease-out 0.1s both;
+  }
+
+  .title .prefix {
+    color: var(--text-faint);
+  }
+
+  .title .verb {
+    font-style: italic;
+  }
+
+  .blurb {
+    color: var(--text);
+    font-size: 1.05rem;
+    line-height: 1.75;
+    margin-bottom: 2.6rem;
+    animation: fade 0.9s ease-out 0.25s both;
+  }
+
+  .tools {
+    color: var(--text-soft);
+    font-size: 0.96rem;
+    line-height: 1.75;
+    animation: fade 0.9s ease-out 0.4s both;
+  }
+
+  .tools-label {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    margin-bottom: 0.8rem;
+  }
+
+  .tools a {
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px solid var(--accent-soft);
+    transition: border-color 0.25s ease, color 0.25s ease;
+  }
+
+  .tools a:hover {
+    color: #d8b884;
+    border-bottom-color: rgba(201, 168, 118, 0.7);
+  }
+
+  @keyframes fade {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  @media (max-width: 600px) {
+    main { padding: 7vh 7vw 6vh; }
+    .title { font-size: 1.18rem; margin-bottom: 2.5rem; }
+    .blurb { font-size: 1rem; }
+    .tools { font-size: 0.92rem; }
+  }
+</style>
+</head>
+<body>
+
+<main>
+
+  <div class="title">
+    <span class="prefix">ajin.im is</span> <span class="verb">learning</span>
+  </div>
+
+  <div class="blurb">
+    Japanese since 2025. Chinese, this year.
+  </div>
+
+  <div class="tools">
+    <div class="tools-label">Self-made tools</div>
+    <a href="/is/learning/konbini/">konbini</a> &mdash; Japanese practice, set in a convenience store.
+  </div>
+
+</main>
+
+</body>
+</html>

--- a/is/reading/index.html
+++ b/is/reading/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ajin.im is reading</title>
+<meta name="description" content="What Ajin Im is reading now and has read this year.">
+<link rel="icon" type="image/png" href="/img/a1.png">
+<link rel="apple-touch-icon" href="/img/a1.png">
+<script src="/analytics.js" defer></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;1,8..60,400&family=IBM+Plex+Mono:wght@300;400&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #1a1612;
+    --text: #e8e0d0;
+    --text-soft: #8a7f70;
+    --text-faint: #6a6055;
+    --rule: rgba(138, 127, 112, 0.18);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Source Serif 4', Georgia, serif;
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
+  }
+
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.85 0 0 0 0 0.78 0 0 0 0 0.66 0 0 0 0.06 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    opacity: 0.4;
+    mix-blend-mode: overlay;
+    z-index: 1;
+  }
+
+  main {
+    position: relative;
+    z-index: 2;
+    max-width: 560px;
+    margin: 0 auto;
+    padding: 10vh 8vw 8vh;
+  }
+
+  .title {
+    font-size: 1.35rem;
+    font-weight: 400;
+    letter-spacing: -0.005em;
+    margin-bottom: 3rem;
+    color: var(--text);
+    animation: fade 0.9s ease-out 0.1s both;
+  }
+
+  .title .prefix {
+    color: var(--text-faint);
+  }
+
+  .title .verb {
+    font-style: italic;
+  }
+
+  .now {
+    color: var(--text);
+    font-size: 1.05rem;
+    line-height: 1.75;
+    margin-bottom: 2.6rem;
+    animation: fade 0.9s ease-out 0.25s both;
+  }
+
+  .now .work-title {
+    color: #c4b9a6;
+  }
+
+  .past {
+    color: var(--text-soft);
+    font-size: 0.96rem;
+    line-height: 1.75;
+    animation: fade 0.9s ease-out 0.4s both;
+  }
+
+  .past-label {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    margin-bottom: 0.8rem;
+  }
+
+  @keyframes fade {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  @media (max-width: 600px) {
+    main { padding: 7vh 7vw 6vh; }
+    .title { font-size: 1.18rem; margin-bottom: 2.5rem; }
+    .now { font-size: 1rem; }
+    .past { font-size: 0.92rem; }
+  }
+</style>
+</head>
+<body>
+
+<main>
+
+  <div class="title">
+    <span class="prefix">ajin.im is</span> <span class="verb">reading</span>
+  </div>
+
+  <div class="now">
+    <span class="work-title">Nobody's Fool</span> by Richard Russo.<br>
+      <span class="work-title">An Immense World</span> by Ed Yong.
+  </div>
+
+  <div class="past">
+    <div class="past-label">This year, so far</div>
+    Butter, Piglet, The Vegetarian, Intimacies, Real World, Woman Running in the Mountains, The Knockout Queen, Elon Musk. SPQR, paused.
+  </div>
+
+</main>
+
+</body>
+</html>

--- a/templates/learning.html
+++ b/templates/learning.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ajin.im is learning</title>
+<meta name="description" content="Languages Ajin Im is learning, and self-made study tools.">
+<link rel="icon" type="image/png" href="/img/a1.png">
+<link rel="apple-touch-icon" href="/img/a1.png">
+<script src="/analytics.js" defer></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;1,8..60,400&family=IBM+Plex+Mono:wght@300;400&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #1a1612;
+    --text: #e8e0d0;
+    --text-soft: #8a7f70;
+    --text-faint: #6a6055;
+    --accent: #c9a876;
+    --accent-soft: rgba(201, 168, 118, 0.25);
+    --rule: rgba(138, 127, 112, 0.18);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Source Serif 4', Georgia, serif;
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
+  }
+
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.85 0 0 0 0 0.78 0 0 0 0 0.66 0 0 0 0.06 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    opacity: 0.4;
+    mix-blend-mode: overlay;
+    z-index: 1;
+  }
+
+  main {
+    position: relative;
+    z-index: 2;
+    max-width: 560px;
+    margin: 0 auto;
+    padding: 10vh 8vw 8vh;
+  }
+
+  .title {
+    font-size: 1.35rem;
+    font-weight: 400;
+    letter-spacing: -0.005em;
+    margin-bottom: 3rem;
+    color: var(--text);
+    animation: fade 0.9s ease-out 0.1s both;
+  }
+
+  .title .prefix {
+    color: var(--text-faint);
+  }
+
+  .title .verb {
+    font-style: italic;
+  }
+
+  .blurb {
+    color: var(--text);
+    font-size: 1.05rem;
+    line-height: 1.75;
+    margin-bottom: 2.6rem;
+    animation: fade 0.9s ease-out 0.25s both;
+  }
+
+  .tools {
+    color: var(--text-soft);
+    font-size: 0.96rem;
+    line-height: 1.75;
+    animation: fade 0.9s ease-out 0.4s both;
+  }
+
+  .tools-label {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    margin-bottom: 0.8rem;
+  }
+
+  .tools a {
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px solid var(--accent-soft);
+    transition: border-color 0.25s ease, color 0.25s ease;
+  }
+
+  .tools a:hover {
+    color: #d8b884;
+    border-bottom-color: rgba(201, 168, 118, 0.7);
+  }
+
+  @keyframes fade {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  @media (max-width: 600px) {
+    main { padding: 7vh 7vw 6vh; }
+    .title { font-size: 1.18rem; margin-bottom: 2.5rem; }
+    .blurb { font-size: 1rem; }
+    .tools { font-size: 0.92rem; }
+  }
+</style>
+</head>
+<body>
+
+<main>
+
+  <div class="title">
+    <span class="prefix">ajin.im is</span> <span class="verb">learning</span>
+  </div>
+
+  <div class="blurb">
+    {{learning}}
+  </div>
+
+  <div class="tools">
+    <div class="tools-label">Self-made tools</div>
+    <a href="/is/learning/konbini/">konbini</a> &mdash; Japanese practice, set in a convenience store.
+  </div>
+
+</main>
+
+</body>
+</html>

--- a/templates/reading.html
+++ b/templates/reading.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ajin.im is reading</title>
+<meta name="description" content="What Ajin Im is reading now and has read this year.">
+<link rel="icon" type="image/png" href="/img/a1.png">
+<link rel="apple-touch-icon" href="/img/a1.png">
+<script src="/analytics.js" defer></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;1,8..60,400&family=IBM+Plex+Mono:wght@300;400&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #1a1612;
+    --text: #e8e0d0;
+    --text-soft: #8a7f70;
+    --text-faint: #6a6055;
+    --rule: rgba(138, 127, 112, 0.18);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Source Serif 4', Georgia, serif;
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
+  }
+
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.85 0 0 0 0 0.78 0 0 0 0 0.66 0 0 0 0.06 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    opacity: 0.4;
+    mix-blend-mode: overlay;
+    z-index: 1;
+  }
+
+  main {
+    position: relative;
+    z-index: 2;
+    max-width: 560px;
+    margin: 0 auto;
+    padding: 10vh 8vw 8vh;
+  }
+
+  .title {
+    font-size: 1.35rem;
+    font-weight: 400;
+    letter-spacing: -0.005em;
+    margin-bottom: 3rem;
+    color: var(--text);
+    animation: fade 0.9s ease-out 0.1s both;
+  }
+
+  .title .prefix {
+    color: var(--text-faint);
+  }
+
+  .title .verb {
+    font-style: italic;
+  }
+
+  .now {
+    color: var(--text);
+    font-size: 1.05rem;
+    line-height: 1.75;
+    margin-bottom: 2.6rem;
+    animation: fade 0.9s ease-out 0.25s both;
+  }
+
+  .now .work-title {
+    color: #c4b9a6;
+  }
+
+  .past {
+    color: var(--text-soft);
+    font-size: 0.96rem;
+    line-height: 1.75;
+    animation: fade 0.9s ease-out 0.4s both;
+  }
+
+  .past-label {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    margin-bottom: 0.8rem;
+  }
+
+  @keyframes fade {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  @media (max-width: 600px) {
+    main { padding: 7vh 7vw 6vh; }
+    .title { font-size: 1.18rem; margin-bottom: 2.5rem; }
+    .now { font-size: 1rem; }
+    .past { font-size: 0.92rem; }
+  }
+</style>
+</head>
+<body>
+
+<main>
+
+  <div class="title">
+    <span class="prefix">ajin.im is</span> <span class="verb">reading</span>
+  </div>
+
+  <div class="now">
+    {{reading_current}}
+  </div>
+
+  <div class="past">
+    <div class="past-label">This year, so far</div>
+    {{reading_year}}
+  </div>
+
+</main>
+
+</body>
+</html>

--- a/templates/root.html
+++ b/templates/root.html
@@ -65,7 +65,6 @@
   .stanza:nth-child(1) { animation-delay: 0.1s; }
   .stanza:nth-child(2) { animation-delay: 0.25s; }
   .stanza:nth-child(3) { animation-delay: 0.4s; }
-  .stanza:nth-child(4) { animation-delay: 0.55s; }
 
   @keyframes fade {
     from { opacity: 0; transform: translateY(6px); }
@@ -104,14 +103,6 @@
 
   .detail .em {
     color: var(--text);
-  }
-
-  .also {
-    margin-top: 0.45rem;
-    color: var(--text-faint);
-    font-size: 0.86rem;
-    line-height: 1.6;
-    font-style: italic;
   }
 
   .detail a, .works a {
@@ -178,16 +169,6 @@
     <div class="line"><span class="prefix">ajin.im is</span> <span class="verb">reading</span></div>
     <div class="detail">
       {{reading_current}}
-      <div class="also">
-        also this year: {{reading_year}}
-      </div>
-    </div>
-  </div>
-
-  <div class="stanza">
-    <div class="line"><span class="prefix">ajin.im is</span> <span class="verb">learning</span></div>
-    <div class="detail">
-      {{learning}}
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

- **Homepage** (`templates/root.html` → `index.html`):
  - Reading stanza: "also this year" line removed; only current reading remains.
  - Learning stanza: removed entirely.
  - Net: 3 stanzas (running, reading, writing) instead of 4.
- **New `/is/reading/`** (`templates/reading.html` → `is/reading/index.html`):
  - Title matches the homepage stanza voice (`ajin.im is reading`).
  - "Now" block: current reading list with the same `work-title` styling as before.
  - "This year, so far" inline list — paused books kept inline as on the old homepage stanza.
- **New `/is/learning/`** (`templates/learning.html` → `is/learning/index.html`):
  - Title `ajin.im is learning`, blurb pulls `{{learning}}` from `stats.md`.
  - "Self-made tools" section with the konbini link and a one-line description.
- **Both new pages are unlinked** from the homepage, per instruction. The existing `/is/learning/konbini/` keeps its URL and `noindex`; `/is/learning/` gives it a parent listing for whenever a doorway is wanted.
- **Build**: `_scripts/build_root.py` now treats reading and learning as templated targets so future Strava-stats rebuilds keep everything in sync from one source.

## Test plan

- [x] `python3 _scripts/build_root.py` runs cleanly and writes all four pages
- [x] `index.html` has 3 stanzas; no "also this year" string; no learning stanza
- [x] `/is/reading/index.html` renders title + current + "this year, so far" with `SPQR, paused.` inline
- [x] `/is/learning/index.html` renders title + blurb + konbini link
- [x] Bird-universe + identifier validators pass on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)