### PR TITLE
bus: drop misleading external arrow + document site-wide new-tab behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,11 @@ When changing a container's width or padding, inspect the computed width of the 
 ## Cross-Site Links
 
 - Use root-relative paths (`/is/writing/nest-court/`) not relative (`../nest-court/`)
-- All cross-site links must include `target="_blank"`
 - The pre-push hook enforces root-relative paths for structural links
+- **New tabs are global, by design.** `/analytics.js` (loaded on every page) runs a `retarget()` on load that sets `target="_blank"` on *every* `<a href>` except in-page `#anchors` and links that already declare a target. So **virtually every link on ajin.im opens in a new tab** — internal page-to-page navigation included, not just cross-site/external links. This is intentional: the current page stays open when you click out.
+  - You don't need to hand-add `target="_blank"` — analytics.js does it. Adding it explicitly (e.g. on a cross-site link) is a harmless fallback; analytics.js skips links that already have a target.
+  - **Don't infer tab behavior from a page's own markup** — it's overridden at runtime. To verify, inspect the rendered DOM (read `a.target`), not the source.
+  - **Don't put an "opens in new tab" marker (e.g. a ↗) on only some links** — since all links open new tabs, a per-link arrow is misleading; at most it can distinguish off-site (different domain) from on-site.
 
 ## AMD Tooling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,11 @@ When changing a container's width or padding, inspect the computed width of the 
 ## Cross-Site Links
 
 - Use root-relative paths (`/is/writing/nest-court/`) not relative (`../nest-court/`)
-- All cross-site links must include `target="_blank"`
 - The pre-push hook enforces root-relative paths for structural links
+- **New tabs are global, by design.** `/analytics.js` (loaded on every page) runs a `retarget()` on load that sets `target="_blank"` on *every* `<a href>` except in-page `#anchors` and links that already declare a target. So **virtually every link on ajin.im opens in a new tab** — internal page-to-page navigation included, not just cross-site/external links. This is intentional: the current page stays open when you click out.
+  - You don't need to hand-add `target="_blank"` — analytics.js does it. Adding it explicitly (e.g. on a cross-site link) is a harmless fallback; analytics.js skips links that already have a target.
+  - **Don't infer tab behavior from a page's own markup** — it's overridden at runtime. To verify, inspect the rendered DOM (read `a.target`), not the source.
+  - **Don't put an "opens in new tab" marker (e.g. a ↗) on only some links** — since all links open new tabs, a per-link arrow is misleading; at most it can distinguish off-site (different domain) from on-site.
 
 ## AMD Tooling
 

--- a/is/building/bus/index.html
+++ b/is/building/bus/index.html
@@ -119,7 +119,7 @@
         var tgt=it.ext?' target="_blank" rel="noreferrer noopener"':'';
         var dotcls=it.s.opens<20?"dot q":"dot";
         li.innerHTML='<a class="row" href="'+it.href+'"'+tgt+'><span class="'+dotcls+'"></span>'+
-          '<span class="nm">'+it.name+(it.ext?' <span class="ext">&#8599;</span>':'')+'</span>'+
+          '<span class="nm">'+it.name+'</span>'+
           '<span class="ds">'+it.desc+'</span>'+spark(it.name+cur)+'<span class="right">'+v+'</span></a>';
       }
       ol.appendChild(li);


### PR DESCRIPTION
- **Bus**: removed the per-row ↗ that sat only on `debug::u`. `/analytics.js` retargets every link to `target=_blank` on load, so **all** bus rows open in new tabs — a lone arrow on the one external row falsely implied only it did. No row carries the marker now.
- **Docs**: documented the global new-tab behavior in `CLAUDE.md` + `AGENTS.md` (Cross-Site Links) — analytics.js retargets all links; don't infer tab behavior from page markup; don't add a per-link new-tab marker. Stops the wrong-from-source-reading mistake recurring across sessions (per owner: the new-tab behavior is intentional).

check_links 937 / 0 broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)