### PR TITLE
Mark build_root.py output as generated; document the build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ Read `INDEX.md` for what to load and when. Modular files:
 
 ## Build Scripts
 
+`_scripts/build_root.py` generates the stats-driven pages — `index.html` (the root `ajin.im is …` page), `is/running/`, `is/reading/`, `is/learning/` — from `templates/{root,running,reading,learning}.html` + `content/stats.md`. **Edit the templates, never the generated `index.html` files.** Direct edits are overwritten on the next build, and `.github/workflows/rebuild-root-on-stats.yml` rebuilds them automatically whenever a template, `stats.md`, or the script changes. Each generated file carries a `GENERATED FILE — DO NOT EDIT` banner under its doctype as an in-file reminder.
+
 `_scripts/build_bird_coo.py` generates all Municipal Coo HTML (index, issues, archive). Manual edits to generated files will be overwritten on next build. Make template changes in the build script.
 
 The script also auto-updates the "From the Municipal Coo" excerpt block on `is/writing/avian-district/index.html`. The block lives between `<!-- COO-EXCERPT-START -->` and `<!-- COO-EXCERPT-END -->` markers — manual edits inside that range will be overwritten on next build. Edit the renderer in `_scripts/build_bird_coo.py` (`render_avian_district_excerpt`) instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ Read `INDEX.md` for what to load and when. Modular files:
 
 ## Build Scripts
 
+`_scripts/build_root.py` generates the stats-driven pages — `index.html` (the root `ajin.im is …` page), `is/running/`, `is/reading/`, `is/learning/` — from `templates/{root,running,reading,learning}.html` + `content/stats.md`. **Edit the templates, never the generated `index.html` files.** Direct edits are overwritten on the next build, and `.github/workflows/rebuild-root-on-stats.yml` rebuilds them automatically whenever a template, `stats.md`, or the script changes. Each generated file carries a `GENERATED FILE — DO NOT EDIT` banner under its doctype as an in-file reminder.
+
 `_scripts/build_bird_coo.py` generates all Municipal Coo HTML (index, issues, archive). Manual edits to generated files will be overwritten on next build. Make template changes in the build script.
 
 The script also auto-updates the "From the Municipal Coo" excerpt block on `is/writing/avian-district/index.html`. The block lives between `<!-- COO-EXCERPT-START -->` and `<!-- COO-EXCERPT-END -->` markers — manual edits inside that range will be overwritten on next build. Edit the renderer in `_scripts/build_bird_coo.py` (`render_avian_district_excerpt`) instead.

--- a/_scripts/build_root.py
+++ b/_scripts/build_root.py
@@ -172,6 +172,28 @@ def render_reading_year(books: list[tuple[str, str]]) -> str:
     return out
 
 
+def with_generated_banner(output: str, template_path: Path) -> str:
+    """Insert a GENERATED-FILE banner just under the doctype.
+
+    The banner is what makes these pages safe to leave around: it trips
+    ~/.claude/hooks/upstream-awareness-guard.py and tells any human/agent
+    reading the file that edits belong in the template, not the output.
+    Placed *after* the doctype line so it never triggers quirks mode.
+    """
+    banner = (
+        f"<!-- GENERATED FILE — DO NOT EDIT. "
+        f"Source: templates/{template_path.name} · built by _scripts/build_root.py. "
+        f"Edits here are overwritten on the next build "
+        f"(.github/workflows/rebuild-root-on-stats.yml). -->\n"
+    )
+    if output.lstrip()[:9].lower() == "<!doctype":
+        nl = output.find("\n")
+        if nl == -1:
+            return output + "\n" + banner
+        return output[: nl + 1] + banner + output[nl + 1 :]
+    return banner + output
+
+
 def render(template_path: Path, replacements: dict[str, str]) -> str:
     if not template_path.is_file():
         raise StatsError(f"template not found: {template_path}")
@@ -185,7 +207,7 @@ def render(template_path: Path, replacements: dict[str, str]) -> str:
     leftover = [t for t in used if t in output]
     if leftover:
         raise StatsError(f"unresolved tokens after substitution in {template_path.name}: {leftover}")
-    return output
+    return with_generated_banner(output, template_path)
 
 
 def build(check_only: bool = False) -> None:

--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- GENERATED FILE — DO NOT EDIT. Source: templates/root.html · built by _scripts/build_root.py. Edits here are overwritten on the next build (.github/workflows/rebuild-root-on-stats.yml). -->
 <html lang="en">
 <head>
 <meta charset="UTF-8">

--- a/is/learning/index.html
+++ b/is/learning/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- GENERATED FILE — DO NOT EDIT. Source: templates/learning.html · built by _scripts/build_root.py. Edits here are overwritten on the next build (.github/workflows/rebuild-root-on-stats.yml). -->
 <html lang="en">
 <head>
 <meta charset="UTF-8">

--- a/is/reading/index.html
+++ b/is/reading/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- GENERATED FILE — DO NOT EDIT. Source: templates/reading.html · built by _scripts/build_root.py. Edits here are overwritten on the next build (.github/workflows/rebuild-root-on-stats.yml). -->
 <html lang="en">
 <head>
 <meta charset="UTF-8">

--- a/is/running/index.html
+++ b/is/running/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- GENERATED FILE — DO NOT EDIT. Source: templates/running.html · built by _scripts/build_root.py. Edits here are overwritten on the next build (.github/workflows/rebuild-root-on-stats.yml). -->
 <html lang="en">
 <head>
 <meta charset="UTF-8">


### PR DESCRIPTION
## Why

Belated catch: the homepage (`index.html`) and `is/{running,reading,learning}/` are **generated** by `_scripts/build_root.py`, but nothing said so — no in-file marker, and `AGENTS.md`/`CLAUDE.md` documented `build_bird_coo.py` while never mentioning `build_root.py`. That gap let a past session edit `index.html` directly (later moved into the template). This makes it self-defending.

## What

- **Banner** — `build_root.py` now injects `<!-- GENERATED FILE — DO NOT EDIT … -->` just under the doctype of each rendered page, naming its source template. Trips the `upstream-awareness-guard` hook's marker layer and is an unmissable in-file signal. Placed after the doctype, so no quirks mode; templates stay banner-free (editing them won't false-trip the guard).
- **Docs** — `AGENTS.md` + `CLAUDE.md` now document `build_root.py` alongside `build_bird_coo.py`.

## Safe

Generated-file diffs are banner-only (+1 line each); stats and the new contact colophon are untouched. Post-merge CI rebuild is idempotent (banner is now part of the build output).