### PR TITLE
build: tidy sitemap (skip stubs/noindex) + Emotional Parking bus link

### DIFF
--- a/_scripts/build_sitemap.py
+++ b/_scripts/build_sitemap.py
@@ -7,6 +7,8 @@ https://ajin.im, and writes a sitemaps.org urlset to REPO_ROOT/sitemap.xml.
 Rules:
   - Excludes anything under /.git/, /.claude/, /_archive/, /_lab/, /templates/,
     and excludes 404.html.
+  - Skips redirect stubs (meta-refresh) and noindex pages — neither should be
+    advertised as a canonical URL.
   - ".../index.html" maps to its directory URL (root index.html -> site root).
   - Any other "*.html" maps to its own .html URL.
   - Future-dated Municipal Coo issues (is/writing/bird-coo/issues/YYYY-MM-DD.html
@@ -66,6 +68,20 @@ def is_future_coo_issue(rel_posix: str, today: date) -> bool:
     return issue_date > today
 
 
+def is_noindex_or_redirect(path: Path) -> bool:
+    """True for redirect stubs (meta-refresh) and noindex pages — neither
+    belongs in the sitemap as a canonical URL."""
+    try:
+        head = path.read_text(encoding="utf-8", errors="ignore")[:8192].lower()
+    except OSError:
+        return False
+    if 'http-equiv="refresh"' in head or "http-equiv='refresh'" in head:
+        return True
+    if 'name="robots"' in head and "noindex" in head:
+        return True
+    return False
+
+
 def url_for(rel_posix: str) -> str:
     """Map a served HTML relative path to its public https://ajin.im URL."""
     if rel_posix == "index.html":
@@ -112,6 +128,8 @@ def collect_urls() -> list[tuple[str, str]]:
         if is_excluded(rel_posix):
             continue
         if is_future_coo_issue(rel_posix, today):
+            continue
+        if is_noindex_or_redirect(path):
             continue
         loc = url_for(rel_posix)
         lastmod = lastmod_for(path, rel_posix)

--- a/is/building/validation/index.html
+++ b/is/building/validation/index.html
@@ -409,7 +409,7 @@
 
 </main>
 
-<footer class="colophon">made by <a href="/">ajin.im</a></footer>
+<footer class="colophon"><a href="/is/building/bus/">&larr; instrument bus</a> &middot; made by <a href="/">ajin.im</a></footer>
 
 <script>
 (function(){

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,20 +5,12 @@
     <lastmod>2026-06-05T14:20:12+09:00</lastmod>
   </url>
   <url>
-    <loc>https://ajin.im/is/</loc>
-    <lastmod>2026-06-03T13:27:31+09:00</lastmod>
-  </url>
-  <url>
     <loc>https://ajin.im/is/building/</loc>
-    <lastmod>2026-06-05T14:20:12+09:00</lastmod>
+    <lastmod>2026-06-05T14:31:24+09:00</lastmod>
   </url>
   <url>
     <loc>https://ajin.im/is/building/bus/</loc>
     <lastmod>2026-06-05T14:04:29+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/building/cross-subject-eval/</loc>
-    <lastmod>2026-06-03T13:30:02+09:00</lastmod>
   </url>
   <url>
     <loc>https://ajin.im/is/building/deadend/</loc>
@@ -53,36 +45,12 @@
     <lastmod>2026-06-05T13:44:50+09:00</lastmod>
   </url>
   <url>
-    <loc>https://ajin.im/is/building/small/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/building/small/deadend/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/building/small/label/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/building/small/qol-or-inflation/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/building/small/questions/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
     <loc>https://ajin.im/is/building/validation/</loc>
     <lastmod>2026-06-05T13:04:42+09:00</lastmod>
   </url>
   <url>
     <loc>https://ajin.im/is/learning/</loc>
     <lastmod>2026-06-03T13:27:31+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/learning/konbini/</loc>
-    <lastmod>2026-06-02T04:18:02+09:00</lastmod>
   </url>
   <url>
     <loc>https://ajin.im/is/reading/</loc>
@@ -99,14 +67,6 @@
   <url>
     <loc>https://ajin.im/is/writing/avian-district/</loc>
     <lastmod>2026-06-02T11:06:21+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/avian-district/map-options/option-4-property-gis-2_5d.html</loc>
-    <lastmod>2026-06-02T04:18:02+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/avian-district/map-options/site-preview-option-4-property-gis-2_5d.html</loc>
-    <lastmod>2026-06-02T04:18:02+09:00</lastmod>
   </url>
   <url>
     <loc>https://ajin.im/is/writing/bird-coo/</loc>
@@ -169,36 +129,8 @@
     <lastmod>2026-06-02T04:18:02+09:00</lastmod>
   </url>
   <url>
-    <loc>https://ajin.im/is/writing/bird-docket-proceedings/</loc>
-    <lastmod>2026-05-25T09:28:44+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/bird-docket/</loc>
-    <lastmod>2026-06-03T13:27:31+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/bird-of-letters/</loc>
-    <lastmod>2026-05-25T09:28:44+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/comedy/</loc>
-    <lastmod>2026-06-03T13:27:31+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/desk/</loc>
-    <lastmod>2026-06-03T13:27:31+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/essays/</loc>
-    <lastmod>2026-06-03T13:27:31+09:00</lastmod>
-  </url>
-  <url>
     <loc>https://ajin.im/is/writing/karen-hawk/</loc>
     <lastmod>2026-06-02T04:18:02+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/loose/</loc>
-    <lastmod>2026-06-03T13:27:31+09:00</lastmod>
   </url>
   <url>
     <loc>https://ajin.im/is/writing/nest-court-proceedings-pigeon/</loc>
@@ -221,48 +153,12 @@
     <lastmod>2026-06-02T04:18:02+09:00</lastmod>
   </url>
   <url>
-    <loc>https://ajin.im/is/writing/patches/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/patches/deadend/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/patches/label/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/patches/qol-or-inflation/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
     <loc>https://ajin.im/is/writing/perch-chat/</loc>
     <lastmod>2026-06-02T04:18:02+09:00</lastmod>
   </url>
   <url>
     <loc>https://ajin.im/is/writing/secondnest/</loc>
     <lastmod>2026-06-02T04:18:02+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/small/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/small/deadend/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/small/label/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/small/qol-or-inflation/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
-  </url>
-  <url>
-    <loc>https://ajin.im/is/writing/small/questions/</loc>
-    <lastmod>2026-06-05T13:27:32+09:00</lastmod>
   </url>
   <url>
     <loc>https://ajin.im/wrote/</loc>


### PR DESCRIPTION
Safe cleanups from the audit sweep.

- **Sitemap**: `build_sitemap.py` now skips meta-refresh redirect stubs and `noindex` pages, so the sitemap advertises only canonical indexable URLs (**126 → 100**). Drops the `small/*` + `patches/*` + `cross-subject-eval` tombstones and the `konbini` / `bird-docket` / map-preview noindex pages. Verified: zero real content pages lost.
- **Emotional Parking** (`/is/building/validation/`) gains a `← instrument bus` back-link in its colophon, matching the other bus instruments.

Verified: `check_links` 937 / 0 broken. (Registry stanza moved to `## Archived` in `~/projects.md` — separate repo, not in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)