### PR TITLE
bird-universe: registry-checker hub-link agreement + reconcile stale linking doc

### DIFF
--- a/_scripts/bird-universe/BIRD-UNIVERSE-LINKING.md
+++ b/_scripts/bird-universe/BIRD-UNIVERSE-LINKING.md
@@ -1,8 +1,9 @@
 # Bird-Universe Linking Rules
 
-This document is local-only workspace guidance for the bird-related sites under
+This document is workspace guidance for the bird-related sites under
 `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/`.
-It is not part of the public site and should not be committed.
+It lives in the committed dev tooling at `_scripts/bird-universe/` and is not
+served as part of the published site output.
 
 ## Scope
 
@@ -94,8 +95,8 @@ Before adding a new bird-universe site:
    - `record_surface`
    - `meta_directory`
    - `listed_only`
-2. Add or update the local registry:
-   `/Users/ajin/Documents/New project/personal/mobetter20.github.io/.codex-local/bird-universe/bird_universe_registry.json`
+2. Add or update the registry:
+   `/Users/ajin/Documents/New project/personal/mobetter20.github.io/_scripts/bird-universe/bird_universe_registry.json`
 3. Decide whether it belongs in:
    - the future `avian-district` official directory
    - the `bird-docket` meta directory
@@ -117,22 +118,25 @@ Known migration watchpoints:
 - `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/index.html`
 - `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/secondnest/index.html`
 
-## Local-Only Rule
+## What Is Committed vs Local
 
-These files are intentionally local-only:
+The bird-universe tooling and this policy doc now live committed under
+`_scripts/bird-universe/` (the former `.codex-local/bird-universe/` location is
+retired). They are dev-only: they run at build / pre-push time and are never
+served as published site output.
 
-- `.codex-local/bird-universe/*`
-- the bird-site `AGENTS.md` files
+Genuinely local / per-machine:
 
-Do not commit them. Do not move them into public site directories in tracked
-form. If a future workflow needs repo-visible automation, keep it generic and
-non-fictional, and continue storing the bird-universe policy layer locally.
+- `_scripts/bird-universe/config.json` — gitignored; each working copy points it
+  at its own checkout of the separate world-bible registry repo.
+- the world-bible entity registry (`02-registry.md`) — lives in a separate repo,
+  not here.
 
 ## Enforcement
 
-- The effective guardrail is the local checker:
-  `/Users/ajin/Documents/New project/personal/mobetter20.github.io/.codex-local/bird-universe/check_bird_universe_links.py`
-- Push-time enforcement should happen through the local Git hook at:
+- The effective guardrail is the checker:
+  `/Users/ajin/Documents/New project/personal/mobetter20.github.io/_scripts/bird-universe/check_bird_universe_links.py`
+- Push-time enforcement happens through the local Git hook at:
   `/Users/ajin/Documents/New project/personal/mobetter20.github.io/.git/hooks/pre-push`
 - `publish.sh` is not the safety model. Treat it as an optional local helper.
 - If this repo is recloned or `.git` is replaced, the local hook and local

--- a/_scripts/bird-universe/bird_universe_registry.json
+++ b/_scripts/bird-universe/bird_universe_registry.json
@@ -5,7 +5,7 @@
   "officialHubSlug": "avian-district",
   "metaDirectorySlug": "bird-docket",
   "notes": [
-    "avian-district is planned and will become the canonical in-world hub.",
+    "avian-district is the live canonical in-world hub; parent-link migration from bird-docket is complete.",
     "bird-docket remains live but is considered the meta/out-of-world directory.",
     "Proceedings pages are subordinate to nest-court and should not be treated as peer hubs."
   ],

--- a/_scripts/bird-universe/check_bird_universe_links.py
+++ b/_scripts/bird-universe/check_bird_universe_links.py
@@ -164,6 +164,29 @@ def main() -> int:
             '/is/writing/karen-hawk/',
         ]
 
+        # The hardcoded list above is the independent enforcement assertion — a
+        # second pair of eyes on what avian-district must link, deliberately not
+        # auto-derived from the registry. Cross-check it against the registry's
+        # showInOfficialHub flags so the two cannot silently drift: a newly
+        # flagged hub site that nobody added here would otherwise go unguarded,
+        # and a leftover entry here would outlive its flag.
+        flagged_hub_paths = {
+            site_entry.get("canonicalPath")
+            for site_entry in sites
+            if site_entry.get("showInOfficialHub") and site_entry.get("slug") != official_hub_slug
+        }
+        required_paths = set(required_root_relative)
+        for missing in sorted(flagged_hub_paths - required_paths):
+            errors.append(
+                f"avian-district: {missing} is showInOfficialHub in the registry "
+                "but missing from the checker's required-link set"
+            )
+        for stale in sorted(required_paths - flagged_hub_paths):
+            errors.append(
+                f"avian-district: {stale} is in the checker's required-link set "
+                "but not showInOfficialHub in the registry"
+            )
+
         if not avian_index.exists():
             warn("avian-district is still planned; parent-link migration has not started yet.")
         else:


### PR DESCRIPTION
Safe subset from a two-critic plan review of the AMD interlinkage tooling.

**What & why**
- **Checker (`check_bird_universe_links.py`)** — cross-checks avian-district's hardcoded required-link set against the registry's `showInOfficialHub` flags, so a newly flagged hub site that's never linked (or a leftover required entry whose flag was dropped) now errors instead of silently drifting. The hardcoded list stays as the independent assertion; the check is purely additive.
- **Registry note** — corrected the stale "avian-district is planned" note; it's live and the bird-docket parent-link migration is complete.
- **LINKING.md** — retired the dead `.codex-local/bird-universe/` paths (tooling lives committed under `_scripts/bird-universe/`) and rewrote the stale "Local-Only Rule" section to the real committed-vs-local split.

**Deliberately NOT done**
Both plan-critics blocked the heavier "generate the directory blocks from the registry" proposal: ahead-of-demand (registry stable, no new-site pressure) and in conflict with LINKING.md's "do not auto-generate bespoke in-world copy" rule — those blocks carry Clerk's-voice prose, not just links. The review also caught factual errors in the original pitch (bird-docket has 8 entries incl. an unmodellable external link; no `publish.sh` exists; the link set lives in 3 places, not 2).

**Verification**
- `check_bird_universe_links.py` + `lint_identifiers.py` both green.
- Negative test: unflagging a hub site makes the checker exit 1 with the expected error; registry restored byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)