### PR TITLE
Lead /is/writing with The Municipal Coo

### DIFF
--- a/is/writing/index.html
+++ b/is/writing/index.html
@@ -46,14 +46,14 @@
 
           <a
             class="room"
-            href="./avian-district/index.html"
+            href="/is/writing/bird-coo/"
             data-room="birds"
             style="--room-index: 1; --desk-col-start: 1; --desk-col-span: 12; --desk-row-start: 5; --desk-row-span: 3; --desk-min-height: 15rem;"
           >
             <div class="room-copy">
-              <p class="room-kicker">Room <span class="room-number"></span> / Active</p>
-              <h2>Avian Municipal District</h2>
-              <span class="room-meta">ajin.im/is/writing/avian-district</span>
+              <p class="room-kicker">Room <span class="room-number"></span> / Weekly</p>
+              <h2>The Municipal Coo</h2>
+              <span class="room-meta">ajin.im/is/writing/bird-coo</span>
             </div>
           </a>
 


### PR DESCRIPTION
## What
The full-width bottom room on `/is/writing` now leads with **The Municipal Coo** instead of the *Avian Municipal District* portal.

- Title: Avian Municipal District → **The Municipal Coo**
- Kicker: `Active` → `Weekly`
- Link: `./avian-district/index.html` (relative) → `/is/writing/bird-coo/` (root-relative)
- Same full-width banner slot — no layout change.

## Why
The Coo is the strongest standalone content for a first-time visitor (a full, readable weekly edition) vs. the portal, which is a lobby whose payoff is another click.

## Discoverability preserved
The Coo's own footer links back to all five AMD properties (Nest Court · SecondNest · Avian Municipal District · The Perch · Karen Hawk), so leading with the Coo does **not** orphan the district.

## Verified
Rendered locally at 1280px — card shows `Room 02 / Weekly · The Municipal Coo · ajin.im/is/writing/bird-coo`; link target resolves `200` and contains the Coo masthead.