### PR TITLE
building: deploy rehearsal/latency/halflife + Emotional Parking on the bus

### DIFF
--- a/is/building/bus/index.html
+++ b/is/building/bus/index.html
@@ -63,7 +63,7 @@
 </head>
 <body>
 <main>
-  <div class="bar"><h1>interior&#8203;-conditions // instrument bus</h1><span class="stat" id="stat">5 live · 5 staging</span></div>
+  <div class="bar"><h1>interior&#8203;-conditions // instrument bus</h1><span class="stat" id="stat">9 live · 2 staging</span></div>
 
   <div class="lens" id="lens"><span class="lead">sort&nbsp;—</span></div>
   <ol class="board" id="board"></ol>
@@ -81,11 +81,12 @@
     {name:"deadend",href:"/is/building/deadend/",status:"live",desc:"egress from a non-terminating thought",s:{helps:9,tender:6,weird:3,cost:5,opens:49}},
     {name:"who's asking",href:"/is/building/questions/",status:"live",desc:"question vs. accusation, discriminated",s:{helps:5,tender:3,weird:4,cost:3,opens:27}},
     {name:"qol or inflation",href:"/is/building/qol-or-inflation/",status:"live",desc:"upgrade vs. baseline-drift, adjudicated",s:{helps:9,tender:1,weird:1,cost:6,opens:25}},
+    {name:"emotional parking",href:"/is/building/validation/",status:"live",desc:"a feeling, metered and found legitimate",s:{helps:7,tender:8,weird:8,cost:6,opens:14}},
     {name:"label",href:"/is/building/label/",status:"live",desc:"a self-issued label, disassembled",s:{helps:8,tender:6,weird:3,cost:4,opens:12}},
-    {name:"rehearsal",status:"staging",desc:"version control for unsent messages",s:{helps:5,tender:10,weird:8,cost:9,opens:-1}},
+    {name:"rehearsal",href:"/is/building/rehearsal/",status:"live",desc:"version control for unsent messages",s:{helps:5,tender:10,weird:8,cost:9,opens:9}},
+    {name:"latency",href:"/is/building/latency/",status:"live",desc:"event-to-response latency diagnostic",s:{helps:3,tender:6,weird:9,cost:9,opens:6}},
+    {name:"halflife",href:"/is/building/halflife/",status:"live",desc:"affective intensity-decay model",s:{helps:5,tender:6,weird:8,cost:6,opens:5}},
     {name:"containment",status:"staging",desc:"object threat-assessment terminal",s:{helps:2,tender:3,weird:9,cost:8,opens:-1}},
-    {name:"latency",status:"staging",desc:"event-to-response latency diagnostic",s:{helps:3,tender:6,weird:9,cost:9,opens:-1}},
-    {name:"halflife",status:"staging",desc:"affective intensity-decay model",s:{helps:5,tender:6,weird:8,cost:6,opens:-1}},
     {name:"sunk",status:"staging",desc:"cost-basis reconciliation of a held position",s:{helps:5,tender:9,weird:5,cost:6,opens:-1}}
   ];
   var LENS=[{k:"opens",l:"open rate"},{k:"helps",l:"clinical value"},{k:"tender",l:"affective load"},{k:"weird",l:"metaphor reach"},{k:"cost",l:"build cost"}];

--- a/is/building/halflife/index.html
+++ b/is/building/halflife/index.html
@@ -1,0 +1,693 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>DECAY ASSAY — affective isotope decay model</title>
+<link rel="icon" type="image/png" href="/img/a3.png">
+<script src="/analytics.js" defer></script>
+<style>
+  :root{
+    --bg:#0b0e0c;
+    --panel:#0d100e;
+    --grid:#16201a;
+    --grid-major:#1d2c23;
+    --ink:#9fb4a6;
+    --ink-dim:#5f7466;
+    --ink-faint:#3c4d43;
+    --curve:#54d08a;
+    --axis:#2f4a3a;
+    --warn:#cdbf6a;
+    --rule:#1a241e;
+    --field-bg:#0a0d0b;
+    --field-line:#243029;
+  }
+  *{box-sizing:border-box;}
+  html,body{margin:0;padding:0;background:var(--bg);}
+  body{
+    font-family:ui-monospace,"SF Mono","JetBrains Mono","IBM Plex Mono",Menlo,monospace;
+    color:var(--ink);
+    font-size:13px;
+    line-height:1.5;
+    -webkit-font-smoothing:antialiased;
+    text-rendering:optimizeLegibility;
+    padding:0 14px 64px;
+  }
+  .wrap{max-width:680px;margin:0 auto;}
+
+  /* masthead */
+  header{
+    padding:26px 0 14px;
+    border-bottom:1px solid var(--rule);
+  }
+  .masthead-row{
+    display:flex;justify-content:space-between;align-items:baseline;
+    gap:12px;flex-wrap:wrap;
+  }
+  h1{
+    font-size:14px;font-weight:600;letter-spacing:.14em;
+    margin:0;color:var(--ink);text-transform:uppercase;
+  }
+  .unit{
+    font-size:10.5px;letter-spacing:.18em;color:var(--ink-faint);
+    text-transform:uppercase;white-space:nowrap;
+  }
+  .sub{
+    font-size:10.5px;letter-spacing:.06em;color:var(--ink-dim);
+    margin-top:7px;text-transform:uppercase;
+  }
+
+  /* form */
+  form{padding:22px 0 6px;}
+  .field{margin-bottom:20px;}
+  label{
+    display:block;font-size:10.5px;letter-spacing:.13em;
+    color:var(--ink-dim);text-transform:uppercase;margin-bottom:8px;
+  }
+  label .idx{color:var(--ink-faint);margin-right:9px;}
+  input[type=text],input[type=date],select{
+    width:100%;
+    background:var(--field-bg);
+    border:1px solid var(--field-line);
+    color:var(--ink);
+    font-family:inherit;font-size:13.5px;
+    padding:10px 11px;
+    border-radius:0;
+    -webkit-appearance:none;appearance:none;
+    letter-spacing:.02em;
+  }
+  input::placeholder{color:var(--ink-faint);letter-spacing:.02em;}
+  input:focus,select:focus{
+    outline:none;border-color:var(--curve);
+    box-shadow:0 0 0 1px var(--curve) inset;
+  }
+  select{
+    background-image:
+      linear-gradient(45deg,transparent 50%,var(--ink-dim) 50%),
+      linear-gradient(135deg,var(--ink-dim) 50%,transparent 50%);
+    background-position:calc(100% - 16px) 50%,calc(100% - 11px) 50%;
+    background-size:5px 5px,5px 5px;
+    background-repeat:no-repeat;
+    padding-right:32px;cursor:pointer;
+  }
+  /* intensity slider */
+  .intensity-head{
+    display:flex;justify-content:space-between;align-items:baseline;
+  }
+  .intensity-val{
+    font-size:15px;color:var(--ink);letter-spacing:.04em;
+  }
+  .intensity-val .scale{color:var(--ink-faint);font-size:11px;}
+  input[type=range]{
+    width:100%;-webkit-appearance:none;appearance:none;
+    background:transparent;height:26px;margin:2px 0 0;cursor:pointer;
+  }
+  input[type=range]::-webkit-slider-runnable-track{
+    height:1px;background:var(--field-line);
+  }
+  input[type=range]::-moz-range-track{
+    height:1px;background:var(--field-line);
+  }
+  input[type=range]::-webkit-slider-thumb{
+    -webkit-appearance:none;appearance:none;
+    width:2px;height:18px;background:var(--curve);
+    border:none;border-radius:0;margin-top:-8.5px;
+  }
+  input[type=range]::-moz-range-thumb{
+    width:2px;height:18px;background:var(--curve);
+    border:none;border-radius:0;
+  }
+  input[type=range]:focus{outline:none;}
+  input[type=range]:focus::-webkit-slider-thumb{box-shadow:0 0 0 3px rgba(84,208,138,.25);}
+  .ticks{
+    display:flex;justify-content:space-between;
+    font-size:9px;color:var(--ink-faint);letter-spacing:.04em;
+    margin-top:3px;padding:0 1px;
+  }
+
+  button{
+    width:100%;
+    background:var(--field-bg);
+    border:1px solid var(--curve);
+    color:var(--curve);
+    font-family:inherit;font-size:11.5px;letter-spacing:.18em;
+    text-transform:uppercase;
+    padding:13px;border-radius:0;cursor:pointer;
+    margin-top:4px;
+  }
+  button:hover{background:rgba(84,208,138,.07);}
+  button:active{background:rgba(84,208,138,.13);}
+  button:focus{outline:none;box-shadow:0 0 0 1px var(--curve) inset;}
+
+  .err{
+    color:var(--warn);font-size:10.5px;letter-spacing:.06em;
+    margin-top:-10px;margin-bottom:14px;min-height:0;text-transform:uppercase;
+  }
+
+  /* readout */
+  #out{display:none;padding-top:8px;}
+  #out.on{display:block;}
+  .assay-hd{
+    border-top:1px solid var(--rule);
+    border-bottom:1px solid var(--rule);
+    padding:13px 0;margin-bottom:18px;
+    display:flex;justify-content:space-between;align-items:baseline;
+    gap:10px;flex-wrap:wrap;
+  }
+  .assay-hd .lbl{font-size:10px;letter-spacing:.16em;color:var(--ink-faint);text-transform:uppercase;}
+  .isotope{font-size:18px;letter-spacing:.06em;color:var(--ink);}
+  .isotope sup{font-size:10px;color:var(--ink-dim);vertical-align:super;letter-spacing:.02em;}
+
+  /* plot */
+  .plot-frame{
+    border:1px solid var(--field-line);
+    background:var(--field-bg);
+    padding:0;margin-bottom:4px;position:relative;
+  }
+  svg{display:block;width:100%;height:auto;}
+  .cap{
+    font-size:9px;letter-spacing:.08em;color:var(--ink-faint);
+    text-transform:uppercase;margin:7px 1px 22px;
+    display:flex;justify-content:space-between;gap:10px;flex-wrap:wrap;
+  }
+
+  /* data block */
+  .datum{
+    display:flex;justify-content:space-between;align-items:baseline;
+    border-bottom:1px solid var(--rule);
+    padding:9px 0;gap:14px;
+  }
+  .datum .k{font-size:10.5px;letter-spacing:.08em;color:var(--ink-dim);text-transform:uppercase;}
+  .datum .v{font-size:13.5px;color:var(--ink);letter-spacing:.03em;text-align:right;}
+  .datum .v .u{color:var(--ink-faint);font-size:10.5px;letter-spacing:.04em;}
+
+  .proj{margin-top:18px;}
+  .proj-hd{
+    font-size:10px;letter-spacing:.16em;color:var(--ink-faint);
+    text-transform:uppercase;padding-bottom:7px;
+  }
+  .proj-row{
+    display:grid;grid-template-columns:1fr auto auto;
+    gap:10px;align-items:baseline;
+    border-bottom:1px solid var(--rule);padding:8px 0;
+  }
+  .proj-row .t{font-size:10.5px;letter-spacing:.06em;color:var(--ink-dim);text-transform:uppercase;}
+  .proj-row .d{font-size:10.5px;color:var(--ink-faint);letter-spacing:.02em;text-align:right;}
+  .proj-row .n{font-size:13px;color:var(--ink);letter-spacing:.03em;text-align:right;min-width:64px;}
+
+  .threshold{
+    margin-top:20px;
+    border:1px solid var(--field-line);
+    padding:14px 13px;
+  }
+  .threshold .k{font-size:10px;letter-spacing:.14em;color:var(--ink-faint);text-transform:uppercase;}
+  .threshold .v{font-size:17px;color:var(--ink);letter-spacing:.04em;margin-top:6px;}
+  .threshold.nocross .v{color:var(--ink);font-size:13.5px;line-height:1.45;}
+
+  .rerun{margin-top:26px;}
+
+  .foot{
+    margin-top:30px;padding-top:13px;border-top:1px solid var(--rule);
+    font-size:9px;letter-spacing:.05em;color:var(--ink-faint);
+    text-transform:uppercase;line-height:1.7;
+  }
+  .foot span{color:var(--ink-faint);}
+
+  @media (max-width:420px){
+    body{font-size:12.5px;padding:0 11px 56px;}
+    .isotope{font-size:16px;}
+    .threshold .v{font-size:15px;}
+    .proj-row{grid-template-columns:1fr auto;}
+    .proj-row .d{grid-column:1 / -1;text-align:left;order:3;padding-top:2px;}
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header>
+    <div class="masthead-row">
+      <h1>Decay&nbsp;Assay</h1>
+      <div class="unit">Affective Isotope Decay Model / rev 3</div>
+    </div>
+    <div class="sub">Models reported affect as a decaying isotope. Output is a projection.</div>
+  </header>
+
+  <form id="f" autocomplete="off" novalidate>
+    <div class="field">
+      <label for="feel"><span class="idx">01</span>Name the feeling</label>
+      <input type="text" id="feel" maxlength="48" placeholder="e.g. the email I should not have sent" spellcheck="false">
+    </div>
+
+    <div class="field">
+      <label for="amt"><span class="idx">02</span>Current intensity</label>
+      <div class="intensity-head">
+        <span></span>
+        <span class="intensity-val"><span id="amtv">6</span><span class="scale">&nbsp;/ 10</span></span>
+      </div>
+      <input type="range" id="amt" min="1" max="10" step="1" value="6">
+      <div class="ticks"><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span><span>7</span><span>8</span><span>9</span><span>10</span></div>
+    </div>
+
+    <div class="field">
+      <label for="onset"><span class="idx">03</span>Onset date</label>
+      <input type="date" id="onset">
+    </div>
+
+    <div class="field">
+      <label for="prior"><span class="idx">04</span>Prior occurrences of this isotope</label>
+      <select id="prior">
+        <option value="first">First detection</option>
+        <option value="recurring">Recurring — observed before</option>
+        <option value="chronic">Chronic — persistent background source</option>
+      </select>
+    </div>
+
+    <div class="err" id="err"></div>
+
+    <button type="submit" id="run">Run assay</button>
+  </form>
+
+  <section id="out" aria-live="polite">
+    <div class="assay-hd">
+      <div>
+        <div class="lbl">Specimen</div>
+        <div class="isotope" id="iso">—</div>
+      </div>
+      <div style="text-align:right">
+        <div class="lbl">Assayed</div>
+        <div class="isotope" style="font-size:13px;color:var(--ink-dim)" id="asof">—</div>
+      </div>
+    </div>
+
+    <div class="plot-frame">
+      <svg id="plot" viewBox="0 0 600 320" preserveAspectRatio="none" role="img" aria-label="Decay curve plot"></svg>
+    </div>
+    <div class="cap">
+      <span id="capx">Horizontal: days from onset</span>
+      <span>Vertical: intensity 0–10</span>
+    </div>
+
+    <div class="datum">
+      <span class="k">Half-life</span>
+      <span class="v"><span id="hl">—</span> <span class="u">days</span></span>
+    </div>
+    <div class="datum">
+      <span class="k">Decay constant &lambda;</span>
+      <span class="v"><span id="lam">—</span> <span class="u">/ day</span></span>
+    </div>
+    <div class="datum">
+      <span class="k">Elapsed since onset</span>
+      <span class="v"><span id="elapsed">—</span> <span class="u">days</span></span>
+    </div>
+    <div class="datum">
+      <span class="k">Current value on curve</span>
+      <span class="v"><span id="cur">—</span> <span class="u">/ 10</span></span>
+    </div>
+
+    <div class="proj">
+      <div class="proj-hd">Projected residual intensity</div>
+      <div class="proj-row"><span class="t">Onset + 30 d</span><span class="d" id="d30">—</span><span class="n" id="p30">—</span></div>
+      <div class="proj-row"><span class="t">Onset + 90 d</span><span class="d" id="d90">—</span><span class="n" id="p90">—</span></div>
+      <div class="proj-row"><span class="t">Onset + 365 d</span><span class="d" id="d365">—</span><span class="n" id="p365">—</span></div>
+    </div>
+
+    <div class="threshold" id="thr">
+      <div class="k">Projected to fall below threshold (3 / 10)</div>
+      <div class="v" id="thrv">—</div>
+    </div>
+
+    <div class="rerun">
+      <button type="button" id="again">Model another isotope</button>
+    </div>
+
+    <div class="foot">
+      Model: first-order decay, N(t) = N&#8320; &middot; e<sup>&minus;&lambda;t</sup>. <span id="footp"></span><br>
+      Threshold fixed at 3.0. Values are modeled, not measured.
+    </div>
+  </section>
+
+</div>
+
+<script>
+(function(){
+  "use strict";
+
+  var $ = function(id){ return document.getElementById(id); };
+  var LN2 = Math.LN2;
+  var THRESHOLD = 3;
+  var WINDOW_DAYS = 3650; // 10-year modeling window
+  var MS_DAY = 86400000;
+  var MONTHS = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+
+  // ---- deterministic hash from feeling text -> isotope identity ----
+  function hash(str){
+    var h = 2166136261 >>> 0;
+    for (var i=0;i<str.length;i++){
+      h ^= str.charCodeAt(i);
+      h = Math.imul(h, 16777619) >>> 0;
+    }
+    return h >>> 0;
+  }
+
+  // pull a short, pronounceable element-style stem out of the text + hash
+  var STEMS = ["Anhed","Rumin","Catastr","Resent","Longium","Dread","Mortif","Vexr",
+               "Nostalg","Acrim","Grievon","Spite","Yearn","Forebod","Compuls","Lament",
+               "Ennuon","Chagr","Remorr","Angst","Despond","Irritium","Fixat","Wistr",
+               "Humilon","Panicl","Sorrium","Obsess","Regrium","Distrac","Apprehen","Mope"];
+
+  // common words that carry no specimen signal; skip them when seeding the stem
+  var STOP = {the:1,a:1,an:1,and:1,or:1,of:1,to:1,for:1,with:1,that:1,this:1,it:1,
+              is:1,was:1,am:1,are:1,my:1,me:1,you:1,your:1,his:1,her:1,not:1,but:1,
+              about:1,from:1,have:1,had:1,has:1,been:1,being:1,too:1,very:1,so:1,
+              all:1,any:1,how:1,why:1,when:1,what:1,just:1,into:1,over:1,out:1,
+              should:1,would:1,could:1,will:1,can:1,did:1,does:1,doing:1,one:1};
+
+  function isotopeName(feeling, intensity){
+    var clean = (feeling||"").trim();
+    var h = hash(clean.toLowerCase());
+    // seed the stem from the first content word; fall back to hash-picked stem
+    var stem = null;
+    var words = clean.toLowerCase().match(/[a-z]{3,}/g) || [];
+    for (var i=0;i<words.length;i++){
+      if (!STOP[words[i]]){
+        var w = words[i];
+        stem = w.charAt(0).toUpperCase() + w.slice(1, Math.min(w.length, 6));
+        break;
+      }
+    }
+    if (!stem) stem = STEMS[h % STEMS.length];
+    // mass number: deterministic, in a plausible isotope range, perturbed by intensity
+    var mass = 100 + (h % 150) + intensity; // 101..259-ish
+    return { stem: stem, mass: mass };
+  }
+
+  // ---- half-life model (days) ----
+  // base scales with intensity (stronger affect persists longer),
+  // recurrence multiplies (prior exposure decays slower), chronic -> beyond window.
+  function halfLife(intensity, prior){
+    if (prior === "chronic") return Infinity;
+    // base curve: intensity 1 -> ~6d, 5 -> ~26d, 10 -> ~70d (super-linear)
+    var base = 4 + 0.55 * intensity * intensity + 1.6 * intensity;
+    var mult = (prior === "recurring") ? 2.4 : 1.0;
+    return base * mult;
+  }
+
+  function fmtNum(x, dp){
+    if (!isFinite(x)) return "∞";
+    if (dp === undefined) dp = 2;
+    return x.toFixed(dp);
+  }
+
+  function fmtDate(d){
+    return d.getDate() + " " + MONTHS[d.getMonth()] + " " + d.getFullYear();
+  }
+  function fmtMonth(d){
+    return MONTHS[d.getMonth()] + " " + d.getFullYear();
+  }
+  function isoShort(d){
+    var mm = ("0"+(d.getMonth()+1)).slice(-2);
+    var dd = ("0"+d.getDate()).slice(-2);
+    return d.getFullYear()+"-"+mm+"-"+dd;
+  }
+
+  function parseDate(v){
+    if (!v) return null;
+    var p = v.split("-");
+    if (p.length !== 3) return null;
+    var d = new Date(+p[0], (+p[1])-1, +p[2]);
+    if (isNaN(d.getTime())) return null;
+    d.setHours(0,0,0,0);
+    return d;
+  }
+
+  // ---- SVG decay curve ----
+  function drawPlot(N0, lambda, onset, today, hl, prior){
+    var svg = $("plot");
+    var W = 600, H = 320;
+    var padL = 38, padR = 14, padT = 16, padB = 30;
+    var plotW = W - padL - padR;
+    var plotH = H - padT - padB;
+
+    // x domain in days: span enough to show the descent.
+    // for chronic (lambda~0) show the window; else ~ 1.2x the threshold-cross or 4 half-lives.
+    var spanDays;
+    if (prior === "chronic"){
+      spanDays = 365; // show a near-flat line over a year
+    } else {
+      var tCross = (N0 > THRESHOLD) ? (Math.log(N0/THRESHOLD)/lambda) : 0;
+      var fourHl = 4 * hl;
+      spanDays = Math.max(tCross * 1.25, fourHl, 30);
+      // also make sure elapsed time is visible
+      var elapsed = (today - onset)/MS_DAY;
+      if (elapsed > spanDays) spanDays = elapsed * 1.1;
+      spanDays = Math.min(spanDays, WINDOW_DAYS);
+    }
+
+    var x = function(days){ return padL + (days/spanDays)*plotW; };
+    var y = function(val){ return padT + (1 - val/10)*plotH; };
+
+    var ns = "http://www.w3.org/2000/svg";
+    while (svg.firstChild) svg.removeChild(svg.firstChild);
+
+    function line(x1,y1,x2,y2,stroke,w,dash,op){
+      var l = document.createElementNS(ns,"line");
+      l.setAttribute("x1",x1); l.setAttribute("y1",y1);
+      l.setAttribute("x2",x2); l.setAttribute("y2",y2);
+      l.setAttribute("stroke",stroke);
+      l.setAttribute("stroke-width",w||1);
+      if (dash) l.setAttribute("stroke-dasharray",dash);
+      if (op!==undefined) l.setAttribute("opacity",op);
+      l.setAttribute("vector-effect","non-scaling-stroke");
+      svg.appendChild(l);
+    }
+    function txt(xx,yy,s,fill,size,anchor){
+      var t = document.createElementNS(ns,"text");
+      t.setAttribute("x",xx); t.setAttribute("y",yy);
+      t.setAttribute("fill",fill);
+      t.setAttribute("font-size",size||10);
+      t.setAttribute("font-family",'ui-monospace,"SF Mono",Menlo,monospace');
+      t.setAttribute("letter-spacing",".04em");
+      if (anchor) t.setAttribute("text-anchor",anchor);
+      t.textContent = s;
+      svg.appendChild(t);
+    }
+
+    // grid: horizontal at every 2 units
+    for (var v=0; v<=10; v+=2){
+      var gy = y(v);
+      line(padL, gy, W-padR, gy, "#16201a", 1, null, 1);
+      txt(padL-7, gy+3, String(v), "#3c4d43", 9.5, "end");
+    }
+    // vertical grid: ~6 divisions across span
+    var divs = 6;
+    for (var i=0;i<=divs;i++){
+      var dd = (spanDays/divs)*i;
+      var gx = x(dd);
+      line(gx, padT, gx, H-padB, "#16201a", 1, null, 1);
+      var lab = Math.round(dd);
+      txt(gx, H-padB+13, String(lab), "#3c4d43", 9, "middle");
+    }
+
+    // axes (slightly brighter)
+    line(padL, padT, padL, H-padB, "#2f4a3a", 1, null, 1);   // y
+    line(padL, H-padB, W-padR, H-padB, "#2f4a3a", 1, null, 1); // x
+
+    // threshold line at 3
+    var ty = y(THRESHOLD);
+    line(padL, ty, W-padR, ty, "#cdbf6a", 1, "3 4", .7);
+    txt(W-padR-2, ty-4, "thr 3.0", "#cdbf6a", 9, "end");
+
+    // decay curve path
+    var pts = [];
+    var steps = 220;
+    for (var s=0;s<=steps;s++){
+      var dday = (spanDays/steps)*s;
+      var val = N0 * Math.exp(-lambda*dday);
+      pts.push([x(dday), y(val)]);
+    }
+    var dPath = "M " + pts.map(function(p){return p[0].toFixed(2)+" "+p[1].toFixed(2);}).join(" L ");
+    var path = document.createElementNS(ns,"path");
+    path.setAttribute("d", dPath);
+    path.setAttribute("fill","none");
+    path.setAttribute("stroke","#54d08a");
+    path.setAttribute("stroke-width","1.5");
+    path.setAttribute("vector-effect","non-scaling-stroke");
+    svg.appendChild(path);
+
+    // "now" marker: vertical at elapsed days, dot on curve
+    var elapsedD = Math.max(0,(today - onset)/MS_DAY);
+    if (elapsedD <= spanDays){
+      var nx = x(elapsedD);
+      var nval = N0 * Math.exp(-lambda*elapsedD);
+      var nyv = y(nval);
+      line(nx, padT, nx, H-padB, "#54d08a", 1, "2 3", .45);
+      var dot = document.createElementNS(ns,"circle");
+      dot.setAttribute("cx",nx); dot.setAttribute("cy",nyv);
+      dot.setAttribute("r","3"); dot.setAttribute("fill","#54d08a");
+      dot.setAttribute("vector-effect","non-scaling-stroke");
+      svg.appendChild(dot);
+      txt(Math.min(nx+5, W-padR-26), padT+11, "now", "#54d08a", 9, "start");
+    }
+
+    // threshold-cross marker
+    if (prior !== "chronic" && N0 > THRESHOLD){
+      var tC = Math.log(N0/THRESHOLD)/lambda;
+      if (tC <= spanDays){
+        var cx = x(tC);
+        var c2 = document.createElementNS(ns,"circle");
+        c2.setAttribute("cx",cx); c2.setAttribute("cy",ty);
+        c2.setAttribute("r","2.5");
+        c2.setAttribute("fill","none");
+        c2.setAttribute("stroke","#cdbf6a");
+        c2.setAttribute("stroke-width","1");
+        c2.setAttribute("vector-effect","non-scaling-stroke");
+        svg.appendChild(c2);
+      }
+    }
+  }
+
+  // ---- main compute + render ----
+  function run(){
+    var feeling = $("feel").value.trim();
+    var intensity = parseInt($("amt").value,10);
+    var onset = parseDate($("onset").value);
+    var prior = $("prior").value;
+    var err = $("err");
+
+    err.textContent = "";
+
+    // a failed assay must not leave a prior readout standing
+    function abort(msg, focusId){ err.textContent = msg; $("out").classList.remove("on"); $(focusId).focus(); }
+
+    if (!feeling){ abort("Specimen label required (field 01).", "feel"); return; }
+    if (!onset){ abort("Onset date required (field 03).", "onset"); return; }
+
+    var today = new Date(); today.setHours(0,0,0,0);
+    if (onset > today){ abort("Onset date is in the future. Decay undefined prior to onset.", "onset"); return; }
+
+    var iso = isotopeName(feeling, intensity);
+    var N0 = intensity; // intensity at onset = reported current intensity, modeled as initial activity
+    var hl = halfLife(intensity, prior);
+    var lambda = isFinite(hl) ? (LN2 / hl) : 0;
+
+    // render specimen identity
+    $("iso").innerHTML = iso.stem + "&#8202;<sup>" + iso.mass + "</sup>";
+    $("asof").textContent = isoShort(today);
+
+    // datum block
+    if (prior === "chronic"){
+      $("hl").textContent = ">" + WINDOW_DAYS;
+      $("lam").textContent = "≈ 0.000";
+    } else {
+      $("hl").textContent = fmtNum(hl, 1);
+      $("lam").textContent = fmtNum(lambda, 4);
+    }
+
+    var elapsedDays = Math.round((today - onset)/MS_DAY);
+    $("elapsed").textContent = String(elapsedDays);
+
+    function valueAtDays(d){ return N0 * Math.exp(-lambda*d); }
+
+    var curVal = valueAtDays(Math.max(0,elapsedDays));
+    $("cur").textContent = fmtNum(curVal, 2);
+
+    // projections measured from ONSET (+30/+90/+365), labeled with absolute dates
+    function projAt(daysFromOnset, nEl, dEl){
+      var val = valueAtDays(daysFromOnset);
+      $(nEl).textContent = fmtNum(val, 2) + " / 10";
+      var dt = new Date(onset.getTime() + daysFromOnset*MS_DAY);
+      $(dEl).textContent = isoShort(dt);
+    }
+    projAt(30,  "p30",  "d30");
+    projAt(90,  "p90",  "d90");
+    projAt(365, "p365", "d365");
+
+    // threshold crossing
+    var thr = $("thr");
+    var thrv = $("thrv");
+    thr.classList.remove("nocross");
+    if (prior === "chronic"){
+      thr.classList.add("nocross");
+      thrv.textContent = "Half-life exceeds modeling window. No threshold crossing projected.";
+    } else if (N0 <= THRESHOLD){
+      // already at/below threshold at onset
+      var crossDate0 = onset; // crossing is at or before onset
+      thr.classList.remove("nocross");
+      // report onset date as the crossing datum (value already <= threshold)
+      thrv.textContent = fmtDate(onset);
+    } else {
+      var tCross = Math.log(N0/THRESHOLD)/lambda; // days from onset
+      if (tCross > WINDOW_DAYS){
+        thr.classList.add("nocross");
+        thrv.textContent = "Crossing falls beyond modeling window. No threshold crossing projected.";
+      } else {
+        var crossDate = new Date(onset.getTime() + tCross*MS_DAY);
+        thrv.textContent = fmtMonth(crossDate) + " (modeled)";
+      }
+    }
+
+    // footnote: model params, flat
+    var priorTxt = prior === "first" ? "First detection." :
+                   prior === "recurring" ? "Recurring source; half-life scaled ×2.4." :
+                   "Chronic source; decay constant approaches zero.";
+    $("footp").textContent = priorTxt;
+
+    // capx note (mobile-friendly span label)
+    $("capx").textContent = "Horizontal: days from onset (" + isoShort(onset) + ")";
+
+    drawPlot(N0, lambda, onset, today, hl, prior);
+
+    $("out").classList.add("on");
+    // bring readout into view on small screens
+    requestAnimationFrame(function(){
+      var top = $("out").getBoundingClientRect().top + window.pageYOffset - 8;
+      window.scrollTo({ top: top, behavior: "smooth" });
+    });
+  }
+
+  // ---- wiring ----
+  $("amt").addEventListener("input", function(){
+    $("amtv").textContent = this.value;
+  });
+
+  $("f").addEventListener("submit", function(e){
+    e.preventDefault();
+    run();
+  });
+
+  $("again").addEventListener("click", function(){
+    $("out").classList.remove("on");
+    $("err").textContent = "";
+    window.scrollTo({ top:0, behavior:"smooth" });
+    $("feel").focus();
+  });
+
+  // default onset = today (low friction); user can change
+  (function initDate(){
+    var t = new Date();
+    var mm = ("0"+(t.getMonth()+1)).slice(-2);
+    var dd = ("0"+t.getDate()).slice(-2);
+    var el = $("onset");
+    el.value = t.getFullYear()+"-"+mm+"-"+dd;
+    el.max = t.getFullYear()+"-"+mm+"-"+dd;
+  })();
+
+  // redraw on resize so the SVG text/strokes stay crisp (viewBox handles scale,
+  // but re-run keeps non-scaling strokes consistent if re-laid out)
+  var rt;
+  window.addEventListener("resize", function(){
+    if (!$("out").classList.contains("on")) return;
+    clearTimeout(rt);
+    rt = setTimeout(function(){ run(); }, 180);
+  });
+
+})();
+</script>
+<a class="bus-home" href="/is/building/bus/">&larr; instrument bus</a>
+<style>
+.bus-home{position:fixed;left:14px;bottom:12px;z-index:60;font:600 11px/1 ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.04em;color:var(--ink-dim);text-decoration:none;padding:6px 10px;border:1px solid var(--rule);border-radius:999px;background:rgba(11,14,12,.8);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);transition:color .18s,border-color .18s}
+.bus-home:hover,.bus-home:focus-visible{color:var(--ink);border-color:var(--ink-dim)}
+</style>
+</body>
+</html>

--- a/is/building/latency/index.html
+++ b/is/building/latency/index.html
@@ -1,0 +1,981 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>STN OBR-1 — propagation monitor</title>
+<link rel="icon" type="image/png" href="/img/a3.png">
+<script src="/analytics.js" defer></script>
+<style>
+  :root {
+    --bg: #07090b;
+    --panel: #0b0f12;
+    --grid: #14201f;
+    --gridmaj: #1d2e2b;
+    --fg: #c7d2c9;
+    --dim: #5d6b62;
+    --dimmer: #38423c;
+    --trace: #e0a84b;
+    --traceq: #6c5a2e;
+    --mark: #7fb6a0;
+    --line: #161d1a;
+    --field: #0a0e10;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: ui-monospace, "SF Mono", "JetBrains Mono", "IBM Plex Mono", Menlo, Consolas, monospace;
+    font-size: 13px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 20px 14px 70px;
+  }
+
+  /* station header bar */
+  header {
+    border: 1px solid var(--line);
+    background: var(--panel);
+    padding: 9px 12px;
+    margin-bottom: 14px;
+  }
+  .hdr-top {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 6px 16px;
+  }
+  .stn-code { color: var(--fg); letter-spacing: 1px; font-weight: 600; }
+  .stn-name { color: var(--dim); font-size: 11px; letter-spacing: 0.5px; }
+  .hdr-right { margin-left: auto; color: var(--dim); font-size: 11px; }
+  .hdr-meta {
+    margin-top: 6px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 18px;
+    color: var(--dim);
+    font-size: 11px;
+  }
+  .hdr-meta span b { color: var(--mark); font-weight: 400; }
+  .dot {
+    display: inline-block; width: 7px; height: 7px; border-radius: 0;
+    background: var(--trace); margin-right: 5px; vertical-align: baseline;
+    animation: pulse 1.8s steps(1) infinite;
+  }
+  @keyframes pulse { 50% { opacity: 0.25; } }
+
+  /* one prose line stating what the station is for — the plain-language
+     entry point a cold visitor needs before the technical codes */
+  .hdr-purpose {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--line);
+    color: #9fb0a4;
+    font-size: 12px;
+    line-height: 1.5;
+    letter-spacing: 0.2px;
+    max-width: 62ch;
+  }
+
+  /* drum / trace panel */
+  .drum {
+    border: 1px solid var(--line);
+    background: var(--panel);
+    padding: 0;
+    margin-bottom: 14px;
+  }
+  .drum-label {
+    display: flex; flex-wrap: wrap; gap: 4px 14px;
+    padding: 7px 12px;
+    border-bottom: 1px solid var(--line);
+    color: var(--dim); font-size: 11px; letter-spacing: 0.5px;
+  }
+  .drum-label .chan { color: var(--fg); }
+  .drum-label .spacer { margin-left: auto; }
+  .canvas-host {
+    position: relative;
+    width: 100%;
+    background:
+      repeating-linear-gradient(90deg, transparent 0 calc(10% - 1px), var(--grid) calc(10% - 1px) 10%),
+      var(--field);
+  }
+  canvas { display: block; width: 100%; height: auto; }
+  .axis-row {
+    display: flex; justify-content: space-between;
+    padding: 4px 12px 8px;
+    color: var(--dimmer); font-size: 10px;
+    border-top: 1px solid var(--line);
+  }
+
+  /* control console */
+  .console {
+    border: 1px solid var(--line);
+    background: var(--panel);
+    padding: 12px 12px 14px;
+  }
+  .console-title {
+    color: var(--dim); font-size: 11px; letter-spacing: 0.5px;
+    border-bottom: 1px solid var(--line);
+    padding-bottom: 8px; margin-bottom: 4px;
+  }
+  label.fld { display: block; margin-top: 13px; }
+  .fld-key { display: block; color: var(--dim); font-size: 11px; margin-bottom: 5px; letter-spacing: 0.3px; }
+  .fld-key b { color: var(--fg); font-weight: 400; }
+  .fld-hint { color: var(--dimmer); }
+  input[type="text"], input[type="date"] {
+    width: 100%;
+    background: var(--field);
+    border: 1px solid var(--line);
+    color: var(--fg);
+    font-family: inherit;
+    font-size: 13px;
+    padding: 8px 10px;
+    border-radius: 0;
+    outline: none;
+  }
+  input::placeholder { color: var(--dimmer); }
+  input:focus { border-color: var(--dim); }
+  input[type="date"] { color-scheme: dark; min-height: 36px; }
+  .row2 { display: flex; gap: 12px; flex-wrap: wrap; }
+  .row2 > .col { flex: 1 1 170px; }
+
+  .magwrap { display: flex; align-items: center; gap: 10px; }
+  input[type="range"] {
+    flex: 1; -webkit-appearance: none; appearance: none;
+    height: 2px; background: var(--line); outline: none; margin: 0;
+  }
+  input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none; appearance: none;
+    width: 9px; height: 17px; background: var(--trace);
+    border: none; border-radius: 0; cursor: pointer;
+  }
+  input[type="range"]::-moz-range-thumb {
+    width: 9px; height: 17px; background: var(--trace);
+    border: none; border-radius: 0; cursor: pointer;
+  }
+  .magval { width: 64px; text-align: right; color: var(--dim); font-size: 11px; white-space: nowrap; }
+
+  .actions { margin-top: 18px; display: flex; gap: 10px; flex-wrap: wrap; }
+  button {
+    font-family: inherit; font-size: 12px;
+    background: var(--field); color: var(--fg);
+    border: 1px solid var(--dim);
+    padding: 8px 16px; border-radius: 0; cursor: pointer; letter-spacing: 0.4px;
+  }
+  button:hover { border-color: var(--trace); color: var(--trace); }
+  button:active { background: #10161480; }
+  button.ghost { border-color: var(--line); color: var(--dim); }
+  button.ghost:hover { border-color: var(--dim); color: var(--fg); }
+  button:disabled { opacity: 0.4; cursor: default; }
+  button:disabled:hover { border-color: var(--dim); color: var(--fg); }
+
+  .err { color: #c4795a; font-size: 11px; margin-top: 11px; min-height: 13px; }
+
+  /* readout */
+  #readout { margin-top: 14px; }
+  #readout:empty { display: none; }
+  .stream {
+    white-space: pre-wrap; word-break: break-word;
+    border: 1px solid var(--line); background: var(--field);
+    padding: 10px 12px; font-size: 12px; line-height: 1.55;
+  }
+  .stream:empty { display: none; }
+  .ln { display: block; }
+  .ln.dim { color: var(--dim); }
+  .ln.trace { color: var(--trace); }
+  .ln.mark { color: var(--mark); }
+  .ln.fg { color: var(--fg); }
+
+  .report { margin-top: 12px; border: 1px solid var(--line); background: var(--panel); }
+  .report .rtitle {
+    padding: 8px 12px; border-bottom: 1px solid var(--line);
+    color: var(--dim); font-size: 11px; letter-spacing: 0.5px;
+  }
+  .report table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  .report td { padding: 7px 12px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  .report tr:last-child td { border-bottom: none; }
+  .report td.k { color: var(--dim); width: 46%; white-space: nowrap; }
+  .report td.v { color: var(--fg); }
+  .report td.v.trace { color: var(--trace); }
+  .report td.v.mark { color: var(--mark); }
+
+  .statusbar {
+    margin-top: 12px; padding: 9px 12px;
+    border: 1px solid var(--line); background: var(--panel);
+    font-size: 12px; color: var(--fg);
+  }
+  .statusbar .sb-key { color: var(--dim); }
+
+  footer {
+    margin-top: 22px; color: var(--dimmer); font-size: 10px;
+    border-top: 1px solid var(--line); padding-top: 9px; letter-spacing: 0.3px;
+  }
+  .cur {
+    display: inline-block; width: 6px; height: 12px; background: var(--trace);
+    vertical-align: text-bottom; animation: pulse 1.05s steps(1) infinite;
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div class="hdr-top">
+      <span class="stn-code"><span class="dot"></span>STN OBR-1</span>
+      <span class="stn-name">single-station felt-arrival monitor</span>
+      <span class="hdr-right" id="clock">--:--:-- UTC</span>
+    </div>
+    <div class="hdr-purpose">Records the interval between an event and the response it produces. The delay is reported as distance from the epicenter.</div>
+    <div class="hdr-meta">
+      <span>net <b>OB</b></span>
+      <span>chan <b>BHZ</b></span>
+      <span>gain <b>auto</b></span>
+      <span>vel model <b>1.00 km/d</b></span>
+      <span id="state-meta">state <b>ACQUIRING</b></span>
+    </div>
+  </header>
+
+  <div class="drum">
+    <div class="drum-label">
+      <span class="chan">BHZ</span>
+      <span>continuous record</span>
+      <span class="spacer"></span>
+      <span id="drum-status">listening</span>
+    </div>
+    <div class="canvas-host">
+      <canvas id="trace" width="1480" height="320" aria-label="seismogram trace"></canvas>
+    </div>
+    <div class="axis-row">
+      <span id="ax-left">origin</span>
+      <span>propagation axis (days from origin) &#8594;</span>
+      <span id="ax-right">now</span>
+    </div>
+  </div>
+
+  <div class="console">
+    <div class="console-title">EVENT LOG — single channel</div>
+    <div class="console-note" style="color:var(--dim);font-size:11px;line-height:1.55;letter-spacing:.3px;margin-bottom:14px;max-width:54ch;">Log an event and the date its response was first felt here. The interval is reported as propagation delay.</div>
+    <form id="form" autocomplete="off">
+      <label class="fld">
+        <span class="fld-key"><b>log event</b> &#8212; origin label</span>
+        <input type="text" id="event" maxlength="120" placeholder="e.g. the call from the hospital" />
+      </label>
+
+      <div class="row2" style="margin-top:13px;">
+        <label class="fld col" style="margin-top:0;">
+          <span class="fld-key"><b>origin time</b> &#8212; when it happened</span>
+          <input type="date" id="t_event" />
+        </label>
+        <label class="fld col" style="margin-top:0;">
+          <span class="fld-key"><b>first arrival at station</b> &#8212; when the response was felt <span class="fld-hint">(blank if none)</span></span>
+          <input type="date" id="t_resp" />
+        </label>
+      </div>
+
+      <label class="fld">
+        <span class="fld-key"><b>recorded amplitude</b> &#8212; 1&#8211;10 <span class="fld-hint">(optional)</span></span>
+        <div class="magwrap">
+          <input type="range" id="mag" min="0" max="10" step="1" value="0" />
+          <span class="magval" id="magval">unset</span>
+        </div>
+      </label>
+
+      <div class="actions">
+        <button type="submit" id="run">record trace</button>
+        <button type="button" class="ghost" id="again" style="display:none;">clear &amp; log next</button>
+      </div>
+      <div class="err" id="err"></div>
+    </form>
+  </div>
+
+  <div id="readout" aria-live="polite"></div>
+
+  <footer>STN OBR-1 records on the vertical component. local session only; no telemetry transmitted.</footer>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var form = document.getElementById("form");
+  var elEvent = document.getElementById("event");
+  var elTEvent = document.getElementById("t_event");
+  var elTResp = document.getElementById("t_resp");
+  var elMag = document.getElementById("mag");
+  var elMagVal = document.getElementById("magval");
+  var elErr = document.getElementById("err");
+  var elReadout = document.getElementById("readout");
+  var btnRun = document.getElementById("run");
+  var btnAgain = document.getElementById("again");
+  var canvas = document.getElementById("trace");
+  var ctx = canvas.getContext("2d");
+  var drumStatus = document.getElementById("drum-status");
+  var axLeft = document.getElementById("ax-left");
+  var axRight = document.getElementById("ax-right");
+  var stateMeta = document.getElementById("state-meta");
+  var clockEl = document.getElementById("clock");
+
+  // --- station clock (cosmetic, ticks UTC) ---
+  function tick() {
+    var d = new Date();
+    function p(n) { return (n < 10 ? "0" : "") + n; }
+    clockEl.textContent = p(d.getUTCHours()) + ":" + p(d.getUTCMinutes()) + ":" + p(d.getUTCSeconds()) + " UTC";
+  }
+  tick();
+  setInterval(tick, 1000);
+
+  elMag.addEventListener("input", function () {
+    var v = parseInt(elMag.value, 10);
+    elMagVal.textContent = v === 0 ? "unset" : (v + " / 10");
+  });
+
+  // --- deterministic hash for cosmetic microseism wiggle (NOT for readings) ---
+  function hash32(str) {
+    var h = 2166136261 >>> 0;
+    for (var i = 0; i < str.length; i++) {
+      h ^= str.charCodeAt(i);
+      h = Math.imul(h, 16777619) >>> 0;
+    }
+    return h >>> 0;
+  }
+  function mixstep(h) {
+    h ^= h << 13; h >>>= 0;
+    h ^= h >> 17;
+    h ^= h << 5;  h >>>= 0;
+    return h >>> 0;
+  }
+  // seeded value generator in [0,1), deterministic
+  function seededRand(seed) {
+    var s = seed >>> 0;
+    return function () {
+      s = mixstep((s + 0x6d2b79f5) >>> 0);
+      return (s >>> 0) / 4294967296;
+    };
+  }
+
+  function pad(n, w) {
+    var s = "" + n;
+    while (s.length < w) s = " " + s;
+    return s;
+  }
+  function fixed(n, d) { return Number(n).toFixed(d); }
+  function commaInt(n) {
+    var s = "" + Math.round(n);
+    return s.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  }
+
+  function parseDate(v) {
+    if (!v) return null;
+    var parts = v.split("-");
+    if (parts.length !== 3) return null;
+    var y = parseInt(parts[0], 10), m = parseInt(parts[1], 10), d = parseInt(parts[2], 10);
+    if (!y || !m || !d) return null;
+    return Date.UTC(y, m - 1, d);
+  }
+
+  var MS_DAY = 86400000;
+  var VELOCITY_KM_PER_DAY = 1.00; // declared velocity model; delay -> distance
+
+  function fmtDateUTC(ms) {
+    var d = new Date(ms);
+    function p(n) { return (n < 10 ? "0" : "") + n; }
+    return d.getUTCFullYear() + "-" + p(d.getUTCMonth() + 1) + "-" + p(d.getUTCDate());
+  }
+  function fmtStamp(ms) {
+    // monitoring-format timestamp: YYYY-MM-DD 00:00:00.000
+    return fmtDateUTC(ms) + " 00:00:00.000";
+  }
+
+  function originLabel(name) {
+    var n = name.trim();
+    if (!n) return "event";
+    return n.length > 54 ? n.slice(0, 53) + "…" : n;
+  }
+
+  // ------------------------------------------------------------------
+  //  CANVAS TRACE
+  //  Single horizontal channel. Quiet microseism baseline runs left->right.
+  //  An arrival burst (the wave) sits at a horizontal position set by the
+  //  propagation delay: the longer the delay, the further right. With no
+  //  arrival, the baseline simply continues quiet.
+  // ------------------------------------------------------------------
+
+  var DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
+
+  var lastHostW = 0, lastCssH = 0;
+  function sizeCanvas() {
+    var hostW = canvas.parentNode.clientWidth || 740;
+    // keep a stable aspect; taller on wide, shorter on narrow
+    var cssH = hostW < 460 ? 240 : 320;
+    // only reallocate the backing store when the box actually changed —
+    // setting canvas.width every animation frame would clear + realloc needlessly
+    if (hostW === lastHostW && cssH === lastCssH) return;
+    lastHostW = hostW; lastCssH = cssH;
+    canvas.style.height = cssH + "px";
+    canvas.width = Math.round(hostW * DPR);
+    canvas.height = Math.round(cssH * DPR);
+  }
+
+  // current trace model, redrawn on resize
+  var traceModel = null; // {seed, delayFrac, amp, hasArrival}
+
+  function quietModel() {
+    return { seed: 0x515E15, delayFrac: 1.0, amp: 0, hasArrival: false, idle: true };
+  }
+
+  function drawTrace(model) {
+    sizeCanvas();
+    var W = canvas.width, H = canvas.height;
+    var padL = 6 * DPR, padR = 6 * DPR;
+    var midY = H * 0.5;
+    var plotW = W - padL - padR;
+
+    ctx.clearRect(0, 0, W, H);
+
+    // grid: faint horizontal guides (drum trace lanes feel)
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = "rgba(125,182,160,0.06)";
+    var lanes = 6;
+    for (var g = 1; g < lanes; g++) {
+      var y = (H / lanes) * g;
+      ctx.beginPath();
+      ctx.moveTo(0, Math.round(y) + 0.5);
+      ctx.lineTo(W, Math.round(y) + 0.5);
+      ctx.stroke();
+    }
+    // zero line
+    ctx.strokeStyle = "rgba(125,182,160,0.12)";
+    ctx.beginPath();
+    ctx.moveTo(0, Math.round(midY) + 0.5);
+    ctx.lineTo(W, Math.round(midY) + 0.5);
+    ctx.stroke();
+
+    var rnd = seededRand(model.seed >>> 0);
+    // pre-roll a few values so different seeds visibly diverge
+    for (var w = 0; w < 7; w++) rnd();
+
+    // microseism noise amplitude (quiet baseline)
+    var noiseAmp = (model.idle ? 2.0 : 2.6) * DPR;
+
+    // arrival geometry
+    var arrivalX = padL + plotW * Math.max(0.04, Math.min(0.98, model.delayFrac));
+    // burst envelope width scales a touch with amplitude, fixed-ish
+    var burstW = (38 + model.amp * 7) * DPR;
+    // peak deflection of the wave; grows with recorded amplitude
+    var peakAmp = (H * 0.30) * (0.30 + 0.70 * (model.amp / 10));
+    if (model.amp === 0) peakAmp = H * 0.20; // default modest deflection when amplitude unset
+
+    // walk pixel by pixel
+    var step = Math.max(1, Math.floor(DPR));
+    var prevX = padL, prevY = midY;
+    var firstPt = true;
+
+    // slow-drift component so baseline isn't a dead ruler
+    var driftPhase = rnd() * Math.PI * 2;
+    var driftFreq = 0.6 + rnd() * 0.5;
+
+    // build a deterministic phase for the burst oscillation
+    var burstFreq = 0.45 + rnd() * 0.25; // rad per px-ish
+    var burstPhase = rnd() * Math.PI * 2;
+
+    ctx.lineWidth = 1.25 * DPR;
+    ctx.strokeStyle = "#e0a84b";
+    ctx.lineJoin = "round";
+    ctx.lineCap = "round";
+    ctx.beginPath();
+
+    for (var x = padL; x <= padL + plotW; x += step) {
+      var t = (x - padL);
+      // quiet microseism: low-amplitude pseudo-noise + slow drift
+      var n = (rnd() - 0.5) * 2 * noiseAmp;
+      var drift = Math.sin((t / plotW) * Math.PI * 2 * driftFreq * 3 + driftPhase) * 1.6 * DPR;
+      var yv = n + drift;
+
+      // arrival burst contribution (only if an arrival registered)
+      if (model.hasArrival) {
+        var dx = x - arrivalX;
+        // gaussian envelope centered at arrivalX, slight asymmetry (coda longer to the right)
+        var sigmaL = burstW * 0.55;
+        var sigmaR = burstW * 1.25;
+        var env;
+        if (dx <= 0) env = Math.exp(-(dx * dx) / (2 * sigmaL * sigmaL));
+        else env = Math.exp(-(dx * dx) / (2 * sigmaR * sigmaR));
+        // oscillation inside the envelope
+        var osc = Math.sin(dx * (burstFreq / DPR) + burstPhase);
+        // a second harmonic for body-wave texture
+        osc = osc * 0.78 + Math.sin(dx * (burstFreq / DPR) * 2.1 + burstPhase * 1.7) * 0.22;
+        yv += env * osc * peakAmp;
+      }
+
+      var py = midY - yv;
+      if (firstPt) { ctx.moveTo(x, py); firstPt = false; }
+      else { ctx.lineTo(x, py); }
+      prevX = x; prevY = py;
+    }
+    ctx.stroke();
+
+    // arrival marker (vertical pick line + label), only when arrival exists
+    if (model.hasArrival) {
+      ctx.save();
+      ctx.setLineDash([5 * DPR, 4 * DPR]);
+      ctx.lineWidth = 1 * DPR;
+      ctx.strokeStyle = "rgba(127,182,160,0.55)";
+      ctx.beginPath();
+      ctx.moveTo(Math.round(arrivalX) + 0.5, H * 0.06);
+      ctx.lineTo(Math.round(arrivalX) + 0.5, H * 0.94);
+      ctx.stroke();
+      ctx.restore();
+
+      ctx.fillStyle = "#7fb6a0";
+      ctx.font = (11 * DPR) + "px ui-monospace, Menlo, monospace";
+      ctx.textBaseline = "top";
+      var lbl = "P";
+      var lblX = arrivalX + 5 * DPR;
+      // keep label on-canvas
+      if (lblX > W - 14 * DPR) lblX = arrivalX - 14 * DPR;
+      ctx.fillText(lbl, lblX, H * 0.06);
+    }
+
+    // "origin" tick at far left
+    ctx.fillStyle = "rgba(127,182,160,0.4)";
+    ctx.font = (10 * DPR) + "px ui-monospace, Menlo, monospace";
+    ctx.textBaseline = "top";
+    ctx.fillText("O", padL + 2 * DPR, H * 0.06);
+  }
+
+  // redraw the recorded/quiet trace (used on resize while an event is shown)
+  function drawCurrent() {
+    drawTrace(traceModel || quietModel());
+  }
+
+  // ------------------------------------------------------------------
+  //  IDLE LIVE RECORD
+  //  "continuous record" actually scrolls: a quiet microseism baseline,
+  //  new samples entering at the right ("now") and drifting left. This is
+  //  what makes the station read as *listening* rather than flatlined.
+  // ------------------------------------------------------------------
+  var IDLE_N = 240;            // logical sample columns across the plot
+  var idleBuf = null;
+  var idleRnd = seededRand(0x1A7E11);
+  var idlePhase = 0;
+  var idleRAF = null;
+  var idleLast = 0;
+
+  function clampv(v, lo, hi) { return v < lo ? lo : (v > hi ? hi : v); }
+
+  function initIdleBuf() {
+    idleBuf = new Float32Array(IDLE_N);
+    var v = 0;
+    for (var i = 0; i < IDLE_N; i++) {
+      v = clampv(v * 0.86 + (idleRnd() - 0.5) * 0.9, -2.2, 2.2);
+      idleBuf[i] = v;
+    }
+  }
+  function pushIdleSample() {
+    var N = idleBuf.length, i;
+    for (i = 0; i < N - 1; i++) idleBuf[i] = idleBuf[i + 1];
+    idleBuf[N - 1] = clampv(idleBuf[N - 2] * 0.86 + (idleRnd() - 0.5) * 0.9, -2.2, 2.2);
+  }
+
+  function drawGrid(W, H, midY) {
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = "rgba(125,182,160,0.06)";
+    var lanes = 6, g, y;
+    for (g = 1; g < lanes; g++) {
+      y = (H / lanes) * g;
+      ctx.beginPath();
+      ctx.moveTo(0, Math.round(y) + 0.5);
+      ctx.lineTo(W, Math.round(y) + 0.5);
+      ctx.stroke();
+    }
+    ctx.strokeStyle = "rgba(125,182,160,0.12)";
+    ctx.beginPath();
+    ctx.moveTo(0, Math.round(midY) + 0.5);
+    ctx.lineTo(W, Math.round(midY) + 0.5);
+    ctx.stroke();
+  }
+
+  function drawIdleFrame() {
+    sizeCanvas();
+    var W = canvas.width, H = canvas.height;
+    var padL = 6 * DPR, padR = 6 * DPR, midY = H * 0.5, plotW = W - padL - padR;
+    ctx.clearRect(0, 0, W, H);
+    drawGrid(W, H, midY);
+
+    idlePhase += 0.02;
+    var ampPx = H * 0.085, driftPx = H * 0.05;
+    var N = idleBuf.length, i, x, drift, yv, py;
+
+    ctx.lineWidth = 1.25 * DPR;
+    ctx.strokeStyle = "#e0a84b";
+    ctx.lineJoin = "round";
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    for (i = 0; i < N; i++) {
+      x = padL + plotW * (i / (N - 1));
+      drift = Math.sin((i / N) * Math.PI * 2 * 1.5 + idlePhase) * 0.35;
+      yv = idleBuf[i] * ampPx + drift * driftPx;
+      py = midY - yv;
+      if (i === 0) ctx.moveTo(x, py); else ctx.lineTo(x, py);
+    }
+    ctx.stroke();
+
+    // "now" write head at the right edge — the pen the record scrolls under
+    ctx.strokeStyle = "rgba(127,182,160,0.30)";
+    ctx.lineWidth = 1 * DPR;
+    ctx.beginPath();
+    ctx.moveTo(Math.round(padL + plotW) + 0.5, H * 0.06);
+    ctx.lineTo(Math.round(padL + plotW) + 0.5, H * 0.94);
+    ctx.stroke();
+
+    // origin tick
+    ctx.fillStyle = "rgba(127,182,160,0.4)";
+    ctx.font = (10 * DPR) + "px ui-monospace, Menlo, monospace";
+    ctx.textBaseline = "top";
+    ctx.fillText("O", padL + 2 * DPR, H * 0.06);
+  }
+
+  function idleLoop(ts) {
+    idleRAF = requestAnimationFrame(idleLoop);
+    if (document.hidden) return;
+    if (!idleLast) idleLast = ts;
+    var dt = ts - idleLast, interval = 38; // ms per new sample (~26/s)
+    if (dt >= interval) {
+      idleLast = ts - (dt % interval);
+      pushIdleSample();
+      drawIdleFrame();
+    }
+  }
+  function startIdle() {
+    if (idleRAF) return;
+    if (!idleBuf) initIdleBuf();
+    traceModel = null;          // idle owns the canvas
+    idleLast = 0;
+    drawIdleFrame();
+    idleRAF = requestAnimationFrame(idleLoop);
+  }
+  function stopIdle() {
+    if (idleRAF) { cancelAnimationFrame(idleRAF); idleRAF = null; }
+  }
+
+  window.addEventListener("resize", function () {
+    if (idleRAF) drawIdleFrame();
+    else drawCurrent();
+  });
+
+  // initial state: live and listening, not a frozen baseline
+  initIdleBuf();
+  startIdle();
+
+  // ------------------------------------------------------------------
+  //  STREAMING READOUT
+  // ------------------------------------------------------------------
+
+  var running = false;
+
+  function lineEl(text, cls) {
+    var span = document.createElement("span");
+    span.className = "ln" + (cls ? " " + cls : "");
+    span.textContent = text;
+    return span;
+  }
+
+  function streamLines(target, items, done) {
+    var i = 0;
+    function next() {
+      if (i >= items.length) { if (done) done(); return; }
+      var it = items[i++];
+      target.appendChild(lineEl(it.text, it.cls));
+      window.scrollTo(0, document.body.scrollHeight);
+      setTimeout(next, it.wait != null ? it.wait : 80);
+    }
+    next();
+  }
+
+  function buildReportTable(rows, titleText) {
+    var box = document.createElement("div");
+    box.className = "report";
+    var t = document.createElement("div");
+    t.className = "rtitle";
+    t.textContent = titleText;
+    box.appendChild(t);
+    var tbl = document.createElement("table");
+    rows.forEach(function (r) {
+      var tr = document.createElement("tr");
+      var td1 = document.createElement("td");
+      td1.className = "k";
+      td1.textContent = r[0];
+      var td2 = document.createElement("td");
+      td2.className = "v" + (r[2] ? " " + r[2] : "");
+      td2.textContent = r[1];
+      tr.appendChild(td1);
+      tr.appendChild(td2);
+      tbl.appendChild(tr);
+    });
+    box.appendChild(tbl);
+    return box;
+  }
+
+  function statusBar(keyText, valText) {
+    var s = document.createElement("div");
+    s.className = "statusbar";
+    var k = document.createElement("span");
+    k.className = "sb-key";
+    k.textContent = keyText + "  ";
+    var v = document.createElement("span");
+    v.textContent = valText;
+    s.appendChild(k);
+    s.appendChild(v);
+    return s;
+  }
+
+  function appendNode(node) {
+    elReadout.appendChild(node);
+    window.scrollTo(0, document.body.scrollHeight);
+  }
+
+  // ------------------------------------------------------------------
+  //  RUN
+  // ------------------------------------------------------------------
+
+  function run() {
+    if (running) return;
+    elErr.textContent = "";
+
+    var evt = elEvent.value.trim();
+    var tE = parseDate(elTEvent.value);
+    var tR = parseDate(elTResp.value);
+    var mag = parseInt(elMag.value, 10) || 0;
+
+    if (!evt) { elErr.textContent = "no origin logged. enter an event to record."; return; }
+    if (tE == null) { elErr.textContent = "origin time required."; return; }
+    if (tR != null && tR < tE) { elErr.textContent = "arrival precedes origin. check the timestamps."; return; }
+
+    running = true;
+    stopIdle();                 // freeze the live record; the event trace takes over
+    btnRun.disabled = true;
+    btnAgain.style.display = "none";
+    elReadout.innerHTML = "";
+    drumStatus.textContent = "arming";
+    stateMeta.innerHTML = "state <b>RECORDING</b>";
+
+    var label = originLabel(evt);
+    var seed = hash32(evt + "|" + elTEvent.value) >>> 0;
+    var hasArrival = (tR != null);
+
+    var days = hasArrival ? Math.round((tR - tE) / MS_DAY) : null;
+    if (days != null && days < 0) days = 0;
+
+    // map delay -> horizontal fraction of the trace.
+    // log-ish compression so a 2-day and a 900-day arrival both fit, both legible.
+    var delayFrac;
+    if (!hasArrival) {
+      delayFrac = 1.0;
+    } else {
+      // 0 d -> ~0.10 ; 1 yr -> ~0.78 ; multi-yr asymptotes toward right edge
+      var f = Math.log(1 + days) / Math.log(1 + 1460); // 1460 d ~= 4 yr reference span
+      delayFrac = 0.10 + 0.84 * Math.min(1, f);
+    }
+
+    // axis labels reflect the recorded span
+    axLeft.textContent = "origin " + (tE != null ? fmtDateUTC(tE) : "");
+    if (hasArrival) {
+      axRight.textContent = fmtDateUTC(tR);
+    } else {
+      axRight.textContent = "monitoring";
+    }
+
+    // build trace model
+    traceModel = { seed: seed, delayFrac: delayFrac, amp: mag, hasArrival: hasArrival, idle: false };
+
+    // streaming "station coming online" sequence into a temp stream box
+    var stream = document.createElement("div");
+    stream.className = "stream";
+    elReadout.appendChild(stream);
+
+    var t0 = fmtStamp(tE);
+    var intro = [
+      { text: "STN OBR-1 :: channel BHZ armed", cls: "dim", wait: 200 },
+      { text: "origin logged  " + t0, cls: "dim", wait: 200 },
+      { text: "event » " + label, cls: "mark", wait: 220 },
+      { text: "transmitting through medium …", cls: "dim", wait: 320 }
+    ];
+
+    streamLines(stream, intro, function () {
+      drumStatus.textContent = "recording";
+      // animate the trace drawing in (progressive reveal via clip)
+      animateTraceIn(traceModel, function () {
+        if (hasArrival) {
+          renderArrival(stream, label, tE, tR, days, delayFrac, mag, seed);
+        } else {
+          renderNoArrival(stream, label, tE, seed);
+        }
+      });
+    });
+  }
+
+  // progressive draw: redraw full trace, then sweep a reveal mask left->right
+  function animateTraceIn(model, done) {
+    drawTrace(model); // full trace rendered underneath
+    var host = canvas.parentNode;
+    var mask = document.createElement("div");
+    mask.style.position = "absolute";
+    mask.style.top = "0";
+    mask.style.right = "0";
+    mask.style.bottom = "0";
+    mask.style.left = "0";
+    mask.style.background = "var(--field)";
+    mask.style.pointerEvents = "none";
+    host.appendChild(mask);
+
+    var start = null;
+    var dur = 900;
+    function frame(ts) {
+      if (start == null) start = ts;
+      var p = Math.min(1, (ts - start) / dur);
+      // reveal from left: mask covers the right portion
+      mask.style.left = (p * 100).toFixed(2) + "%";
+      if (p < 1) {
+        requestAnimationFrame(frame);
+      } else {
+        host.removeChild(mask);
+        if (done) setTimeout(done, 160);
+      }
+    }
+    requestAnimationFrame(frame);
+  }
+
+  function ampDescriptor(mag) {
+    // seismic-flavored amplitude band, purely a label for the given 1-10 input
+    if (mag <= 0) return "not recorded";
+    if (mag <= 2) return "trace deflection";
+    if (mag <= 4) return "low amplitude";
+    if (mag <= 6) return "moderate amplitude";
+    if (mag <= 8) return "strong amplitude";
+    return "full-scale deflection";
+  }
+
+  function renderArrival(stream, label, tE, tR, days, delayFrac, mag, seed) {
+    var distanceKm = days * VELOCITY_KM_PER_DAY;
+
+    var arrivalLines = [
+      { text: "", wait: 100 },
+      { text: "first arrival registered  " + fmtStamp(tR), cls: "trace", wait: 260 },
+      { text: "P-phase picked", cls: "dim", wait: 180 },
+      { text: "", wait: 80 }
+    ];
+
+    streamLines(stream, arrivalLines, function () {
+      var rows = [];
+      rows.push(["origin event", label, "mark"]);
+      rows.push(["origin time", fmtStamp(tE), ""]);
+      rows.push(["first arrival", fmtStamp(tR), ""]);
+      rows.push(["phase", "P", ""]);
+      rows.push(["propagation delay", days + (days === 1 ? " d" : " d"), "trace"]);
+      rows.push(["station distance", commaInt(distanceKm) + " km", "trace"]);
+      rows.push(["velocity model", fixed(VELOCITY_KM_PER_DAY, 2) + " km/d", ""]);
+      if (mag > 0) {
+        rows.push(["recorded amplitude", mag + " / 10  (" + ampDescriptor(mag) + ")", ""]);
+      } else {
+        rows.push(["recorded amplitude", "not recorded", "dim"]);
+      }
+      rows.push(["channel", "BHZ", ""]);
+
+      appendNode(buildReportTable(rows, "READING — STN OBR-1 / " + label));
+
+      // flat status line: distance restatement, no interpretation
+      appendNode(statusBar(
+        "ARRIVAL RECORDED.",
+        "Propagation delay " + days + " d. Station distance " + commaInt(distanceKm) + " km from epicenter at the declared velocity. Trace stored."
+      ));
+
+      stateMeta.innerHTML = "state <b>STORED</b>";
+      drumStatus.textContent = "stored";
+      finish();
+    });
+  }
+
+  function renderNoArrival(stream, label, tE, seed) {
+    var lines = [
+      { text: "", wait: 100 },
+      { text: "no arrival within recorded window", cls: "dim", wait: 280 },
+      { text: "channel BHZ continues", cls: "dim", wait: 200 },
+      { text: "", wait: 80 }
+    ];
+    streamLines(stream, lines, function () {
+      var rows = [];
+      rows.push(["origin event", label, "mark"]);
+      rows.push(["origin time", fmtStamp(tE), ""]);
+      rows.push(["first arrival", "—", ""]);
+      rows.push(["phase", "—", ""]);
+      rows.push(["propagation delay", "—", ""]);
+      rows.push(["station distance", "indeterminate", ""]);
+      rows.push(["channel", "BHZ", ""]);
+      rows.push(["state", "MONITORING", "mark"]);
+
+      appendNode(buildReportTable(rows, "READING — STN OBR-1 / " + label));
+
+      appendNode(statusBar(
+        "NO ARRIVAL RECORDED.",
+        "Event transmitted. No arrival has registered at this station. The station continues monitoring."
+      ));
+
+      stateMeta.innerHTML = "state <b>MONITORING</b>";
+      drumStatus.textContent = "monitoring";
+      finish();
+    });
+  }
+
+  function finish() {
+    running = false;
+    btnRun.disabled = false;
+    btnAgain.style.display = "inline-block";
+    var c = document.createElement("div");
+    c.className = "ln dim";
+    c.style.marginTop = "10px";
+    c.style.fontSize = "11px";
+    var inner = document.createElement("span");
+    inner.textContent = "OBR-1 ";
+    var cur = document.createElement("span");
+    cur.className = "cur";
+    c.appendChild(inner);
+    c.appendChild(cur);
+    appendNode(c);
+  }
+
+  form.addEventListener("submit", function (e) {
+    e.preventDefault();
+    run();
+  });
+
+  btnAgain.addEventListener("click", function () {
+    elReadout.innerHTML = "";
+    elErr.textContent = "";
+    elEvent.value = "";
+    elTEvent.value = "";
+    elTResp.value = "";
+    elMag.value = "0";
+    elMagVal.textContent = "unset";
+    btnAgain.style.display = "none";
+    stateMeta.innerHTML = "state <b>ACQUIRING</b>";
+    drumStatus.textContent = "listening";
+    axLeft.textContent = "origin";
+    axRight.textContent = "now";
+    startIdle();                // resume the live record
+    elEvent.focus();
+    window.scrollTo(0, 0);
+  });
+})();
+</script>
+<a class="bus-home" href="/is/building/bus/">&larr; instrument bus</a>
+<style>
+.bus-home{position:fixed;left:14px;bottom:12px;z-index:60;font:600 11px/1 ui-monospace,"SF Mono",Menlo,monospace;letter-spacing:.04em;color:var(--dim);text-decoration:none;padding:6px 10px;border:1px solid var(--line);border-radius:999px;background:rgba(7,9,11,.8);backdrop-filter:blur(4px);-webkit-backdrop-filter:blur(4px);transition:color .18s,border-color .18s}
+.bus-home:hover,.bus-home:focus-visible{color:var(--fg);border-color:var(--mark)}
+</style>
+</body>
+</html>

--- a/is/building/rehearsal/index.html
+++ b/is/building/rehearsal/index.html
@@ -1,0 +1,772 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>rehearsal</title>
+<link rel="icon" type="image/png" href="/img/a3.png">
+<script src="/analytics.js" defer></script>
+<style>
+  :root {
+    --bg:        #14171c;
+    --bg-panel:  #181b21;
+    --bg-input:  #1d2026;
+    --line:      #262b33;
+    --fg:        #c2c8d0;
+    --fg-dim:    #6b7280;
+    --fg-faint:  #444b56;
+    --accent:    #8a93a0;
+    --hash:      #d2a45a;
+    --add-fg:    #7faa72;
+    --add-bg:    #1c2a1d;
+    --del-fg:    #b06a6a;
+    --del-bg:    #2a1c1d;
+    --branch:    #6f93b3;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: ui-monospace, "SF Mono", "JetBrains Mono", "IBM Plex Mono", Menlo, monospace;
+    font-size: 13px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+    padding-bottom: 34px;
+  }
+  .wrap {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 18px 14px 40px;
+  }
+
+  /* masthead */
+  .masthead {
+    border-bottom: 1px solid var(--line);
+    padding-bottom: 10px;
+    margin-bottom: 16px;
+  }
+  .masthead .title {
+    font-size: 12px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--accent);
+  }
+  .masthead .sub {
+    font-size: 11px;
+    color: var(--fg-faint);
+    margin-top: 3px;
+  }
+
+  /* generic block label */
+  .label {
+    font-size: 10px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--fg-dim);
+    margin-bottom: 7px;
+    display: block;
+  }
+
+  /* init form */
+  .init { margin-bottom: 4px; }
+  .row { display: flex; gap: 8px; align-items: stretch; flex-wrap: wrap; }
+  .prefix-field {
+    flex: 1 1 200px;
+    display: flex;
+    align-items: center;
+    background: var(--bg-input);
+    border: 1px solid var(--line);
+    padding: 0 10px;
+    min-height: 34px;
+  }
+  .prefix-field .glyph {
+    color: var(--fg-faint);
+    margin-right: 7px;
+    white-space: nowrap;
+    user-select: none;
+  }
+  input[type=text] {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--fg);
+    font-family: inherit;
+    font-size: 13px;
+    padding: 8px 0;
+    min-width: 0;
+  }
+  input[type=text]::placeholder { color: var(--fg-faint); }
+
+  button {
+    font-family: inherit;
+    font-size: 12px;
+    background: var(--bg-input);
+    color: var(--fg);
+    border: 1px solid var(--line);
+    padding: 8px 16px;
+    cursor: pointer;
+    letter-spacing: 0.04em;
+    transition: border-color .12s, color .12s;
+    white-space: nowrap;
+  }
+  button:hover { border-color: var(--accent); color: #fff; }
+  button:active { background: #20242b; }
+  button:disabled { color: var(--fg-faint); cursor: not-allowed; border-color: var(--line); }
+  button:disabled:hover { color: var(--fg-faint); border-color: var(--line); }
+
+  .ghost {
+    background: transparent;
+    border-color: transparent;
+    color: var(--fg-dim);
+    padding: 6px 0;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+  .ghost:hover { color: var(--fg); background: transparent; border-color: transparent; }
+
+  /* editor area */
+  .stage { display: none; }
+  .stage.on { display: block; }
+
+  .repoline {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 14px;
+    flex-wrap: wrap;
+  }
+  .repoline .repo {
+    color: var(--fg);
+  }
+  .repoline .repo b { color: #e7ebf0; font-weight: 600; }
+  .repoline .br {
+    color: var(--branch);
+  }
+  .repoline .det {
+    color: var(--fg-faint);
+    font-size: 11px;
+  }
+
+  .editor {
+    border: 1px solid var(--line);
+    background: var(--bg-panel);
+    margin-bottom: 10px;
+  }
+  .editor .gutter-row {
+    display: flex;
+    border-bottom: 1px solid var(--line);
+  }
+  .editor .ln {
+    width: 34px;
+    flex: 0 0 34px;
+    text-align: right;
+    padding: 8px 8px 8px 0;
+    color: var(--fg-faint);
+    background: var(--bg-input);
+    user-select: none;
+    font-size: 12px;
+    border-right: 1px solid var(--line);
+  }
+  textarea {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    resize: vertical;
+    color: var(--fg);
+    font-family: inherit;
+    font-size: 13px;
+    line-height: 1.55;
+    padding: 8px 10px;
+    min-height: 78px;
+    min-width: 0;
+  }
+  textarea::placeholder { color: var(--fg-faint); }
+
+  .commitbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 22px;
+    flex-wrap: wrap;
+  }
+  .commitbar .hint {
+    color: var(--fg-faint);
+    font-size: 11px;
+  }
+  .commitbar .hint .nochange { color: var(--del-fg); }
+
+  /* diff panel */
+  .section { margin-bottom: 22px; }
+  .diffhead {
+    color: var(--fg-dim);
+    font-size: 11px;
+    margin-bottom: 6px;
+    word-break: break-all;
+  }
+  .diffhead .a { color: var(--del-fg); }
+  .diffhead .b { color: var(--add-fg); }
+  .diffbox {
+    border: 1px solid var(--line);
+    background: var(--bg-panel);
+    padding: 10px 12px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-size: 13px;
+    line-height: 1.7;
+  }
+  .diffbox .add {
+    color: var(--add-fg);
+    background: var(--add-bg);
+  }
+  .diffbox .del {
+    color: var(--del-fg);
+    background: var(--del-bg);
+    text-decoration: line-through;
+    text-decoration-color: var(--del-fg);
+  }
+  .diffbox .eq { color: var(--fg-dim); }
+  .diffnote {
+    color: var(--fg-faint);
+    font-size: 11px;
+    margin-top: 6px;
+  }
+  .diffnote .plus { color: var(--add-fg); }
+  .diffnote .minus { color: var(--del-fg); }
+
+  /* log */
+  .log { border-top: 1px solid var(--line); }
+  .commit {
+    display: flex;
+    gap: 10px;
+    padding: 8px 2px;
+    border-bottom: 1px solid var(--line);
+    align-items: baseline;
+  }
+  .commit .sha { color: var(--hash); flex: 0 0 auto; }
+  .commit .meta { flex: 1; min-width: 0; }
+  .commit .msg {
+    color: var(--fg);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .commit .when {
+    color: var(--fg-faint);
+    font-size: 11px;
+  }
+  .commit.head .sha::after {
+    content: " (HEAD -> unsent)";
+    color: var(--branch);
+    font-size: 11px;
+  }
+
+  .statblock {
+    margin-top: 16px;
+    color: var(--fg-dim);
+    font-size: 12px;
+  }
+  .statblock .num { color: var(--fg); }
+
+  /* bottom status bar (IDE) */
+  .statusbar {
+    position: fixed;
+    left: 0; right: 0; bottom: 0;
+    height: 26px;
+    background: #0f1216;
+    border-top: 1px solid var(--line);
+    display: flex;
+    align-items: center;
+    gap: 0;
+    font-size: 11px;
+    color: var(--fg-dim);
+    z-index: 10;
+    overflow: hidden;
+  }
+  .statusbar .seg {
+    padding: 0 10px;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    border-right: 1px solid var(--line);
+    white-space: nowrap;
+  }
+  .statusbar .seg.branch { color: var(--branch); }
+  .statusbar .seg.spacer { flex: 1; border-right: none; }
+  .statusbar .seg.right { border-right: none; border-left: 1px solid var(--line); }
+  @media (max-width: 460px) {
+    .statusbar .seg.hide-narrow { display: none; }
+  }
+
+  .empty {
+    color: var(--fg-faint);
+    font-size: 12px;
+    padding: 10px 2px;
+  }
+
+  /* pre-init empty state — gives the landing a living 'no repository' panel
+     so the void below the form reads as 'ready', not 'failed to load' */
+  .preinit { margin-top: 20px; max-width: 560px; }
+  .preinit.off { display: none; }
+  .ep {
+    border: 1px solid var(--line);
+    background: var(--bg-panel);
+    padding: 15px 16px 14px;
+  }
+  .ep-node { color: var(--fg-dim); margin-bottom: 11px; }
+  .ep-node .hollow { color: var(--fg-faint); margin-right: 8px; }
+  .ep-node .br { color: var(--branch); }
+  .ep-body { color: var(--fg-faint); font-size: 12px; line-height: 1.7; max-width: 48ch; }
+  .ep-body .kw { color: var(--fg-dim); }
+  .ep-body .br { color: var(--branch); }
+  .ep-prompt {
+    margin-top: 13px; padding-top: 12px;
+    border-top: 1px solid var(--line);
+    color: var(--fg-dim);
+  }
+  .ep-prompt .dollar { color: var(--fg-faint); margin-right: 9px; }
+  .caret {
+    display: inline-block; width: 7px; height: 14px;
+    background: var(--branch); margin-left: 3px;
+    vertical-align: text-bottom;
+    animation: blink 1.1s steps(1) infinite;
+  }
+  @keyframes blink { 50% { opacity: 0; } }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="masthead">
+    <div class="title">rehearsal</div>
+    <div class="sub" style="color:var(--fg-dim);">drafts of what you didn't say</div>
+  </div>
+
+  <!-- INIT -->
+  <div class="init" id="init">
+    <span class="label">Recipient</span>
+    <div class="row">
+      <div class="prefix-field">
+        <input type="text" id="recipient" placeholder="the person you didn't say it to" autocomplete="off" spellcheck="false" />
+      </div>
+      <button id="initBtn">git init</button>
+    </div>
+    <div class="diffnote" style="margin-top:8px;">Initializes a repository on branch <span style="color:var(--branch)">unsent</span>.</div>
+  </div>
+
+  <!-- PRE-INIT empty state: a living 'no repository' panel, hidden after init -->
+  <div class="preinit" id="preinit">
+    <span class="label">Source control</span>
+    <div class="ep">
+      <div class="ep-node"><span class="hollow">&#9676;</span><span class="br">unsent</span> &#8212; no repository</div>
+      <div class="ep-body">Nothing is tracked yet. Name a recipient above and run <span class="kw">git init</span> to open a working copy on branch <span class="br">unsent</span>. Drafts you commit are kept on this branch and never pushed.</div>
+      <div class="ep-prompt"><span class="dollar">$</span>git init<span class="caret"></span></div>
+    </div>
+  </div>
+
+  <!-- STAGE -->
+  <div class="stage" id="stage">
+    <div class="repoline">
+      <span class="repo">repo <b id="repoName">mom</b></span>
+      <span class="br">branch: unsent</span>
+      <span class="det" id="repoDet"></span>
+    </div>
+
+    <span class="label">Working copy</span>
+    <div class="editor">
+      <div class="gutter-row">
+        <div class="ln" id="lnCol">1</div>
+        <textarea id="draft" placeholder="Stage a version of the message." spellcheck="false"></textarea>
+      </div>
+    </div>
+    <div class="commitbar">
+      <button id="commitBtn">git commit</button>
+      <span class="hint" id="commitHint">No commits yet.</span>
+    </div>
+
+    <div class="section" id="diffSection" style="display:none;">
+      <span class="label">Diff</span>
+      <div class="diffhead" id="diffHead"></div>
+      <div class="diffbox" id="diffBox"></div>
+      <div class="diffnote" id="diffNote"></div>
+    </div>
+
+    <div class="section">
+      <span class="label">Log</span>
+      <div class="log" id="log">
+        <div class="empty" id="logEmpty">No commits on unsent.</div>
+      </div>
+      <div class="statblock" id="statBlock"></div>
+    </div>
+
+    <button class="ghost" id="resetBtn">Start a new branch.</button>
+  </div>
+
+</div>
+
+<!-- IDE status bar -->
+<div class="statusbar" id="statusbar">
+  <a class="seg" href="/is/building/bus/" style="color:var(--branch);text-decoration:none" title="back to the instrument bus">&larr; bus</a>
+  <div class="seg branch" id="sbBranch">unsent</div>
+  <div class="seg" id="sbAhead">0 ahead</div>
+  <div class="seg hide-narrow" id="sbPushed">0 pushed</div>
+  <div class="seg spacer"></div>
+  <div class="seg right hide-narrow" id="sbState">no repository</div>
+  <div class="seg right">UTF-8</div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  // ---- deterministic short SHA (FNV-1a 32-bit, doubled for 7 hex chars) ----
+  function fnv1a(str) {
+    var h = 0x811c9dc5;
+    for (var i = 0; i < str.length; i++) {
+      h ^= str.charCodeAt(i);
+      // h *= 16777619, kept in 32-bit unsigned range
+      h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+    }
+    return h >>> 0;
+  }
+  function shortSha(seed) {
+    // mix two passes for a stable 7-char hex string from content alone
+    var a = fnv1a(seed);
+    var b = fnv1a(seed + "\0" + (a >>> 0).toString(16));
+    var hex = (a >>> 0).toString(16) + (b >>> 0).toString(16);
+    while (hex.length < 7) hex = "0" + hex;
+    return hex.slice(0, 7);
+  }
+
+  // ---- word tokenization (keeps whitespace runs as their own tokens) ----
+  function tokenize(text) {
+    if (text === "") return [];
+    // split into words and whitespace, preserving both
+    var m = text.match(/\s+|[^\s]+/g);
+    return m ? m : [];
+  }
+
+  // ---- LCS-based word-level diff -> ops array {t:'eq'|'add'|'del', s:string} ----
+  function diffTokens(aTok, bTok) {
+    var n = aTok.length, m = bTok.length;
+    // DP table of LCS lengths
+    var dp = [];
+    for (var i = 0; i <= n; i++) {
+      dp.push(new Int32Array(m + 1));
+    }
+    for (i = n - 1; i >= 0; i--) {
+      for (var j = m - 1; j >= 0; j--) {
+        if (aTok[i] === bTok[j]) {
+          dp[i][j] = dp[i + 1][j + 1] + 1;
+        } else {
+          dp[i][j] = dp[i + 1][j] >= dp[i][j + 1] ? dp[i + 1][j] : dp[i][j + 1];
+        }
+      }
+    }
+    var ops = [];
+    i = 0; j = 0;
+    while (i < n && j < m) {
+      if (aTok[i] === bTok[j]) {
+        ops.push({ t: "eq", s: aTok[i] });
+        i++; j++;
+      } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+        ops.push({ t: "del", s: aTok[i] });
+        i++;
+      } else {
+        ops.push({ t: "add", s: bTok[j] });
+        j++;
+      }
+    }
+    while (i < n) { ops.push({ t: "del", s: aTok[i] }); i++; }
+    while (j < m) { ops.push({ t: "add", s: bTok[j] }); j++; }
+    return ops;
+  }
+
+  function escapeHtml(s) {
+    return s.replace(/[&<>]/g, function (c) {
+      return c === "&" ? "&amp;" : c === "<" ? "&lt;" : "&gt;";
+    });
+  }
+
+  // render diff ops to HTML. whitespace tokens carry their class so add/del
+  // gaps are visible, but a pure-whitespace eq token renders plain.
+  function renderDiff(ops) {
+    var html = "";
+    for (var k = 0; k < ops.length; k++) {
+      var op = ops[k];
+      var cls = op.t === "add" ? "add" : op.t === "del" ? "del" : "eq";
+      var safe = escapeHtml(op.s);
+      if (op.t === "eq") {
+        html += '<span class="eq">' + safe + "</span>";
+      } else {
+        html += '<span class="' + cls + '">' + safe + "</span>";
+      }
+    }
+    return html;
+  }
+
+  function countWords(ops, type) {
+    var c = 0;
+    for (var k = 0; k < ops.length; k++) {
+      if (ops[k].t === type && /\S/.test(ops[k].s)) c++;
+    }
+    return c;
+  }
+
+  // ---- relative time ----
+  function relTime(then, now) {
+    var s = Math.floor((now - then) / 1000);
+    if (s < 5) return "just now";
+    if (s < 60) return s + " seconds ago";
+    var mn = Math.floor(s / 60);
+    if (mn < 60) return mn + (mn === 1 ? " minute ago" : " minutes ago");
+    var hr = Math.floor(mn / 60);
+    if (hr < 24) return hr + (hr === 1 ? " hour ago" : " hours ago");
+    var d = Math.floor(hr / 24);
+    return d + (d === 1 ? " day ago" : " days ago");
+  }
+
+  function firstLine(text) {
+    var t = text.replace(/\s+/g, " ").trim();
+    if (t === "") return "(empty)";
+    return t;
+  }
+
+  function slugRepo(recipient) {
+    var r = recipient.trim();
+    if (r === "") r = "someone";
+    return r.toLowerCase().replace(/\s+/g, "-").replace(/[^\w.\-]/g, "");
+  }
+
+  // ---- state ----
+  var commits = []; // { sha, msg, ts, full }
+  var recipientName = "";
+
+  // ---- DOM ----
+  var initEl   = document.getElementById("init");
+  var preinitEl= document.getElementById("preinit");
+  var stageEl  = document.getElementById("stage");
+  var recInput = document.getElementById("recipient");
+  var initBtn  = document.getElementById("initBtn");
+  var draft    = document.getElementById("draft");
+  var commitBtn= document.getElementById("commitBtn");
+  var commitHint = document.getElementById("commitHint");
+  var lnCol    = document.getElementById("lnCol");
+  var repoName = document.getElementById("repoName");
+  var repoDet  = document.getElementById("repoDet");
+  var diffSection = document.getElementById("diffSection");
+  var diffHead = document.getElementById("diffHead");
+  var diffBox  = document.getElementById("diffBox");
+  var diffNote = document.getElementById("diffNote");
+  var logEl    = document.getElementById("log");
+  var logEmpty = document.getElementById("logEmpty");
+  var statBlock= document.getElementById("statBlock");
+  var resetBtn = document.getElementById("resetBtn");
+
+  var sbBranch = document.getElementById("sbBranch");
+  var sbAhead  = document.getElementById("sbAhead");
+  var sbPushed = document.getElementById("sbPushed");
+  var sbState  = document.getElementById("sbState");
+
+  // ---- gutter line numbers track the textarea wrapping count loosely (by \n) ----
+  function updateGutter() {
+    var lines = draft.value.split("\n").length;
+    if (lines < 1) lines = 1;
+    var out = "";
+    for (var i = 1; i <= lines; i++) out += (i > 1 ? "\n" : "") + i;
+    lnCol.textContent = out;
+  }
+
+  // ---- init ----
+  function doInit() {
+    recipientName = recInput.value.trim();
+    var slug = slugRepo(recipientName);
+    repoName.textContent = slug;
+    sbBranch.textContent = "unsent";
+    initEl.style.display = "none";
+    preinitEl.style.display = "none";
+    stageEl.classList.add("on");
+    sbState.textContent = "branch unsent · clean";
+    repoDet.textContent = "Initialized empty repository.";
+    render();
+    draft.focus();
+  }
+
+  // ---- commit ----
+  function doCommit() {
+    var text = draft.value;
+    if (text.replace(/\s+/g, "") === "") {
+      flashHint("nothing to commit — working copy empty.", true);
+      return;
+    }
+    var prevFull = commits.length ? commits[commits.length - 1].full : null;
+    if (prevFull !== null && prevFull === text) {
+      flashHint("nothing to commit — working copy clean.", true);
+      return;
+    }
+    // deterministic SHA from recipient slug + index-independent content
+    // include parent sha so identical text under different history still differs,
+    // but the value is fully derived from content (no randomness)
+    var parent = commits.length ? commits[commits.length - 1].sha : "0000000";
+    var seed = slugRepo(recipientName) + "\n" + parent + "\n" + text;
+    var sha = shortSha(seed);
+    commits.push({
+      sha: sha,
+      msg: firstLine(text),
+      ts: Date.now(),
+      full: text
+    });
+    render();
+    flashHint("committed " + sha + " to unsent.", false);
+  }
+
+  var hintTimer = null;
+  function flashHint(msg, isWarn) {
+    commitHint.innerHTML = isWarn
+      ? '<span class="nochange">' + escapeHtml(msg) + "</span>"
+      : escapeHtml(msg);
+    if (hintTimer) clearTimeout(hintTimer);
+    hintTimer = setTimeout(function () { refreshHint(); }, 4000);
+  }
+  function refreshHint() {
+    if (commits.length === 0) {
+      commitHint.textContent = "No commits yet.";
+    } else {
+      var head = commits[commits.length - 1];
+      commitHint.textContent = "HEAD at " + head.sha + ".";
+    }
+  }
+
+  // ---- render everything ----
+  function render() {
+    var now = Date.now();
+    var n = commits.length;
+
+    // repo detail
+    if (n === 0) {
+      repoDet.textContent = "no commits yet";
+    } else {
+      repoDet.textContent = n + (n === 1 ? " commit" : " commits") + " · " + n + " ahead of origin/sent";
+    }
+
+    // status bar
+    sbAhead.textContent = n + " ahead";
+    sbPushed.textContent = "0 pushed";
+    sbState.textContent = n === 0 ? "branch unsent · clean" : "unsent ↑" + n;
+
+    // diff (latest two)
+    if (n >= 2) {
+      diffSection.style.display = "block";
+      var a = commits[n - 2], b = commits[n - 1];
+      var ops = diffTokens(tokenize(a.full), tokenize(b.full));
+      diffHead.innerHTML = "diff " +
+        '<span class="a">' + escapeHtml(a.sha) + "</span>" + " " +
+        '<span class="b">' + escapeHtml(b.sha) + "</span>";
+      diffBox.innerHTML = renderDiff(ops);
+      var added = countWords(ops, "add");
+      var removed = countWords(ops, "del");
+      diffNote.innerHTML =
+        '<span class="plus">+' + added + (added === 1 ? " word" : " words") + "</span>" +
+        " · " +
+        '<span class="minus">-' + removed + (removed === 1 ? " word" : " words") + "</span>";
+    } else if (n === 1) {
+      diffSection.style.display = "block";
+      var b1 = commits[0];
+      var ops1 = diffTokens([], tokenize(b1.full));
+      diffHead.innerHTML = "diff " +
+        '<span class="a">0000000</span> ' +
+        '<span class="b">' + escapeHtml(b1.sha) + "</span>";
+      diffBox.innerHTML = renderDiff(ops1);
+      var add1 = countWords(ops1, "add");
+      diffNote.innerHTML =
+        '<span class="plus">+' + add1 + (add1 === 1 ? " word" : " words") + "</span>" +
+        ' · <span class="minus">-0 words</span> · initial commit';
+    } else {
+      diffSection.style.display = "none";
+    }
+
+    // log (newest first)
+    if (n === 0) {
+      logEl.innerHTML = '<div class="empty">No commits on unsent.</div>';
+    } else {
+      var html = "";
+      for (var i = n - 1; i >= 0; i--) {
+        var c = commits[i];
+        var headClass = (i === n - 1) ? " head" : "";
+        html +=
+          '<div class="commit' + headClass + '">' +
+            '<span class="sha">' + escapeHtml(c.sha) + "</span>" +
+            '<span class="meta">' +
+              '<div class="msg">' + escapeHtml(c.msg) + "</div>" +
+              '<div class="when">' + escapeHtml(relTime(c.ts, now)) + "</div>" +
+            "</span>" +
+          "</div>";
+      }
+      logEl.innerHTML = html;
+    }
+
+    // stat block
+    if (n === 0) {
+      statBlock.textContent = "";
+    } else {
+      statBlock.innerHTML =
+        '<span class="num">' + n + "</span> " + (n === 1 ? "revision" : "revisions") + ".";
+    }
+
+    refreshHint();
+  }
+
+  // ---- ticking relative time ----
+  setInterval(function () {
+    if (stageEl.classList.contains("on") && commits.length > 0) {
+      var now = Date.now();
+      var whenEls = logEl.querySelectorAll(".commit");
+      var n = commits.length;
+      for (var i = 0; i < whenEls.length; i++) {
+        var c = commits[n - 1 - i];
+        var w = whenEls[i].querySelector(".when");
+        if (w) w.textContent = relTime(c.ts, now);
+      }
+    }
+  }, 1000);
+
+  // ---- reset ----
+  function doReset() {
+    commits = [];
+    recipientName = "";
+    recInput.value = "";
+    draft.value = "";
+    updateGutter();
+    stageEl.classList.remove("on");
+    initEl.style.display = "block";
+    preinitEl.style.display = "block";
+    sbBranch.textContent = "unsent";
+    sbAhead.textContent = "0 ahead";
+    sbPushed.textContent = "0 pushed";
+    sbState.textContent = "no repository";
+    recInput.focus();
+  }
+
+  // ---- wiring ----
+  initBtn.addEventListener("click", doInit);
+  recInput.addEventListener("keydown", function (e) {
+    if (e.key === "Enter") { e.preventDefault(); doInit(); }
+  });
+  commitBtn.addEventListener("click", doCommit);
+  draft.addEventListener("input", updateGutter);
+  // Cmd/Ctrl+Enter commits
+  draft.addEventListener("keydown", function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      doCommit();
+    }
+  });
+  resetBtn.addEventListener("click", doReset);
+
+  updateGutter();
+})();
+</script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -25,8 +25,16 @@
     <lastmod>2026-06-05T13:27:32+09:00</lastmod>
   </url>
   <url>
+    <loc>https://ajin.im/is/building/halflife/</loc>
+    <lastmod>2026-06-05</lastmod>
+  </url>
+  <url>
     <loc>https://ajin.im/is/building/label/</loc>
     <lastmod>2026-06-05T13:27:32+09:00</lastmod>
+  </url>
+  <url>
+    <loc>https://ajin.im/is/building/latency/</loc>
+    <lastmod>2026-06-05</lastmod>
   </url>
   <url>
     <loc>https://ajin.im/is/building/omen.ops/</loc>
@@ -39,6 +47,10 @@
   <url>
     <loc>https://ajin.im/is/building/questions/</loc>
     <lastmod>2026-06-05T13:27:32+09:00</lastmod>
+  </url>
+  <url>
+    <loc>https://ajin.im/is/building/rehearsal/</loc>
+    <lastmod>2026-06-05</lastmod>
   </url>
   <url>
     <loc>https://ajin.im/is/building/small/</loc>


### PR DESCRIPTION
Lights up four more instruments on the bus. Builds on #96.

## What changed
- **Deployed** `rehearsal`, `latency`, `halflife` to flat `/is/building/<name>/` (from the parallel session's instrument mocks). Each gains analytics, the `a3` favicon, and a palette-matched way-home to the bus — rehearsal's rides its IDE status bar; latency/halflife use a muted corner pill.
- **Emotional Parking** (already live at `/is/building/validation/`) added as a live bus row.
- Bus: `rehearsal/latency/halflife` flipped **staging → live** with flat hrefs; stat now **9 live · 2 staging**.
- `containment` + `sunk` remain staging (built and ready, but not in this request).

## Verification
- `check_links.py`: 936 links / 143 pages / **0 broken**
- HTTP serve check: bus + 3 new tools + /validation/ all 200; bus renders `9 live · 2 staging`; back-links resolve to `/is/building/bus/`
- Back-link collision with rehearsal's fixed status bar caught and fixed (moved into the status bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)