### PR TITLE
Municipal Coo: introduce Ask Cordelia (issue 30 debut)

### DIFF
--- a/_scripts/build_bird_coo.py
+++ b/_scripts/build_bird_coo.py
@@ -41,6 +41,22 @@ class AdBlock:
 
 
 @dataclass(frozen=True)
+class AdviceLetter:
+    title: str
+    paragraphs: list[str]
+    signature: str
+    reply_paragraphs: list[str]
+
+
+@dataclass(frozen=True)
+class AdviceColumn:
+    eyebrow: str
+    title: str
+    byline: str
+    letters: list[AdviceLetter]
+
+
+@dataclass(frozen=True)
 class Issue:
     issue_number: str
     issue_date: date
@@ -60,6 +76,7 @@ class Issue:
     letter_paragraphs: list[str]
     letter_signature: str
     letter_editor_note: str | None = None
+    advice_column: AdviceColumn | None = None
 
     @property
     def slug(self) -> str:
@@ -1349,12 +1366,99 @@ ISSUES = [
         ],
         letter_signature="Name withheld",
     ),
+    Issue(
+        issue_number="30",
+        issue_date=date(2026, 9, 29),
+        lead_headline="Clerk's Office Sees Early Volume as Autumn Pair-Bond Review Season Opens",
+        lead_dateline="Clerk's Office · District Desk",
+        lead_paragraphs=[
+            "The Clerk's office has issued its annual notice of the autumn pair-bond review season, which traditionally begins the third Tuesday of September. Filings under this period — review-of-status declarations, voluntary continuations, and the occasional surprise dissolution — typically run three times the usual weekly volume.",
+            "T. Nuthatch, Clerk, asked at the public window whether the season was busier than last year, said it was too early to say but that he had already received \"two filings before the office opened, one of which was slipped under the door.\" He declined to characterize the contents.",
+            "Forms are available at the front desk. Birds reviewing in good standing should expect a five-day processing window. Birds reviewing because the other party has already filed should expect a shorter one.",
+        ],
+        court_title="Filing Opens — AMNC-2026-029A",
+        court_paragraphs=[
+            "Dove v. Dove (Autumn Review). Joint declaration filed under the pair-bond review provisions. Both parties present at filing. Both parties asked the Clerk if filing jointly was \"still considered filing.\" The Clerk confirmed it was, but noted the question itself was, in his experience, \"the beginning of a longer conversation.\"",
+            "Hearing date: not scheduled. The Court has placed the matter on the autumn calendar and will revisit if either party files an addendum, which it expects within the week.",
+            "Clerk: T. Nuthatch.",
+        ],
+        classified_title="WANTED: A second opinion",
+        classified_paragraphs=[
+            "A second opinion. On a situation. I have asked three friends. They have given me three different answers. I have asked my mother. She has given me a fourth. I am willing to pay a reasonable fee for a fifth opinion, provided the giver does not know me and is not currently going through anything themselves.",
+            "Discretion appreciated. So is honesty. I will know if you are sugarcoating it.",
+        ],
+        classified_reply="Box 029-C, c/o this publication.",
+        personal_title="FEMALE, ROBIN, 43",
+        personal_paragraphs=[
+            "Pleasant on the branch and capable in the nest. Not seeking a project. Not opposed to one if it is upfront about being one.",
+            "Last partnership ended on terms I have stopped trying to characterize. I am told this means I have processed it. I am not sure it means anything except that I have stopped trying.",
+            "Looking for: company, accountability, someone who answers when I call. In that order.",
+        ],
+        personal_reply="Reply to: Box 43-R.",
+        display_ad=AdBlock(
+            title="KAREN HAWK, ATTORNEY AT LAW",
+            tagline="Autumn filing season is here. So are we.",
+            body_paragraphs=[
+                "If a joint review is on your calendar this week, you may have heard that \"we will work it out without lawyers\" is also a position. It is, briefly. Karen Hawk handles the part after that. Autumn appointments fill quickly. Same-week filings still available.",
+            ],
+            testimonial="\"I came in for a 'consultation.' I left with a filing date and a clear plan. He came in expecting reconciliation. He left.\" — D.D., Sycamore Lane",
+            contact_lines=[
+                "Walk-ins discouraged. Calls returned within the day. I do not do mediation. I do conclusions.",
+            ],
+        ),
+        letter_title=None,
+        letter_paragraphs=[
+            "I would like to thank whoever has been cleaning the birdbath at the Sycamore Lane bus stop. I noticed it had gone green two months ago. I am not the kind of bird who cleans birdbaths. I am the kind of bird who waits to see if anyone else will.",
+            "Someone has been. Three Saturdays in a row the birdbath has been a little clearer than the Saturday before. I would like that bird to know I have noticed and am grateful. I do not know how to find them without involving the rest of the street, which I do not want to do.",
+        ],
+        letter_signature="Quiet thanks, Sycamore Lane",
+        advice_column=AdviceColumn(
+            eyebrow="The Salmon Pages",
+            title="Ask Cordelia",
+            byline="Cordelia Crow, formerly of the Sycamore District Counseling Practice, answers letters on matters this publication is not qualified to address.",
+            letters=[
+                AdviceLetter(
+                    title="\"My partner has become more interesting than I am\"",
+                    paragraphs=[
+                        "I have been paired with my husband for fourteen years. In that time he has learned three new songs, taken up wood identification as a hobby, and made friends with a heron who he describes as \"challenging in a good way.\" I have done none of these things. I have kept the nest in order. I have raised our chicks. I have been the bird he comes back to.",
+                        "Lately I notice that when we are on the branch together, he tells me things and I have nothing to tell him back. Not because nothing has happened. Because what has happened is that I have run the household while he ran his own development.",
+                        "I am not angry. I am asking whether being out-paced by your own husband means anything, or whether it is just what staying still feels like next to someone who didn't.",
+                    ],
+                    signature="A.R., Birch Court",
+                    reply_paragraphs=[
+                        "Dear A.R.,",
+                        "Yes. It means something. The thing it means is that one of you treated the nest as a project and the other treated it as a base. Both are honest uses of a nest. They are not equivalent in what they leave you with at fifty.",
+                        "I am not going to tell you to take up wood identification. You already know what your husband does and you have declined to do it, which is information.",
+                        "The question worth answering is whether your stillness was a contribution to the partnership — which is what it sounds like you believe — or a habit you have stopped questioning. These are not the same, and only you can tell them apart. Though I will say: when I asked myself this question, I lied to myself about the answer for nine years.",
+                        "Walk somewhere new tomorrow. Anywhere. Don't tell him. See what it feels like to come back with something he doesn't know.",
+                    ],
+                ),
+                AdviceLetter(
+                    title="\"The chick is not ours\"",
+                    paragraphs=[
+                        "Our second clutch hatched in April. Three eggs. Two of them are ours. The third is a cuckoo.",
+                        "My husband wants to push the chick out of the nest, which he says is well within our rights and is in fact what most of the district would do. He has cited cases. He has been to see Karen Hawk.",
+                        "I am the one feeding her. She does not know she is not ours. She opens her mouth wider than the other two and I bring her more, which I am told is biologically inevitable but which feels like a choice I am making.",
+                        "What do I owe a chick I did not lay, who I am raising at the expense of the two I did?",
+                    ],
+                    signature="L.W., name withheld",
+                    reply_paragraphs=[
+                        "Dear L.W.,",
+                        "You owe the chick what you have already been giving her, which is a lot. You do not owe her more. You do not, in particular, owe her the position your two are currently being out-fed for.",
+                        "I am not going to tell you to push her out. I am going to tell you that the question you wrote me is not actually about the cuckoo chick. It is about whether being the bird who feeds the loudest mouth is a thing you are doing, or a thing that is happening to you. Those have very different answers.",
+                        "Your husband is wrong about most of this and right about the part that matters, which is that two of those mouths are yours. Karen Hawk will tell you the same thing in fewer words and charge you for it. Save the money.",
+                        "If you want to keep the cuckoo, keep her, and make sure your two see you doing it on purpose. If you want her gone, that is also within the range of choices a reasonable bird makes in this district. What is not within the range is feeding her on autopilot and resenting her at the same time. That is not raising a chick. That is martyrdom with a feeding schedule.",
+                    ],
+                ),
+            ],
+        ),
+    ),
 ]
 
 # Most issues run the standard Karen Hawk ad. A few carry an intentional
 # alternate (Perch & Perch #13, Finch & Sons #15, Lionel Kingfisher #22/#27,
-# Pearl Magpie #28) and keep their own display_ad.
-_ALT_AD_ISSUES = {"13", "15", "22", "27", "28"}
+# Pearl Magpie #28, autumn-variant Karen Hawk #30) and keep their own display_ad.
+_ALT_AD_ISSUES = {"13", "15", "22", "27", "28", "30"}
 ISSUES = [
     issue if issue.issue_number in _ALT_AD_ISSUES else replace(issue, display_ad=KAREN_HAWK_AD)
     for issue in ISSUES
@@ -1397,6 +1501,34 @@ def link_case_numbers(html_str: str, *, relative_prefix: str = "") -> str:
     return html_str
 
 
+def render_advice_block(advice: AdviceColumn) -> str:
+    letters_html = []
+    for letter in advice.letters:
+        letters_html.append(
+            f'<article class="cordelia-letter">\n'
+            f'<h4>{text(letter.title)}</h4>\n'
+            f'<div class="cordelia-letter-body">\n{build_paragraphs(letter.paragraphs)}\n</div>\n'
+            f'<div class="cordelia-letter-sig">— {text(letter.signature)}</div>\n'
+            f'<div class="cordelia-reply">\n'
+            f'<div class="cordelia-reply-label">Cordelia replies</div>\n'
+            f'<div class="cordelia-reply-body">\n{build_paragraphs(letter.reply_paragraphs)}\n</div>\n'
+            f'<div class="cordelia-reply-sig">— C.</div>\n'
+            f'</div>\n'
+            f'</article>'
+        )
+    return (
+        f'<hr class="section-rule">\n\n'
+        f'<div class="cordelia-eyebrow">{text(advice.eyebrow)}</div>\n\n'
+        f'<section class="cordelia-section" id="cordelia">\n'
+        f'<div class="cordelia-masthead">\n'
+        f'<h2 class="cordelia-title">{text(advice.title)}</h2>\n'
+        f'<p class="cordelia-byline">{text(advice.byline)}</p>\n'
+        f'</div>\n\n'
+        + "\n\n".join(letters_html)
+        + "\n\n</section>"
+    )
+
+
 def issue_page_html(
     issue: Issue,
     *,
@@ -1424,6 +1556,9 @@ def issue_page_html(
             + "\n".join(f"<p>{text(line)}</p>" for line in issue.display_ad.contact_lines)
             + "\n</div>"
         )
+    mast_subtitle = "Online Edition · with Ask Cordelia" if issue.advice_column else "Online Edition · Published Tuesdays"
+    nav_cordelia = '\n<a href="#cordelia">Ask Cordelia</a>' if issue.advice_column else ""
+    advice_section = f"\n\n{render_advice_block(issue.advice_column)}" if issue.advice_column else ""
 
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -1447,7 +1582,7 @@ def issue_page_html(
 <h1 class="mast-title">{text(SITE_TITLE)}</h1>
 <div class="mast-meta">
 <span>{text(issue.date_label)}</span>
-<span>Online Edition · Published Tuesdays</span>
+<span>{text(mast_subtitle)}</span>
 <span>Est. unrecorded</span>
 </div>
 </header>
@@ -1458,7 +1593,7 @@ def issue_page_html(
 <a href="#classifieds">Classifieds</a>
 <a href="#personals">Personals</a>
 <a href="#services">Services</a>
-<a href="#letters">Letters</a>
+<a href="#letters">Letters</a>{nav_cordelia}
 </nav>
 
 <main class="content">
@@ -1525,7 +1660,7 @@ def issue_page_html(
 {build_paragraphs(issue.letter_paragraphs)}
 </div>
 <div class="sig">— {text(issue.letter_signature)}</div>{letter_editor_note}
-</div>
+</div>{advice_section}
 
 </main>
 

--- a/is/writing/bird-coo/issues/2026-09-29.html
+++ b/is/writing/bird-coo/issues/2026-09-29.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" type="image/png" href="/img/a3.png">
+<link rel="apple-touch-icon" href="/img/a3.png">
+<title>The Municipal Coo — September 29, 2026</title>
+<meta name="description" content="Clerk&#x27;s Office Sees Early Volume as Autumn Pair-Bond Review Season Opens">
+<link rel="canonical" href="https://ajin.im/is/writing/bird-coo/issues/2026-09-29.html">
+<link rel="stylesheet" href="../styles.css">
+<script src="../../../../analytics.js" defer></script>
+</head>
+<body>
+
+<div class="page issue-page">
+
+<header class="masthead">
+<div class="mast-district">Avian Municipal District</div>
+<h1 class="mast-title">The Municipal Coo</h1>
+<div class="mast-meta">
+<span>Tuesday, September 29, 2026</span>
+<span>Online Edition · with Ask Cordelia</span>
+<span>Est. unrecorded</span>
+</div>
+</header>
+
+<nav class="nav">
+<a href="#district">District</a>
+<a href="#court">Court Notices</a>
+<a href="#classifieds">Classifieds</a>
+<a href="#personals">Personals</a>
+<a href="#services">Services</a>
+<a href="#letters">Letters</a>
+<a href="#cordelia">Ask Cordelia</a>
+</nav>
+
+<main class="content">
+
+<article class="lead-story" id="district">
+<div class="section-label">Around the District</div>
+<h2 class="lead-headline">Clerk's Office Sees Early Volume as Autumn Pair-Bond Review Season Opens</h2>
+<div class="lead-dateline">Clerk's Office · District Desk</div>
+<div class="lead-text">
+<p>The Clerk's office has issued its annual notice of the autumn pair-bond review season, which traditionally begins the third Tuesday of September. Filings under this period — review-of-status declarations, voluntary continuations, and the occasional surprise dissolution — typically run three times the usual weekly volume.</p>
+<p>T. Nuthatch, Clerk, asked at the public window whether the season was busier than last year, said it was too early to say but that he had already received "two filings before the office opened, one of which was slipped under the door." He declined to characterize the contents.</p>
+<p>Forms are available at the front desk. Birds reviewing in good standing should expect a five-day processing window. Birds reviewing because the other party has already filed should expect a shorter one.</p>
+</div>
+</article>
+
+<hr class="section-rule heavy">
+
+<div class="section-label" id="court">Court Notices</div>
+<div class="court-notice">
+<div class="court-notice-header">Avian Municipal Nest Court — Branch Division</div>
+<h3>Filing Opens — AMNC-2026-029A</h3>
+<p>Dove v. Dove (Autumn Review). Joint declaration filed under the pair-bond review provisions. Both parties present at filing. Both parties asked the Clerk if filing jointly was "still considered filing." The Clerk confirmed it was, but noted the question itself was, in his experience, "the beginning of a longer conversation."</p>
+<p>Hearing date: not scheduled. The Court has placed the matter on the autumn calendar and will revisit if either party files an addendum, which it expects within the week.</p>
+<p>Clerk: T. Nuthatch.</p>
+<div class="court-notice-footer">Nest Court of the Avian Municipal District · 14 Municipal Oak, Third Fork · Sycamore District</div>
+</div>
+
+<hr class="section-rule">
+
+<div class="columns-2" id="classifieds">
+
+<div class="classified">
+<div class="section-label">Classified</div>
+<h4>WANTED: A second opinion</h4>
+<p>A second opinion. On a situation. I have asked three friends. They have given me three different answers. I have asked my mother. She has given me a fourth. I am willing to pay a reasonable fee for a fifth opinion, provided the giver does not know me and is not currently going through anything themselves.</p>
+<p>Discretion appreciated. So is honesty. I will know if you are sugarcoating it.</p>
+<div class="box-reply">Box 029-C, c/o this publication.</div>
+</div>
+
+<div class="personal" id="personals">
+<div class="section-label">Personal</div>
+<h4>FEMALE, ROBIN, 43</h4>
+<p>Pleasant on the branch and capable in the nest. Not seeking a project. Not opposed to one if it is upfront about being one.</p>
+<p>Last partnership ended on terms I have stopped trying to characterize. I am told this means I have processed it. I am not sure it means anything except that I have stopped trying.</p>
+<p>Looking for: company, accountability, someone who answers when I call. In that order.</p>
+<div class="box-reply">Reply to: Box 43-R.</div>
+</div>
+
+</div>
+
+<hr class="section-rule heavy">
+
+<div id="services">
+<div class="display-ad">
+<h3>KAREN HAWK, ATTORNEY AT LAW</h3>
+<div class="ad-tagline">Autumn filing season is here. So are we.</div>
+<div class="ad-body">
+<p>If a joint review is on your calendar this week, you may have heard that "we will work it out without lawyers" is also a position. It is, briefly. Karen Hawk handles the part after that. Autumn appointments fill quickly. Same-week filings still available.</p>
+</div>
+<div class="ad-testimonial">"I came in for a 'consultation.' I left with a filing date and a clear plan. He came in expecting reconciliation. He left." — D.D., Sycamore Lane</div>
+<div class="ad-contact">
+<p>Walk-ins discouraged. Calls returned within the day. I do not do mediation. I do conclusions.</p>
+</div>
+</div>
+</div>
+
+<hr class="section-rule">
+
+<div class="letter" id="letters">
+<div class="section-label">Letters</div>
+<h3 class="letter-section-head">Letters to the Editor</h3>
+<div class="letter-disclaimer">Letters may be edited for length and clarity. Views expressed are the author's.</div>
+
+<div class="salutation">Dear Editor,</div>
+<div class="letter-body">
+<p>I would like to thank whoever has been cleaning the birdbath at the Sycamore Lane bus stop. I noticed it had gone green two months ago. I am not the kind of bird who cleans birdbaths. I am the kind of bird who waits to see if anyone else will.</p>
+<p>Someone has been. Three Saturdays in a row the birdbath has been a little clearer than the Saturday before. I would like that bird to know I have noticed and am grateful. I do not know how to find them without involving the rest of the street, which I do not want to do.</p>
+</div>
+<div class="sig">— Quiet thanks, Sycamore Lane</div>
+</div>
+
+<hr class="section-rule">
+
+<div class="cordelia-eyebrow">The Salmon Pages</div>
+
+<section class="cordelia-section" id="cordelia">
+<div class="cordelia-masthead">
+<h2 class="cordelia-title">Ask Cordelia</h2>
+<p class="cordelia-byline">Cordelia Crow, formerly of the Sycamore District Counseling Practice, answers letters on matters this publication is not qualified to address.</p>
+</div>
+
+<article class="cordelia-letter">
+<h4>"My partner has become more interesting than I am"</h4>
+<div class="cordelia-letter-body">
+<p>I have been paired with my husband for fourteen years. In that time he has learned three new songs, taken up wood identification as a hobby, and made friends with a heron who he describes as "challenging in a good way." I have done none of these things. I have kept the nest in order. I have raised our chicks. I have been the bird he comes back to.</p>
+<p>Lately I notice that when we are on the branch together, he tells me things and I have nothing to tell him back. Not because nothing has happened. Because what has happened is that I have run the household while he ran his own development.</p>
+<p>I am not angry. I am asking whether being out-paced by your own husband means anything, or whether it is just what staying still feels like next to someone who didn't.</p>
+</div>
+<div class="cordelia-letter-sig">— A.R., Birch Court</div>
+<div class="cordelia-reply">
+<div class="cordelia-reply-label">Cordelia replies</div>
+<div class="cordelia-reply-body">
+<p>Dear A.R.,</p>
+<p>Yes. It means something. The thing it means is that one of you treated the nest as a project and the other treated it as a base. Both are honest uses of a nest. They are not equivalent in what they leave you with at fifty.</p>
+<p>I am not going to tell you to take up wood identification. You already know what your husband does and you have declined to do it, which is information.</p>
+<p>The question worth answering is whether your stillness was a contribution to the partnership — which is what it sounds like you believe — or a habit you have stopped questioning. These are not the same, and only you can tell them apart. Though I will say: when I asked myself this question, I lied to myself about the answer for nine years.</p>
+<p>Walk somewhere new tomorrow. Anywhere. Don't tell him. See what it feels like to come back with something he doesn't know.</p>
+</div>
+<div class="cordelia-reply-sig">— C.</div>
+</div>
+</article>
+
+<article class="cordelia-letter">
+<h4>"The chick is not ours"</h4>
+<div class="cordelia-letter-body">
+<p>Our second clutch hatched in April. Three eggs. Two of them are ours. The third is a cuckoo.</p>
+<p>My husband wants to push the chick out of the nest, which he says is well within our rights and is in fact what most of the district would do. He has cited cases. He has been to see Karen Hawk.</p>
+<p>I am the one feeding her. She does not know she is not ours. She opens her mouth wider than the other two and I bring her more, which I am told is biologically inevitable but which feels like a choice I am making.</p>
+<p>What do I owe a chick I did not lay, who I am raising at the expense of the two I did?</p>
+</div>
+<div class="cordelia-letter-sig">— L.W., name withheld</div>
+<div class="cordelia-reply">
+<div class="cordelia-reply-label">Cordelia replies</div>
+<div class="cordelia-reply-body">
+<p>Dear L.W.,</p>
+<p>You owe the chick what you have already been giving her, which is a lot. You do not owe her more. You do not, in particular, owe her the position your two are currently being out-fed for.</p>
+<p>I am not going to tell you to push her out. I am going to tell you that the question you wrote me is not actually about the cuckoo chick. It is about whether being the bird who feeds the loudest mouth is a thing you are doing, or a thing that is happening to you. Those have very different answers.</p>
+<p>Your husband is wrong about most of this and right about the part that matters, which is that two of those mouths are yours. Karen Hawk will tell you the same thing in fewer words and charge you for it. Save the money.</p>
+<p>If you want to keep the cuckoo, keep her, and make sure your two see you doing it on purpose. If you want her gone, that is also within the range of choices a reasonable bird makes in this district. What is not within the range is feeding her on autopilot and resenting her at the same time. That is not raising a chick. That is martyrdom with a feeding schedule.</p>
+</div>
+<div class="cordelia-reply-sig">— C.</div>
+</div>
+</article>
+
+</section>
+
+</main>
+
+<footer class="site-footer">
+<p>The Municipal Coo is the local online edition for the Avian Municipal District. Court notices are published as scheduled. Box replies remain with this publication unless otherwise directed. All matters domestic.</p>
+<p><a href="./index.html">Past Issues</a></p>
+<p class="district-links"><a href="/is/writing/nest-court/" target="_blank">Nest Court</a> · <a href="/is/writing/secondnest/" target="_blank">SecondNest</a> · <a href="/is/writing/avian-district/" target="_blank">Avian Municipal District</a> · <a href="/is/writing/perch-chat/" target="_blank">The Perch</a> · <a href="/is/writing/karen-hawk/" target="_blank">Karen Hawk</a></p>
+</footer>
+
+</div>
+
+</body>
+</html>

--- a/is/writing/bird-coo/styles.css
+++ b/is/writing/bird-coo/styles.css
@@ -481,6 +481,135 @@ a {
   font-style: italic;
 }
 
+/* ── ASK CORDELIA (the salmon pages — biweekly insert) ── */
+
+:root {
+  --cordelia-bg: #f0d0c2;
+  --cordelia-bg-deep: #e8c2b2;
+  --cordelia-rule: #c89c8c;
+  --cordelia-accent: #6b1818;
+}
+
+.cordelia-eyebrow {
+  margin: 1.8rem 0 0.5rem;
+  color: var(--cordelia-accent);
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.6rem;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.cordelia-section {
+  margin: 0 0 1.8rem;
+  padding: 1.4rem 1.5rem 1.6rem;
+  background: var(--cordelia-bg);
+  border: 1px solid var(--cordelia-rule);
+  border-radius: 2px;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.04);
+}
+
+.cordelia-masthead {
+  text-align: center;
+  margin-bottom: 1rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--cordelia-rule);
+}
+
+.cordelia-title {
+  margin: 0 0 0.15rem;
+  color: var(--ink);
+  font-family: "Playfair Display", serif;
+  font-size: 1.7rem;
+  font-weight: 900;
+  letter-spacing: 0.01em;
+  line-height: 1;
+}
+
+.cordelia-byline {
+  margin: 0;
+  color: var(--ink-faded);
+  font-family: "Source Serif 4", serif;
+  font-size: 0.75rem;
+  font-style: italic;
+}
+
+.cordelia-letter {
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.cordelia-letter + .cordelia-letter {
+  margin-top: 1.6rem;
+  padding-top: 1.4rem;
+  border-top: 1px dashed var(--cordelia-rule);
+}
+
+.cordelia-letter h4 {
+  margin: 0 0 0.5rem;
+  color: var(--ink);
+  font-family: "Playfair Display", serif;
+  font-size: 1.05rem;
+  font-style: italic;
+  font-weight: 700;
+}
+
+.cordelia-letter-body {
+  color: var(--ink-light);
+  font-family: "Source Serif 4", serif;
+  font-size: 0.92rem;
+  line-height: 1.65;
+}
+
+.cordelia-letter-body p { margin: 0; }
+.cordelia-letter-body p + p { margin-top: 0.5rem; }
+
+.cordelia-letter-sig {
+  margin-top: 0.5rem;
+  color: var(--ink-faded);
+  font-family: "Source Serif 4", serif;
+  font-size: 0.8rem;
+  font-style: italic;
+  text-align: right;
+}
+
+.cordelia-reply {
+  margin-top: 0.9rem;
+  padding: 0.9rem 1rem;
+  background: var(--cordelia-bg-deep);
+  border-left: 3px solid var(--cordelia-accent);
+}
+
+.cordelia-reply-label {
+  margin: 0 0 0.4rem;
+  color: var(--cordelia-accent);
+  font-family: "IBM Plex Sans", sans-serif;
+  font-size: 0.55rem;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.cordelia-reply-body {
+  color: var(--ink-light);
+  font-family: "Source Serif 4", serif;
+  font-size: 0.92rem;
+  line-height: 1.65;
+}
+
+.cordelia-reply-body p { margin: 0; }
+.cordelia-reply-body p + p { margin-top: 0.45rem; }
+
+.cordelia-reply-sig {
+  margin-top: 0.5rem;
+  color: var(--ink-faded);
+  font-family: "Source Serif 4", serif;
+  font-size: 0.85rem;
+  font-style: italic;
+  text-align: right;
+}
+
 /* ── FOOTER ── */
 
 .site-footer {
@@ -647,5 +776,13 @@ a {
 
   .service-feature {
     padding: 0.8rem;
+  }
+
+  .cordelia-section {
+    padding: 1.2rem 1rem 1.4rem;
+  }
+
+  .cordelia-title {
+    font-size: 1.4rem;
   }
 }


### PR DESCRIPTION
## Summary
- Adds Cordelia Crow as a biweekly advice columnist debuting in issue 30 (Sept 29, 2026) — full salmon-pages treatment, eyebrow on cream, oxblood-ruled reply blocks
- Adds \`AdviceLetter\` and \`AdviceColumn\` dataclasses + optional \`advice_column\` field on \`Issue\`; conditional masthead toggle ("with Ask Cordelia") and nav link when present
- Substance slot keeps its full length on purpose — the contrast with the surrounding dry register is the architecture

## Test plan
- [x] Build script runs without error
- [x] Issue 30 generated at \`is/writing/bird-coo/issues/2026-09-29.html\`
- [x] Cordelia section renders at 375px (mobile) — inset card, salmon bg, reply block legible
- [x] Cordelia section renders at 768px (tablet) — cream framing visible on left/right, oxblood reply rule clean
- [x] Top-of-page renders at 1280px (desktop) — masthead shows "WITH ASK CORDELIA", nav includes "Ask Cordelia" link

## Follow-up
- [ ] Add \`AMNC-2026-029A\` (Dove v. Dove autumn review) + Cordelia Crow character to \`bird-universe/02-registry.md\`, regen graph cache