### PR TITLE
Pause /works/ — move to _archive/, remove from homepage

### DIFF
--- a/_archive/README.md
+++ b/_archive/README.md
@@ -1,0 +1,34 @@
+# `_archive/`
+
+Pages and content that have been pulled from the live site but kept in the
+repo for possible revival. Directories starting with `_` are excluded by
+default Jekyll/GH Pages behavior, so anything here is preserved in git but
+not served at its original URL.
+
+Each entry below records: the path it lived at, when it was paused, why,
+and what it would take to bring it back.
+
+## Paused entries
+
+### `works/`
+
+- **Was at**: `ajin.im/works`
+- **Now at**: `_archive/works/index.html` (with `<meta name="robots" content="noindex, nofollow">` added as belt-and-braces)
+- **Paused**: 2026-05-09
+- **Why**: not needed at the moment. Author wants the option to revive later.
+- **What it was**: a "Taste as a Service" pitch page for bilingual copywriting / editorial strategy work.
+- **Was linked from**: only the homepage footer (`professionally, ajin.im/works`). That link has been removed from `templates/root.html`. No other internal links existed at time of pause.
+
+#### To revive
+
+1. `git mv _archive/works/ works/`
+2. Optional: remove the `<meta name="robots" content="noindex, nofollow">` line from `works/index.html`
+3. Add the homepage footer link back to `templates/root.html`. The block looked like:
+   ```html
+   <div class="works">
+     professionally, <a href="/works">ajin.im/works</a>
+   </div>
+   ```
+   along with its CSS (`.works { ... }` and `.works a { ... }`, plus the shared `.detail a, .works a { ... }` selectors). See git history of `templates/root.html` around the pause date for the exact rules.
+4. Run `python3 _scripts/build_root.py` to regenerate `index.html`.
+5. Remove this entry from this README.

--- a/_archive/works/index.html
+++ b/_archive/works/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
   <title>Ajin Im — Taste as a Service</title>
   <meta name="description" content="Bilingual copywriter and editorial strategist. I help Korean tech companies sound world-class in English.">
   <link rel="icon" type="image/png" href="/img/a2.png">

--- a/index.html
+++ b/index.html
@@ -105,14 +105,14 @@
     color: var(--text);
   }
 
-  .detail a, .works a {
+  .detail a {
     color: var(--accent);
     text-decoration: none;
     border-bottom: 1px solid var(--accent-soft);
     transition: border-color 0.25s ease, color 0.25s ease;
   }
 
-  .detail a:hover, .works a:hover {
+  .detail a:hover {
     color: #d8b884;
     border-bottom-color: rgba(201, 168, 118, 0.7);
   }
@@ -128,21 +128,6 @@
   .line .verb a:hover {
     color: #f4ecdc;
     border-bottom-color: rgba(232, 224, 208, 0.45);
-  }
-
-  .works {
-    margin-top: auto;
-    padding-top: 5rem;
-    font-family: 'IBM Plex Mono', monospace;
-    font-size: 0.78rem;
-    color: var(--text-faint);
-    letter-spacing: 0.01em;
-    animation: fade 0.9s ease-out 0.85s both;
-  }
-
-  .works a {
-    color: var(--text-soft);
-    border-bottom-color: rgba(138, 127, 112, 0.3);
   }
 
   @media (max-width: 600px) {
@@ -179,10 +164,6 @@
       <a href="https://propagandaformyself.xyz">BIC</a>, an institutional comedy archive.<br>
       <a href="/is/writing/bird-coo/">AMD</a>, a fictional bird municipality.
     </div>
-  </div>
-
-  <div class="works">
-    professionally, <a href="/works">ajin.im/works</a>
   </div>
 
 </main>

--- a/templates/root.html
+++ b/templates/root.html
@@ -105,14 +105,14 @@
     color: var(--text);
   }
 
-  .detail a, .works a {
+  .detail a {
     color: var(--accent);
     text-decoration: none;
     border-bottom: 1px solid var(--accent-soft);
     transition: border-color 0.25s ease, color 0.25s ease;
   }
 
-  .detail a:hover, .works a:hover {
+  .detail a:hover {
     color: #d8b884;
     border-bottom-color: rgba(201, 168, 118, 0.7);
   }
@@ -128,21 +128,6 @@
   .line .verb a:hover {
     color: #f4ecdc;
     border-bottom-color: rgba(232, 224, 208, 0.45);
-  }
-
-  .works {
-    margin-top: auto;
-    padding-top: 5rem;
-    font-family: 'IBM Plex Mono', monospace;
-    font-size: 0.78rem;
-    color: var(--text-faint);
-    letter-spacing: 0.01em;
-    animation: fade 0.9s ease-out 0.85s both;
-  }
-
-  .works a {
-    color: var(--text-soft);
-    border-bottom-color: rgba(138, 127, 112, 0.3);
   }
 
   @media (max-width: 600px) {
@@ -178,10 +163,6 @@
       <a href="https://propagandaformyself.xyz">BIC</a>, an institutional comedy archive.<br>
       <a href="/is/writing/bird-coo/">AMD</a>, a fictional bird municipality.
     </div>
-  </div>
-
-  <div class="works">
-    professionally, <a href="/works">ajin.im/works</a>
   </div>
 
 </main>


### PR DESCRIPTION
## Summary

The author doesn't need `/works/` live at the moment but wants the option to revive later. Moving it cleanly to a Jekyll-excluded archive directory.

- **Moved** `works/index.html` → `_archive/works/index.html`. Directories starting with `_` are excluded from GH Pages output by default, so the file is preserved in git but not served at any URL. Added `<meta name="robots" content="noindex, nofollow">` as belt-and-braces.
- **Homepage** (`templates/root.html` → `index.html`): the `.works` footer block (`professionally, ajin.im/works`) and its CSS removed.
- **Documented** the pause in `_archive/README.md` with: what it was, why paused, when, and a step-by-step to revive (move back + restore homepage block + rerun build_root.py).

No other pages linked to `/works/`, so the homepage was the only inbound to clean up.

## Test plan

- [x] `python3 _scripts/build_root.py` runs cleanly; `index.html` no longer references `/works/` or "professionally"
- [x] `_archive/works/index.html` exists with `noindex, nofollow` meta
- [x] `_archive/README.md` records the pause with revival instructions
- [x] Bird-universe + identifier validators pass on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)