### PR TITLE
building: Title-Case "Instrument Bus" as a name on home + index

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
     <div class="line"><span class="prefix">ajin.im is</span> <span class="verb"><a href="/is/building/">building</a></span></div>
     <div class="detail">
       <a href="https://seoulcrushing.com">Seoul Crushing</a>, Korea made legible. With bite.<br>
-      <a href="/is/building/bus/">instrument bus</a>, small tools for big feelings.
+      <a href="/is/building/bus/">Instrument Bus</a>, small tools for big feelings.
     </div>
   </div>
 

--- a/is/building/index.html
+++ b/is/building/index.html
@@ -127,7 +127,7 @@
     </div>
     <div class="project">
       <div class="project-head">
-        <span class="project-name"><a href="/is/building/bus/">instrument bus</a></span>
+        <span class="project-name"><a href="/is/building/bus/">Instrument Bus</a></span>
         <span class="project-status is-collection">9 live &rarr;</span>
       </div>
       <p class="project-desc">Diagnostic instruments for interior conditions.</p>

--- a/templates/root.html
+++ b/templates/root.html
@@ -201,7 +201,7 @@
     <div class="line"><span class="prefix">ajin.im is</span> <span class="verb"><a href="/is/building/">building</a></span></div>
     <div class="detail">
       <a href="https://seoulcrushing.com">Seoul Crushing</a>, Korea made legible. With bite.<br>
-      <a href="/is/building/bus/">instrument bus</a>, small tools for big feelings.
+      <a href="/is/building/bus/">Instrument Bus</a>, small tools for big feelings.
     </div>
   </div>
 


### PR DESCRIPTION
Casing consistency fix Ajin flagged. On the home page "instrument bus" was the lone lowercase entry beside Title Case proper names (Seoul Crushing, Bureau of Interior Conditions, Avian Municipal District), so it read as a slip.

- **Home page** (`templates/root.html` → `index.html`) and **`/is/building/` index**: `instrument bus` → **`Instrument Bus`** (the editorial name references).
- **Unchanged on purpose**: the console's own lowercase masthead (`interior-conditions // instrument bus`) and the `← instrument bus` tool back-links — that lowercase is deliberate terminal styling.

Verified: `check_links` 936 / 0 broken; root rebuilt from template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)