### PR TITLE
is/building: fix bold title (font-weight 400)

### DIFF
--- a/is/building/index.html
+++ b/is/building/index.html
@@ -50,7 +50,7 @@
     max-width: 560px; margin: 0 auto; padding: 10vh 8vw 8vh;
   }
   .title {
-    font-size: 1.35rem; letter-spacing: -0.005em; margin-bottom: 3.5rem;
+    font-size: 1.35rem; font-weight: 400; letter-spacing: -0.005em; margin-bottom: 3.5rem;
     animation: fade 0.9s ease-out 0.1s both;
   }
   .title .prefix { color: var(--text-faint); }


### PR DESCRIPTION
The "ajin.im is building" title rendered **bold** — the real cause of the original report. The hand-written building page's `.title` is an `<h1>` but never set `font-weight`, so it inherited the browser default **700**. The frame templates and house pages all set `400`; building was the lone exception. (EB Garamond has no italic-700, so the bold italic verb fell back to a heavy synthetic italic — worse.)

One-line fix: `font-weight: 400` on `.title`. Verified: verb now computes to 400, EB italic-400 loads, renders light/delicate like the rest of the site.