### PR TITLE
Add contact@ajin.im colophon to root; drop · Seoul from writing footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,11 +130,36 @@
     border-bottom-color: rgba(232, 224, 208, 0.45);
   }
 
+  /* colophon — a quiet door, pinned to the bottom of the page; recedes from the verse */
+  .colophon {
+    margin-top: auto;
+    padding-top: 3.5rem;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.8rem;
+    font-weight: 300;
+    letter-spacing: 0.02em;
+    color: var(--text-faint);
+    animation: fade 0.9s ease-out 0.55s both;
+  }
+
+  .colophon a {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: color 0.25s ease, border-color 0.25s ease;
+  }
+
+  .colophon a:hover {
+    color: var(--text-soft);
+    border-bottom-color: rgba(138, 127, 112, 0.45);
+  }
+
   @media (max-width: 600px) {
     main { padding: 7vh 7vw 5vh; }
     .line { font-size: 1.18rem; }
     .detail { font-size: 0.93rem; }
     .stanza { margin-bottom: 2.6rem; }
+    .colophon { padding-top: 2.5rem; }
   }
 </style>
 </head>
@@ -164,6 +189,10 @@
       <a href="https://seoulcrushing.com">seoulcrushing.com</a>, Korea made legible. With bite.
     </div>
   </div>
+
+  <footer class="colophon">
+    <a href="mailto:contact@ajin.im">contact@ajin.im</a>
+  </footer>
 
 </main>
 

--- a/is/writing/index.html
+++ b/is/writing/index.html
@@ -76,7 +76,6 @@
       <footer class="house-footer">
         <p class="house-footer-line">
           <a href="mailto:contact@ajin.im">contact@ajin.im</a>
-          <span>· Seoul</span>
           <a class="house-footer-aside" href="/wrote/">ajin.im/wrote</a>
         </p>
       </footer>

--- a/templates/root.html
+++ b/templates/root.html
@@ -130,11 +130,36 @@
     border-bottom-color: rgba(232, 224, 208, 0.45);
   }
 
+  /* colophon — a quiet door, pinned to the bottom of the page; recedes from the verse */
+  .colophon {
+    margin-top: auto;
+    padding-top: 3.5rem;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.8rem;
+    font-weight: 300;
+    letter-spacing: 0.02em;
+    color: var(--text-faint);
+    animation: fade 0.9s ease-out 0.55s both;
+  }
+
+  .colophon a {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: color 0.25s ease, border-color 0.25s ease;
+  }
+
+  .colophon a:hover {
+    color: var(--text-soft);
+    border-bottom-color: rgba(138, 127, 112, 0.45);
+  }
+
   @media (max-width: 600px) {
     main { padding: 7vh 7vw 5vh; }
     .line { font-size: 1.18rem; }
     .detail { font-size: 0.93rem; }
     .stanza { margin-bottom: 2.6rem; }
+    .colophon { padding-top: 2.5rem; }
   }
 </style>
 </head>
@@ -164,6 +189,10 @@
       <a href="https://seoulcrushing.com">seoulcrushing.com</a>, Korea made legible. With bite.
     </div>
   </div>
+
+  <footer class="colophon">
+    <a href="mailto:contact@ajin.im">contact@ajin.im</a>
+  </footer>
 
 </main>
 


### PR DESCRIPTION
## What

- **Root page** (`templates/root.html` → rebuilt `index.html`): adds a faint, mono `contact@ajin.im` colophon pinned to the bottom of the page. A quiet door for the rare reader who wants to reach out — deliberately *not* a fourth stanza or a CTA, so the running/writing/building verse stays intact.
- **Writing footer** (`is/writing/index.html`): drops the `· Seoul` datum, leaving `contact@ajin.im · ajin.im/wrote`. Makes the contact treatment placeless and consistent with the new root colophon.

## Why

`contact@ajin.im` already lived (sincerely) in the writing-section footer and routes through Fastmail. The root page was the only place missing a contact path. Chose a colophon over a verse line to preserve the homepage's composition; dropped Seoul because a location datum doesn't earn its place in either footer.

## Notes

- Root `index.html` is generated by `_scripts/build_root.py` from `templates/root.html`; both are committed. Rebuild reproduced the existing running stats exactly — the only `index.html` diff is the colophon.
- Verified locally: colophon renders in IBM Plex Mono at `--text-faint`, pinned bottom; writing footer confirmed Seoul-free.