### PR TITLE
Nest Court docket: bring Spring Term current (Coo #14-#18); Karen Hawk district-hub address

### DIFF
--- a/is/writing/avian-district/index.html
+++ b/is/writing/avian-district/index.html
@@ -1381,7 +1381,7 @@ a:hover { color: var(--link-hover); }
         <span class="card-ref">Reg. 02 · Family law</span>
       </div>
       <div class="card-title">Karen Hawk, Attorney at Law</div>
-      <div class="card-desc">Family law. Eighteen years. The Clerk's Office processes her filings more frequently than any other practitioner's. This is not an endorsement. It is a volume observation.</div>
+      <div class="card-desc">Family law. Eighteen years. Offices at 11 Municipal Oak, Suite 4, Sycamore District. The Clerk's Office processes her filings more frequently than any other practitioner's. This is not an endorsement. It is a volume observation.</div>
       <div class="card-cue"><span>Practitioner listing</span><span class="arrow">→</span></div>
     </a>
   </div>

--- a/is/writing/nest-court/calendar/index.html
+++ b/is/writing/nest-court/calendar/index.html
@@ -508,7 +508,7 @@
 <div class="doc-shell">
 
   <div class="doc-meta">
-    <span>Term Docket · Posted Mar 2, 2026 · Last revised Apr 14, 2026</span>
+    <span>Term Docket · Posted Mar 2, 2026 · Last revised Jul 7, 2026 · Mid-Term Notice in effect</span>
   </div>
 
   <article class="docket">
@@ -526,20 +526,26 @@
       <div><span class="label">Issued by:</span> <span class="val">Clerk's Office, 14 Municipal Oak</span></div>
       <div><span class="label">Presiding:</span> <span class="val">Hon. M. Owl</span></div>
       <div><span class="label">First posted:</span> <span class="val">March 2, 2026</span></div>
-      <div><span class="label">Last revised:</span> <span class="val">April 14, 2026</span></div>
+      <div><span class="label">Last revised:</span> <span class="val">July 7, 2026</span></div>
       <div><span class="label">Form:</span> <span class="val">CL-TD-04 (Rev. 2024)</span></div>
-      <div><span class="label">Next term:</span> <span class="val">Summer Term — posts late May</span></div>
+      <div><span class="label">Next term:</span> <span class="val">Summer Term — posting delayed; see Mid-Term Notice</span></div>
     </div>
 
     <!-- Clerk's preamble -->
     <p class="term-preamble">This docket records what the Court intends to do, what the Court has already done, and what otherwise concerns the Court. Past dockets are kept on file at the Clerk's Office.</p>
+
+    <!-- Mid-Term Notice — late-term revision -->
+    <div class="mid-term-strip">
+      <span class="label">Mid-Term Notice · Issued July 7, 2026</span>
+      The Spring Term has run somewhat past its nominal close. Several matters calendared for May have since been heard and disposed; their dispositions are recorded below. The Summer Term docket will post once the Spring Term has finished happening. The Clerk's Office is aware that it is July. The Clerk's Office was aware in June.
+    </div>
 
     <!-- ============================================ -->
     <!-- SECTION 1: PENDING THIS TERM -->
     <!-- ============================================ -->
     <h2 class="section-header">
       <span>Pending This Term</span>
-      <span class="count">14 matters · organized by month</span>
+      <span class="count">9 matters · organized by month</span>
     </h2>
 
     <!-- MARCH -->
@@ -564,23 +570,6 @@
           (P) Denise Dove, pro se · (R) Greg Dove, pro se
         </div>
         <div class="clerk-aside">Both parties confirmed attendance. The Court has reserved a longer block than usual.</div>
-      </div>
-    </div>
-
-    <div class="entry">
-      <div class="entry-when">
-        <span class="week">Wk of Mar 23</span>
-        <span class="session">Morning Sitting</span>
-      </div>
-      <div class="entry-case">
-        <span>AMNC-2026-009A</span>
-        <span class="type-code">410 — Noise / Domestic</span>
-      </div>
-      <div class="entry-detail">
-        <div class="caption">Wren v. Wren <span class="badge">Pre-Hearing</span></div>
-        <div class="hearing-type">Scheduling conference; recording-evidence review</div>
-        <div class="parties">(P) Wren, pro se · (R) Wren, pro se</div>
-        <div class="clerk-aside">The Petitioner has indicated she will bring a recording. The Respondent has indicated he was not aware he was being recorded.</div>
       </div>
     </div>
 
@@ -637,10 +626,10 @@
         <span class="type-code">410 — Noise / Nuisance</span>
       </div>
       <div class="entry-detail">
-        <div class="caption">Mun. Dist. v. Conrad <span class="badge">Rule to Show Cause</span></div>
-        <div class="hearing-type">Quiet hours violation review (6:29 AM, April 22)</div>
+        <div class="caption">Mun. Dist. v. Conrad <span class="badge">Ruling Reserved</span></div>
+        <div class="hearing-type">Quiet hours violation review (6:29 AM, April 22); heard, ruling reserved</div>
         <div class="parties">(P) Municipal District · (R) Conrad, pro se</div>
-        <div class="clerk-aside">The Respondent has been advised that the Court recognizes the concept of a clock and recommends the Respondent acquire one.</div>
+        <div class="clerk-aside">The matter was heard. The Court has reserved ruling on whether 6:29 AM falls before 6:30 AM. The complainant has characterized the timing as deliberate. The Court has not yet characterized it at all.</div>
       </div>
     </div>
 
@@ -654,10 +643,10 @@
         <span class="type-code">510 — Territorial Dispute</span>
       </div>
       <div class="entry-detail">
-        <div class="caption">H. v. H. <span class="badge">Pre-Hearing</span></div>
+        <div class="caption">H. v. H. <span class="badge">Held Open</span></div>
         <div class="hearing-type">Status conference re: park perch (south end)</div>
         <div class="parties">(P) Margaret H., pro se · (R) Gerald H., pro se</div>
-        <div class="clerk-aside">Both parties have indicated a willingness to attend. Neither has indicated a willingness to leave.</div>
+        <div class="clerk-aside">The Respondent has stopped appearing. The Petitioner now holds the perch in full, including the center she had previously declined to occupy. The Court has left the matter open pending clarification of whether a dispute still exists.</div>
       </div>
     </div>
 
@@ -669,40 +658,6 @@
 
     <div class="entry">
       <div class="entry-when">
-        <span class="week">Wk of May 4</span>
-        <span class="session">Morning Sitting</span>
-      </div>
-      <div class="entry-case">
-        <span>AMNC-2026-021A</span>
-        <span class="type-code">770 — Vine Provenance</span>
-      </div>
-      <div class="entry-detail">
-        <div class="caption">In re: Unclaimed Vine, Birch / Sycamore <span class="badge">Petition</span></div>
-        <div class="hearing-type">Petition for adjudication of abandoned property</div>
-        <div class="parties">(P) Clerk's Office · (R) None appearing</div>
-        <div class="clerk-aside">The vine has been at the Clerk's Office since February. The Clerk would like it not to be.</div>
-      </div>
-    </div>
-
-    <div class="entry">
-      <div class="entry-when">
-        <span class="week">Wk of May 11</span>
-        <span class="session">Morning Sitting</span>
-      </div>
-      <div class="entry-case">
-        <span>AMNC-2026-009A</span>
-        <span class="type-code">410 — Noise / Domestic</span>
-      </div>
-      <div class="entry-detail">
-        <div class="caption">Wren v. Wren <span class="badge">Hearing on Merits</span></div>
-        <div class="hearing-type">Hearing on the merits; recording reviewed; ruling expected</div>
-        <div class="parties">(P) Wren, pro se · (R) Wren, pro se</div>
-        <div class="clerk-aside">The Court has set aside additional time to listen to the recording, which has been described as "patterned."</div>
-      </div>
-    </div>
-
-    <div class="entry">
-      <div class="entry-when">
         <span class="week">Wk of May 11</span>
         <span class="session">Late Light</span>
       </div>
@@ -711,27 +666,10 @@
         <span class="type-code">130 — Separate Branch Maintenance</span>
       </div>
       <div class="entry-detail">
-        <div class="caption">Finch v. Finch <span class="badge continued">Continued (3rd)</span></div>
+        <div class="caption">Finch v. Finch <span class="badge continued">Continued (4th)</span></div>
         <div class="hearing-type">Motion to compel division of jointly held materials</div>
         <div class="parties">(P) F. Finch · (R) F. Finch</div>
-        <div class="clerk-aside">Continued at the request of both parties, who have not stated whose request takes precedence. Both will be re-set.</div>
-      </div>
-    </div>
-
-    <div class="entry">
-      <div class="entry-when">
-        <span class="week">Wk of May 18</span>
-        <span class="session">Afternoon Calendar</span>
-      </div>
-      <div class="entry-case">
-        <span>AMNC-2026-018A</span>
-        <span class="type-code">111 — Nest Abandonment (uncontested)</span>
-      </div>
-      <div class="entry-detail">
-        <div class="caption">In re: Sparrow <span class="badge pro-se">Pro Se</span></div>
-        <div class="hearing-type">Confirmation of nest dissolution; entry of default</div>
-        <div class="parties">(P) C. Sparrow · (R) did not file an answer</div>
-        <div class="clerk-aside">The Respondent has not been seen on the branch since February. The Court will infer.</div>
+        <div class="clerk-aside">Continued a fourth time, again at the request of both parties, neither of whom will say which of them asked. A fifth date has been set. The parties have been directed to bring a list of the disputed materials. The file, to date, contains only continuances.</div>
       </div>
     </div>
 
@@ -755,20 +693,20 @@
     <div class="entry">
       <div class="entry-when">
         <span class="week">Wk of May 25</span>
-        <span class="session">Emergency</span>
+        <span class="session">Afternoon Calendar</span>
       </div>
       <div class="entry-case">
         <span>AMNC-2026-020A</span>
         <span class="type-code">220 — Egg Custody</span>
       </div>
       <div class="entry-detail">
-        <div class="caption conf-row">In re: <span class="redacted">██████████</span> <span class="badge emergency">Emergency</span></div>
+        <div class="caption conf-row">In re: <span class="redacted">██████████</span> <span class="badge">Regular Calendar</span></div>
         <div class="hearing-type">Modification of visitation schedule</div>
         <div class="parties conf-row">
           Confidential — matter involves fledglings.<br>
           Caption and parties are not displayed.
         </div>
-        <div class="clerk-aside">The Court reminds the public that scheduling difficulties between two parents are not, by themselves, grounds for an emergency. The Court will determine what is.</div>
+        <div class="clerk-aside">The petition for emergency relief has been moved to the regular calendar. Two parents who cannot agree on a Tuesday do not, between them, constitute an emergency. The eggs are not in any hurry.</div>
       </div>
     </div>
 
@@ -794,13 +732,64 @@
     <!-- ============================================ -->
     <h2 class="section-header">
       <span>Disposed This Term</span>
-      <span class="count">3 matters · ruled or closed</span>
+      <span class="count">6 matters · ruled or closed</span>
     </h2>
 
     <div class="entry disposed">
       <div class="entry-when">
         <span class="week">Disposed</span>
-        <span class="session">Apr 9, 2026</span>
+        <span class="session">Jun 30, 2026</span>
+      </div>
+      <div class="entry-case">
+        <span>AMNC-2026-009A</span>
+        <span class="type-code">410 — Noise / Domestic</span>
+      </div>
+      <div class="entry-detail">
+        <div class="caption">Wren v. Wren <span class="badge ruled">Order Satisfied</span></div>
+        <div class="hearing-type">Ruled (Respondent to vary the rhythm); compliance reviewed and accepted</div>
+        <div class="parties">(P) Wren, pro se · (R) Wren, pro se</div>
+        <div class="clerk-aside">The Respondent now hums a different four-note phrase, identified as the song from the parties' honeymoon. The Petitioner noted it. The Court considers the order satisfied and declines to specify which songs remain available.</div>
+      </div>
+    </div>
+
+    <div class="entry disposed">
+      <div class="entry-when">
+        <span class="week">Disposed</span>
+        <span class="session">Jun 23, 2026</span>
+      </div>
+      <div class="entry-case">
+        <span>AMNC-2026-018A</span>
+        <span class="type-code">111 — Nest Abandonment (uncontested)</span>
+      </div>
+      <div class="entry-detail">
+        <div class="caption">In re: Sparrow <span class="badge ruled">Default Ruling</span></div>
+        <div class="hearing-type">Default entered for Petitioner; nest dissolution confirmed</div>
+        <div class="parties">(P) C. Sparrow · (R) did not appear, file, or respond</div>
+        <div class="clerk-aside">The Respondent has not been seen on the branch since February. The Court has made no finding as to where he went — only that he has not come back.</div>
+      </div>
+    </div>
+
+    <div class="entry disposed">
+      <div class="entry-when">
+        <span class="week">Disposed</span>
+        <span class="session">Jun 23, 2026</span>
+      </div>
+      <div class="entry-case">
+        <span>AMNC-2026-021A</span>
+        <span class="type-code">770 — Vine Provenance</span>
+      </div>
+      <div class="entry-detail">
+        <div class="caption">In re: Unclaimed Vine, Birch / Sycamore <span class="badge ruled">Adjudicated</span></div>
+        <div class="hearing-type">Petition granted; vine declared abandoned property and released for general use</div>
+        <div class="parties">(P) Clerk's Office · (R) None appearing</div>
+        <div class="clerk-aside">After four months in the Clerk's drawer and a formal adjudication, the vine has been declared abandoned and released. No party came forward to explain why it was left at the intersection. The Clerk's Office is glad to have the drawer back.</div>
+      </div>
+    </div>
+
+    <div class="entry disposed">
+      <div class="entry-when">
+        <span class="week">Disposed</span>
+        <span class="session">May 12, 2026</span>
       </div>
       <div class="entry-case">
         <span>AMNC-2026-014B</span>
@@ -899,7 +888,8 @@
         <li>Matters involving fledglings are not displayed. Matters under seal are not displayed. Matters the Clerk has chosen not to display are not displayed.</li>
         <li>The Court does not sit on Wednesdays except under emergency calendar. The Clerk's Office is, however, open. Filings will be received but not processed.</li>
         <li>Mid-Term Notices may be issued as needed. Their absence should not be interpreted as the absence of activity. Their presence should not be interpreted as the presence of urgency.</li>
-        <li>The vine recovered at the Birch / Sycamore intersection (February 2026) remains unclaimed and is set for adjudication in May. Interested parties are encouraged to claim it before the Court adjudicates it on their behalf.</li>
+        <li>The vine recovered at the Birch / Sycamore intersection (February 2026) has since been adjudicated, declared abandoned, and released for general use. No party came forward. The Clerk's drawer is, at last, available for other purposes.</li>
+        <li>The question of whether 6:29 AM precedes 6:30 AM (AMNC-2026-011A) remains under advisement. The Court is aware that it does. The Court is considering whether it matters.</li>
         <li>The Clerk's Office has received seven (7) phone calls this term from individuals impersonating the Clerk's Office. The public is reminded that the Clerk's Office does not call. The Clerk's Office is called.</li>
       </ul>
 


### PR DESCRIPTION
Brings the live Nest Court docket (Spring Term, `calendar/index.html`) current with the reconciled registry through **Coo #18**, as a Spring Term *late revision* (canon is now July; the Coo still labels the term "Spring" as of #13, so the term frame is preserved).

**Docket** (`is/writing/nest-court/calendar/index.html`):
- Moved to Disposed: 009A (compliance satisfied, #17), 018A (default entered, #16), 021A (vine released, #16)
- 016B continued a 4th time / 5th date set (#15); 020A off emergency → regular calendar (#14); 011A heard, ruling reserved on the 6:29 question (#18); 019A held open (#17)
- Corrected 014B disposed-date Apr 9 → May 12 (per Coo #10)
- Added a Mid-Term Notice (reused the dormant `.mid-term-strip` component); **preserved** the Hon. Miriam / M. Owl signature ambiguity and the 020A redaction

**District hub** (`is/writing/avian-district/index.html`):
- Karen Hawk service card now carries the canonical office address (11 Municipal Oak, Suite 4, Sycamore District); relationship line unchanged

Scope: Coo #12–#18 (reconciled-registry window). Perch/SecondNest needed no live edit (registry-side / preserved ambiguities). Validators pass; verified at desktop + mobile (375px).
