### PR TITLE
Design system: typographic tiers; /wrote + Small Ware → house-title device

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,28 @@
 
 Static site hosted on GitHub Pages. Contains the creative house at `ajin.im/is/writing/` and the Avian Municipal District universe.
 
+## Design System — typographic tiers
+
+Governing rule: **consistent chrome, free content.** The wrapper is uniform; what's inside is free to vary by tier. When adding or restyling a page, classify it first, then give it that tier's chrome.
+
+**Tier test — does the visitor *dwell* in the page, or *scan past* it?**
+
+| Tier | Test | Serif | Where |
+|---|---|---|---|
+| **Frame** | scan-and-navigate; points at things | Source Serif 4 | `/`, `/is/running`, `/is/reading`, `/is/learning`, `/is/building` |
+| **House** | dwell; the page *is* the made thing | Cormorant (`creative-house.css`) | `/is/writing` + rooms (comedy, essays, desk, loose, bird-coo, bird-docket), `/wrote` |
+| **Bespoke** | a singular work whose form is part of the art | its own | avian-district, secondnest, konbini, the `every-few-years` essay, perch-chat, Small Ware's sub-tools |
+
+Tier follows a page's **nature, not its URL parent** — konbini (bespoke) sits under frame `/is/learning`; Small Ware (house) sits under frame `/is/building`. A sub-page keeps its own tier and gets a working up-link to its parent; it does NOT inherit the parent's serif.
+
+**Chrome = a 5-part envelope:** (1) the "ajin.im is ___" title device — faint prefix, italic verb, "ajin.im" links home (`target="_self"`); (2) a way home / up-link; (3) a contact/footer line; (4) DM Mono for labels; (5) warm-dark palette (bg `#1a1612` frame / `#110d0b` house, text `#e8e0d0`).
+
+**Chrome is a gradient, not a switch:**
+- **Frame + House** wear the FULL envelope. The title device renders in the page's own serif: frame uses `.title` (in `templates/*.html`), house uses `.house-title` (in `creative-house.css`). Same device, tier-local serif.
+- **Bespoke** wear only the ANCHORS — a way home + palette sympathy + DM Mono if labels appear. Do NOT force the title device on them; their singular design is intentional, and flattening it is a regression.
+
+Within the house, `.house-title` marks **section entrances and orphan URLs** (`/is/writing` → "ajin.im *is* writing"; `/wrote` → "ajin.im *wrote*", past tense). Individual works (comedy pieces, essays, Coo issues) carry their own title as content. The device tolerates the page's tense/phrasing — a sub-hub may fold its tagline in, e.g. Small Ware → "ajin.im *is* building small ware for big questions."
+
 ## World Bible
 
 The world-building reference for the Avian Municipal District lives in two locations that must stay in sync:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,28 @@
 
 Static site hosted on GitHub Pages. Contains the creative house at `ajin.im/is/writing/` and the Avian Municipal District universe.
 
+## Design System — typographic tiers
+
+Governing rule: **consistent chrome, free content.** The wrapper is uniform; what's inside is free to vary by tier. When adding or restyling a page, classify it first, then give it that tier's chrome.
+
+**Tier test — does the visitor *dwell* in the page, or *scan past* it?**
+
+| Tier | Test | Serif | Where |
+|---|---|---|---|
+| **Frame** | scan-and-navigate; points at things | Source Serif 4 | `/`, `/is/running`, `/is/reading`, `/is/learning`, `/is/building` |
+| **House** | dwell; the page *is* the made thing | Cormorant (`creative-house.css`) | `/is/writing` + rooms (comedy, essays, desk, loose, bird-coo, bird-docket), `/wrote` |
+| **Bespoke** | a singular work whose form is part of the art | its own | avian-district, secondnest, konbini, the `every-few-years` essay, perch-chat, Small Ware's sub-tools |
+
+Tier follows a page's **nature, not its URL parent** — konbini (bespoke) sits under frame `/is/learning`; Small Ware (house) sits under frame `/is/building`. A sub-page keeps its own tier and gets a working up-link to its parent; it does NOT inherit the parent's serif.
+
+**Chrome = a 5-part envelope:** (1) the "ajin.im is ___" title device — faint prefix, italic verb, "ajin.im" links home (`target="_self"`); (2) a way home / up-link; (3) a contact/footer line; (4) DM Mono for labels; (5) warm-dark palette (bg `#1a1612` frame / `#110d0b` house, text `#e8e0d0`).
+
+**Chrome is a gradient, not a switch:**
+- **Frame + House** wear the FULL envelope. The title device renders in the page's own serif: frame uses `.title` (in `templates/*.html`), house uses `.house-title` (in `creative-house.css`). Same device, tier-local serif.
+- **Bespoke** wear only the ANCHORS — a way home + palette sympathy + DM Mono if labels appear. Do NOT force the title device on them; their singular design is intentional, and flattening it is a regression.
+
+Within the house, `.house-title` marks **section entrances and orphan URLs** (`/is/writing` → "ajin.im *is* writing"; `/wrote` → "ajin.im *wrote*", past tense). Individual works (comedy pieces, essays, Coo issues) carry their own title as content. The device tolerates the page's tense/phrasing — a sub-hub may fold its tagline in, e.g. Small Ware → "ajin.im *is* building small ware for big questions."
+
 ## World Bible
 
 The world-building reference for the Avian Municipal District lives in two locations that must stay in sync:

--- a/is/building/small/index.html
+++ b/is/building/small/index.html
@@ -20,9 +20,8 @@
   <body class="house-page writing-house small-tools-house">
     <main class="house-stage">
       <header class="house-lede">
-        <a class="back-link" href="/is/building/">Back to the house</a>
-        <p class="path-mark">ajin.im/is/building/small</p>
-        <p class="house-whisper">Small Ware for big questions.</p>
+        <a class="back-link" href="/is/building/">Back to building</a>
+        <p class="house-title"><span class="prefix"><a href="/" target="_self">ajin.im</a> is</span> <span class="verb">building small ware for big questions</span></p>
       </header>
 
       <section class="house-frame" aria-label="Small Ware">

--- a/wrote/index.html
+++ b/wrote/index.html
@@ -56,8 +56,7 @@
     <main class="archive-shell">
       <header class="archive-head">
         <a class="back-link" href="/is/writing/">Back to the house</a>
-        <p class="path-mark">ajin.im wrote</p>
-        <h1 class="sentence">What I wrote &mdash; essays &amp; older comedy.</h1>
+        <h1 class="house-title"><span class="prefix"><a href="/" target="_self">ajin.im</a></span> <span class="verb">wrote</span></h1>
         <p class="archive-intro">
           Essays in the present voice. The comedy is from the Medium years (2022&ndash;2023).
         </p>


### PR DESCRIPTION
Ratifies a site-wide typographic guideline — **consistent chrome, free content** — and applies it to the two pages an audit flagged as orphaned from the rule.

## The guideline (now in CLAUDE.md + AGENTS.md)
A 3-tier system keyed by a **dwell-vs-scan** test:
- **Frame** (Source Serif) — scan-and-navigate hubs: `/`, `/is/running|reading|learning|building`
- **House** (Cormorant) — dwell-in rooms: `/is/writing` + rooms, `/wrote`
- **Bespoke** — singular works with their own design (avian-district, secondnest, konbini, …) — never flattened

Chrome = a 5-part envelope (the "ajin.im is ___" device + way home + contact + DM Mono labels + warm-dark palette), worn fully by frame/house and reduced to anchors on bespoke. The device renders in each tier’s own serif.

## Applied
- **`/wrote`** — `.sentence` hero → `.house-title` device "ajin.im *wrote*" (past tense); archive-intro + essays/comedy grid kept; single `h1` preserved.
- **Small Ware** (`/is/building/small`) — `path-mark` + `house-whisper` → `.house-title` "ajin.im *is* building small ware for big questions"; up-link fixed "Back to the house" → "Back to building"; room cards + imagery untouched.

Verified at 375 / 768 / 1280: no overflow, native rendering, no console errors.

## Deferred (needs copy-review)
`comedy/index` + `essays/index` share the same pre-device header pattern but converting them needs creative verb copy — surfaced separately rather than auto-shipped.