### PR TITLE
Listing copy: drop em-dash from sky-over-seoul description

### DIFF
--- a/is/building/index.html
+++ b/is/building/index.html
@@ -140,7 +140,7 @@
         <span class="project-name"><a href="/is/building/sky-over-seoul/">the sky over Seoul</a></span>
         <span class="project-status">live</span>
       </div>
-      <p class="project-desc">130 years of real Joseon Seoul weather, kept daily &mdash; and the days the world remembers, leveled in the same hand.</p>
+      <p class="project-desc">130 years of real Joseon Seoul weather, kept daily. The days the world remembers, leveled in the same hand.</p>
     </div>
     <div class="project">
       <div class="project-head">


### PR DESCRIPTION
Follow-up to #105/#106. The `/is/building/` listing line for the new sky-over-seoul entry used an em-dash; `feedback_no_em_dash` bars em-dashes in drafted site copy. Recast with a period, which also matches the voice of the other listing entries (none use em-dashes).

One-line text change, no layout impact. Pre-push validators green.