### PR TITLE
Bank Municipal Coo issues 26-27 (2026-09-01, 2026-09-08)

### DIFF
--- a/_scripts/build_bird_coo.py
+++ b/_scripts/build_bird_coo.py
@@ -1188,11 +1188,88 @@ ISSUES = [
         ],
         letter_signature="Milo S., age 8",
     ),
+    Issue(
+        issue_number="26",
+        issue_date=date(2026, 9, 1),
+        lead_headline="Migration Season Nears; the Recently Divorced Confront the Question of Routes",
+        lead_dateline="Open grounds · District Desk",
+        lead_paragraphs=[
+            "With the first cold mornings, the district's migratory residents have begun planning the flight south — a matter of logistics most years, and this year, for several recently separated pairs, a negotiation.",
+            "The dispute is over routes. Birds who once flew together now file two plans, and the good route — the warm coast, the reliable stopovers — cannot, by long custom, be shared by birds no longer speaking. One male has announced he will take the inland route \"for the challenge.\" Residents note the inland route offers no challenge. It is merely colder, and alone.",
+            "The Clerk's Office has been asked to mediate three route disputes and declined all three, noting that it holds no jurisdiction over the sky, and that the birds will resolve it the way they resolve everything: badly, and in the air.",
+        ],
+        court_title="New Filing — AMNC-2026-024A",
+        court_paragraphs=[
+            "A petition asks the Court to decide which of two separated parties keeps the nest through the winter — the petitioner intending to migrate, the respondent intending to stay. The petitioner argues a nest should be held for the one who returns; the respondent, that a nest is for the one who is in it.",
+            "The Court has set a hearing and asked each party to define \"home,\" in writing, in under fifty words. Clerk: T. Nuthatch.",
+        ],
+        classified_title="FOR SALE: one board game, two-player",
+        classified_paragraphs=[
+            "We stopped mid-game and never settled who was ahead. I am selling it with the score pad included. I was ahead.",
+        ],
+        classified_reply="Box 26-B, c/o this publication.",
+        personal_title="FEMALE, WARBLER, 37",
+        personal_paragraphs=[
+            "I have a great deal to say and have been told, by one bird in particular, that I say it. I have chosen to take that as confirmed rather than corrected. Seeking someone who listens the way one listens to the radio, and not the news.",
+        ],
+        personal_reply="Reply to: Box 37-W.",
+        display_ad=KAREN_HAWK_AD,
+        letter_title=None,
+        letter_paragraphs=[
+            "I am not flying south this year. I have the excuses ready — the wind, the wing, the cost of the stopovers. The truth is the route was only ever somewhere because she was at the end of it. Without her it is distance.",
+            "I will stay. I will keep the feeder full. I will be here when the others come back.",
+        ],
+        letter_signature="Dennis",
+    ),
+    Issue(
+        issue_number="27",
+        issue_date=date(2026, 9, 8),
+        lead_headline="Conrad Resumes Morning Performances at 6:30 Sharp",
+        lead_dateline="Municipal Oak · District Desk",
+        lead_paragraphs=[
+            "Conrad, the mockingbird restricted by court order from singing before 6:30 AM, has begun singing at 6:30 AM exactly. Not 6:31. Neighbors report he is audibly waiting.",
+            "The performances have grown longer and more pointed. One neighbor described the current material as \"impressions of the birds who complained,\" rendered, he allowed, \"accurately.\" Another said the 6:30 start was technically perfect and, in spirit, a provocation.",
+            "R. Nuthatch, who brought the original complaint, has filed nothing further. He was overheard observing that one cannot file a complaint against a bird for obeying the order, and that this was, he suspected, the entire point.",
+        ],
+        court_title="Hearing Held — AMNC-2026-016B",
+        court_paragraphs=[
+            "Finch v. Finch. For the first time since the matter was filed, both parties appeared on the same day, each having been told a continuance could be granted only in person. Each waited for the other to request it. Neither did.",
+            "The Court, with both parties present and no pending motion, heard the case. Ruling reserved. Clerk: T. Nuthatch.",
+        ],
+        classified_title="NOTICE: Unclaimed items, Clerk's Office",
+        classified_paragraphs=[
+            "Left at the counter during filings and never retrieved: two pens, a reading glass, a house key that fits nothing the Office has tried, and a photograph of a nest with one party removed by careful tearing. Owners may claim them. The photograph in particular.",
+        ],
+        classified_reply="Inquiries to the Clerk's Office, 14 Municipal Oak.",
+        personal_title="MALE, GREBE, 48",
+        personal_paragraphs=[
+            "In my courting days I performed a water dance, mirror-perfect, for hours; I am told it is why she married me and, when it stopped sometime in the second year, part of why she left. I have been practicing again. Seeking someone to practice toward.",
+        ],
+        personal_reply="Reply to: Box 48-G.",
+        display_ad=AdBlock(
+            title="Lionel Kingfisher, Investigations",
+            tagline="Discreet Observation · Hand-Illustrated Reports",
+            body_paragraphs=[
+                "Autumn is my busy season; the light is good and everyone is leaving. I will document a departure with sensitivity and, if asked, a small watercolor.",
+                "I remain unable to catch anyone at anything, and have stopped advertising otherwise.",
+            ],
+            testimonial=None,
+            contact_lines=[
+                "The south parking lot. I am the blue one.",
+            ],
+        ),
+        letter_title=None,
+        letter_paragraphs=[
+            "I have begun reading the personals not to reply but to feel better, and I am writing to report that it works. Every week a male my age describes himself as \"low-maintenance\" and \"told he doesn't give much,\" and every week I think: not yet.",
+            "There is comfort in the column. Thank you for keeping it.",
+        ],
+        letter_signature="Name withheld, Sycamore Lane",
+    ),
 ]
 
 # Most issues run the standard Karen Hawk ad. A few carry an intentional
 # alternate (Perch & Perch #13, Finch & Sons #15) and keep their own display_ad.
-_ALT_AD_ISSUES = {"13", "15", "22"}
+_ALT_AD_ISSUES = {"13", "15", "22", "27"}
 ISSUES = [
     issue if issue.issue_number in _ALT_AD_ISSUES else replace(issue, display_ad=KAREN_HAWK_AD)
     for issue in ISSUES

--- a/is/writing/bird-coo/issues/2026-09-01.html
+++ b/is/writing/bird-coo/issues/2026-09-01.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" type="image/png" href="/img/a3.png">
+<link rel="apple-touch-icon" href="/img/a3.png">
+<title>The Municipal Coo — September 1, 2026</title>
+<meta name="description" content="Migration Season Nears; the Recently Divorced Confront the Question of Routes">
+<link rel="canonical" href="https://ajin.im/is/writing/bird-coo/issues/2026-09-01.html">
+<link rel="stylesheet" href="../styles.css">
+<script src="../../../../analytics.js" defer></script>
+</head>
+<body>
+
+<div class="page issue-page">
+
+<header class="masthead">
+<div class="mast-district">Avian Municipal District</div>
+<h1 class="mast-title">The Municipal Coo</h1>
+<div class="mast-meta">
+<span>Tuesday, September 1, 2026</span>
+<span>Online Edition · Published Tuesdays</span>
+<span>Est. unrecorded</span>
+</div>
+</header>
+
+<nav class="nav">
+<a href="#district">District</a>
+<a href="#court">Court Notices</a>
+<a href="#classifieds">Classifieds</a>
+<a href="#personals">Personals</a>
+<a href="#services">Services</a>
+<a href="#letters">Letters</a>
+</nav>
+
+<main class="content">
+
+<article class="lead-story" id="district">
+<div class="section-label">Around the District</div>
+<h2 class="lead-headline">Migration Season Nears; the Recently Divorced Confront the Question of Routes</h2>
+<div class="lead-dateline">Open grounds · District Desk</div>
+<div class="lead-text">
+<p>With the first cold mornings, the district's migratory residents have begun planning the flight south — a matter of logistics most years, and this year, for several recently separated pairs, a negotiation.</p>
+<p>The dispute is over routes. Birds who once flew together now file two plans, and the good route — the warm coast, the reliable stopovers — cannot, by long custom, be shared by birds no longer speaking. One male has announced he will take the inland route "for the challenge." Residents note the inland route offers no challenge. It is merely colder, and alone.</p>
+<p>The Clerk's Office has been asked to mediate three route disputes and declined all three, noting that it holds no jurisdiction over the sky, and that the birds will resolve it the way they resolve everything: badly, and in the air.</p>
+</div>
+</article>
+
+<hr class="section-rule heavy">
+
+<div class="section-label" id="court">Court Notices</div>
+<div class="court-notice">
+<div class="court-notice-header">Avian Municipal Nest Court — Branch Division</div>
+<h3>New Filing — AMNC-2026-024A</h3>
+<p>A petition asks the Court to decide which of two separated parties keeps the nest through the winter — the petitioner intending to migrate, the respondent intending to stay. The petitioner argues a nest should be held for the one who returns; the respondent, that a nest is for the one who is in it.</p>
+<p>The Court has set a hearing and asked each party to define "home," in writing, in under fifty words. Clerk: T. Nuthatch.</p>
+<div class="court-notice-footer">Nest Court of the Avian Municipal District · 14 Municipal Oak, Third Fork · Sycamore District</div>
+</div>
+
+<hr class="section-rule">
+
+<div class="columns-2" id="classifieds">
+
+<div class="classified">
+<div class="section-label">Classified</div>
+<h4>FOR SALE: one board game, two-player</h4>
+<p>We stopped mid-game and never settled who was ahead. I am selling it with the score pad included. I was ahead.</p>
+<div class="box-reply">Box 26-B, c/o this publication.</div>
+</div>
+
+<div class="personal" id="personals">
+<div class="section-label">Personal</div>
+<h4>FEMALE, WARBLER, 37</h4>
+<p>I have a great deal to say and have been told, by one bird in particular, that I say it. I have chosen to take that as confirmed rather than corrected. Seeking someone who listens the way one listens to the radio, and not the news.</p>
+<div class="box-reply">Reply to: Box 37-W.</div>
+</div>
+
+</div>
+
+<hr class="section-rule heavy">
+
+<div id="services">
+<div class="display-ad">
+<h3>Karen Hawk</h3>
+<div class="ad-tagline">Attorney at Law · Rapid Descents · Clean Separations</div>
+<div class="ad-body">
+<p>Specializing in contested nest divisions, emergency no-perch orders, and situations where he says it was "just drinks." Eighteen years of family law experience. Exposed to every version of "it's not what it looks like." Still not impressed.</p>
+</div>
+<div class="ad-testimonial">"She got me the branch, the eggs, and an apology I could use in future proceedings." — former client</div>
+<div class="ad-contact">
+<p>Free consultation · Evening and weekend appointments</p>
+<p>I do not do couples counseling. That ship has sailed, sunk, and been entered into evidence.</p>
+</div>
+</div>
+</div>
+
+<hr class="section-rule">
+
+<div class="letter" id="letters">
+<div class="section-label">Letters</div>
+<h3 class="letter-section-head">Letters to the Editor</h3>
+<div class="letter-disclaimer">Letters may be edited for length and clarity. Views expressed are the author's.</div>
+
+<div class="salutation">Dear Editor,</div>
+<div class="letter-body">
+<p>I am not flying south this year. I have the excuses ready — the wind, the wing, the cost of the stopovers. The truth is the route was only ever somewhere because she was at the end of it. Without her it is distance.</p>
+<p>I will stay. I will keep the feeder full. I will be here when the others come back.</p>
+</div>
+<div class="sig">— Dennis</div>
+</div>
+
+</main>
+
+<footer class="site-footer">
+<p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
+<p><a href="./index.html">Past Issues</a></p>
+<p class="district-links"><a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
+</footer>
+
+</div>
+
+</body>
+</html>

--- a/is/writing/bird-coo/issues/2026-09-08.html
+++ b/is/writing/bird-coo/issues/2026-09-08.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" type="image/png" href="/img/a3.png">
+<link rel="apple-touch-icon" href="/img/a3.png">
+<title>The Municipal Coo — September 8, 2026</title>
+<meta name="description" content="Conrad Resumes Morning Performances at 6:30 Sharp">
+<link rel="canonical" href="https://ajin.im/is/writing/bird-coo/issues/2026-09-08.html">
+<link rel="stylesheet" href="../styles.css">
+<script src="../../../../analytics.js" defer></script>
+</head>
+<body>
+
+<div class="page issue-page">
+
+<header class="masthead">
+<div class="mast-district">Avian Municipal District</div>
+<h1 class="mast-title">The Municipal Coo</h1>
+<div class="mast-meta">
+<span>Tuesday, September 8, 2026</span>
+<span>Online Edition · Published Tuesdays</span>
+<span>Est. unrecorded</span>
+</div>
+</header>
+
+<nav class="nav">
+<a href="#district">District</a>
+<a href="#court">Court Notices</a>
+<a href="#classifieds">Classifieds</a>
+<a href="#personals">Personals</a>
+<a href="#services">Services</a>
+<a href="#letters">Letters</a>
+</nav>
+
+<main class="content">
+
+<article class="lead-story" id="district">
+<div class="section-label">Around the District</div>
+<h2 class="lead-headline">Conrad Resumes Morning Performances at 6:30 Sharp</h2>
+<div class="lead-dateline">Municipal Oak · District Desk</div>
+<div class="lead-text">
+<p>Conrad, the mockingbird restricted by court order from singing before 6:30 AM, has begun singing at 6:30 AM exactly. Not 6:31. Neighbors report he is audibly waiting.</p>
+<p>The performances have grown longer and more pointed. One neighbor described the current material as "impressions of the birds who complained," rendered, he allowed, "accurately." Another said the 6:30 start was technically perfect and, in spirit, a provocation.</p>
+<p>R. Nuthatch, who brought the original complaint, has filed nothing further. He was overheard observing that one cannot file a complaint against a bird for obeying the order, and that this was, he suspected, the entire point.</p>
+</div>
+</article>
+
+<hr class="section-rule heavy">
+
+<div class="section-label" id="court">Court Notices</div>
+<div class="court-notice">
+<div class="court-notice-header">Avian Municipal Nest Court — Branch Division</div>
+<h3>Hearing Held — AMNC-2026-016B</h3>
+<p>Finch v. Finch. For the first time since the matter was filed, both parties appeared on the same day, each having been told a continuance could be granted only in person. Each waited for the other to request it. Neither did.</p>
+<p>The Court, with both parties present and no pending motion, heard the case. Ruling reserved. Clerk: T. Nuthatch.</p>
+<div class="court-notice-footer">Nest Court of the Avian Municipal District · 14 Municipal Oak, Third Fork · Sycamore District</div>
+</div>
+
+<hr class="section-rule">
+
+<div class="columns-2" id="classifieds">
+
+<div class="classified">
+<div class="section-label">Classified</div>
+<h4>NOTICE: Unclaimed items, Clerk's Office</h4>
+<p>Left at the counter during filings and never retrieved: two pens, a reading glass, a house key that fits nothing the Office has tried, and a photograph of a nest with one party removed by careful tearing. Owners may claim them. The photograph in particular.</p>
+<div class="box-reply">Inquiries to the Clerk's Office, 14 Municipal Oak.</div>
+</div>
+
+<div class="personal" id="personals">
+<div class="section-label">Personal</div>
+<h4>MALE, GREBE, 48</h4>
+<p>In my courting days I performed a water dance, mirror-perfect, for hours; I am told it is why she married me and, when it stopped sometime in the second year, part of why she left. I have been practicing again. Seeking someone to practice toward.</p>
+<div class="box-reply">Reply to: Box 48-G.</div>
+</div>
+
+</div>
+
+<hr class="section-rule heavy">
+
+<div id="services">
+<div class="display-ad">
+<h3>Lionel Kingfisher, Investigations</h3>
+<div class="ad-tagline">Discreet Observation · Hand-Illustrated Reports</div>
+<div class="ad-body">
+<p>Autumn is my busy season; the light is good and everyone is leaving. I will document a departure with sensitivity and, if asked, a small watercolor.</p>
+<p>I remain unable to catch anyone at anything, and have stopped advertising otherwise.</p>
+</div>
+<div class="ad-contact">
+<p>The south parking lot. I am the blue one.</p>
+</div>
+</div>
+</div>
+
+<hr class="section-rule">
+
+<div class="letter" id="letters">
+<div class="section-label">Letters</div>
+<h3 class="letter-section-head">Letters to the Editor</h3>
+<div class="letter-disclaimer">Letters may be edited for length and clarity. Views expressed are the author's.</div>
+
+<div class="salutation">Dear Editor,</div>
+<div class="letter-body">
+<p>I have begun reading the personals not to reply but to feel better, and I am writing to report that it works. Every week a male my age describes himself as "low-maintenance" and "told he doesn't give much," and every week I think: not yet.</p>
+<p>There is comfort in the column. Thank you for keeping it.</p>
+</div>
+<div class="sig">— Name withheld, Sycamore Lane</div>
+</div>
+
+</main>
+
+<footer class="site-footer">
+<p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
+<p><a href="./index.html">Past Issues</a></p>
+<p class="district-links"><a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
+</footer>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Banks two issues (the originally-drafted noir #26 was dropped as overstuffed; migration and Conrad slid up).

**#26 (09-01, migration):** the recently divorced negotiate migration routes; new case 024A (winter nest residency, 'define home in <50 words'); board-game classified; warbler personal; Dennis letter (not migrating, tender).
**#27 (09-08, Conrad):** Conrad resumes performances at 6:30 sharp (malicious compliance, post-011A); 016B finally heard (ruling reserved); Clerk lost-and-found notice; grebe personal; Lionel autumn ad.

Author-approved. Canon registered (024A, 016B heard, Conrad arc, Dennis). Validators pass.