### PR TITLE
bus: remove dead .ext CSS

### DIFF
--- a/is/building/bus/index.html
+++ b/is/building/bus/index.html
@@ -56,7 +56,6 @@
   .right{font-size:.74rem; min-width:6.5ch; text-align:right; color:var(--ac)}
   .right .u{color:var(--tx3)}
   .right.s{color:var(--stage); letter-spacing:.08em; text-transform:uppercase; font-size:.64rem}
-  .ext{color:var(--tx3); font-size:.66rem}
   footer{margin-top:2.4rem; padding-top:1rem; border-top:1px solid var(--line);
     display:flex; justify-content:space-between; align-items:baseline; gap:1rem; font-size:.7rem}
   footer a{color:var(--tx3); text-decoration:none}


### PR DESCRIPTION
Tidy-up: the `.ext` CSS rule only styled the external ↗ arrow, which was removed in #102. Now-dead rule deleted. No visual/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)