### PR TITLE
Listing copy: plain one-liner for sky-over-seoul

### DIFF
--- a/is/building/index.html
+++ b/is/building/index.html
@@ -140,7 +140,7 @@
         <span class="project-name"><a href="/is/building/sky-over-seoul/">the sky over Seoul</a></span>
         <span class="project-status">live</span>
       </div>
-      <p class="project-desc">130 years of real Joseon Seoul weather, kept daily. The days the world remembers, leveled in the same hand.</p>
+      <p class="project-desc">130 years of real daily weather over Joseon Seoul.</p>
     </div>
     <div class="project">
       <div class="project-head">


### PR DESCRIPTION
Replaces the verbose/poetic listing description with a plain one-liner matching the other entries voice. Per direct feedback (too verbose, no overwritten language).