### PR TITLE
Add LunarOnce: one-time lunar-to-solar birthday converter

### DIFF
--- a/is/building/lunaronce/index.html
+++ b/is/building/lunaronce/index.html
@@ -1,0 +1,448 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>음력 · 农历 · âm lịch · lunar birthdays in your calendar</title>
+<link rel="icon" type="image/png" href="/img/a3.png">
+<link rel="apple-touch-icon" href="/img/a3.png">
+<script src="/analytics.js" defer></script>
+<style>
+  :root{
+    --bg:#14110d; --panel:#1a1610; --line:#2e2a22; --line2:#221e18;
+    --ink:#ede6d6; --dim:#94897a; --dimmer:#6b6354;
+    --acc:#c4452f; --acc-ink:#fdf6e9; --gold:#c9a227; --ok:#7a9b6b;
+    --field:#100d09;
+    --mono:"SF Mono","JetBrains Mono",ui-monospace,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0;}
+  html,body{background:var(--bg);color:var(--ink);font-family:var(--mono);
+    font-size:15px;line-height:1.55;-webkit-font-smoothing:antialiased;}
+  body{background-image:
+    radial-gradient(circle at 14% -10%,rgba(196,69,47,.06),transparent 42%),
+    radial-gradient(circle at 90% 112%,rgba(201,162,39,.05),transparent 46%);
+    min-height:100vh;padding:clamp(18px,5vw,56px) 16px;}
+  .wrap{max-width:680px;margin:0 auto;}
+  .badge{font-size:11px;letter-spacing:.22em;color:var(--dimmer);text-transform:uppercase;
+    border:1px solid var(--line);border-radius:999px;padding:4px 12px;display:inline-block;}
+  h1{font-size:clamp(25px,5.5vw,36px);font-weight:600;letter-spacing:-.015em;
+    margin:18px 0 12px;line-height:1.12;}
+  h1 .hl{color:var(--acc);}
+  .sub{color:var(--dim);font-size:14px;max-width:60ch;margin-bottom:6px;line-height:1.6;}
+
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:14px;
+    padding:clamp(20px,4vw,30px);margin-top:26px;
+    box-shadow:0 18px 50px -28px rgba(0,0,0,.9);}
+  label{display:block;font-size:11px;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--dim);margin-bottom:9px;}
+  .field{margin-bottom:22px;}
+  input[type=text]{width:100%;background:var(--field);border:1px solid var(--line);
+    color:var(--ink);font-family:var(--mono);font-size:15px;padding:12px 13px;
+    border-radius:9px;outline:none;transition:border-color .15s,box-shadow .15s;}
+  input[type=text]:focus{border-color:var(--acc);box-shadow:0 0 0 3px rgba(196,69,47,.15);}
+  input::placeholder{color:var(--dimmer);}
+  .dategrid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;}
+
+  .seg{display:flex;gap:0;border:1px solid var(--line);border-radius:9px;overflow:hidden;}
+  .seg button{flex:1;background:var(--field);border:none;color:var(--dim);font-family:var(--mono);
+    font-size:13px;padding:11px 8px;cursor:pointer;transition:.15s;border-right:1px solid var(--line);}
+  .seg button:last-child{border-right:none;}
+  .seg button.on{background:var(--acc);color:var(--acc-ink);font-weight:600;}
+  .seg button:not(.on):hover{color:var(--ink);background:#16120d;}
+  .hint{color:var(--dimmer);font-size:11.5px;margin-top:6px;line-height:1.5;}
+
+  .leapwrap{display:flex;align-items:center;gap:9px;margin-top:14px;
+    color:var(--dim);font-size:13px;cursor:pointer;user-select:none;}
+  .leapwrap input{width:16px;height:16px;accent-color:var(--acc);cursor:pointer;}
+
+  .dd{position:relative;}
+  .dd-head{width:100%;background:var(--field);border:1px solid var(--line);color:var(--ink);
+    font-family:var(--mono);font-size:15px;padding:12px 13px;border-radius:9px;cursor:pointer;
+    display:flex;justify-content:space-between;align-items:center;transition:border-color .15s,box-shadow .15s;}
+  .dd-head:hover{border-color:var(--dimmer);}
+  .dd.open .dd-head{border-color:var(--acc);box-shadow:0 0 0 3px rgba(196,69,47,.15);}
+  .dd-arrow{color:var(--dim);font-size:12px;transition:transform .18s;}
+  .dd.open .dd-arrow{transform:rotate(180deg);}
+  .dd-list{position:absolute;top:calc(100% + 6px);left:0;right:0;background:#181410;
+    border:1px solid var(--line);border-radius:9px;overflow:hidden;z-index:20;
+    box-shadow:0 16px 40px -16px rgba(0,0,0,.85);
+    opacity:0;transform:translateY(-6px);pointer-events:none;transition:opacity .15s,transform .15s;}
+  .dd.open .dd-list{opacity:1;transform:none;pointer-events:auto;}
+  .dd-opt{padding:11px 13px;font-size:14px;color:var(--dim);cursor:pointer;
+    border-bottom:1px solid var(--line2);transition:.12s;display:flex;align-items:center;gap:9px;}
+  .dd-opt:last-child{border-bottom:none;}
+  .dd-opt:hover{background:#1f1a13;color:var(--ink);}
+  .dd-opt.on{color:var(--ink);}
+  .dd-opt.on::before{content:"›";color:var(--acc);font-weight:700;}
+  .dd-opt:not(.on){padding-left:24px;}
+
+  .go{width:100%;margin-top:6px;background:var(--acc);color:var(--acc-ink);border:none;
+    font-family:var(--mono);font-size:15px;font-weight:600;letter-spacing:.01em;
+    padding:15px;border-radius:10px;cursor:pointer;transition:.15s;}
+  .go:hover{background:#d24e36;transform:translateY(-1px);}
+  .go:active{transform:translateY(0);}
+  .err{color:var(--acc);font-size:13px;margin-top:12px;display:none;}
+
+  .out{margin-top:24px;display:none;}
+  .out.show{display:block;animation:rise .4s ease;}
+  @keyframes rise{from{opacity:0;transform:translateY(8px);}to{opacity:1;transform:none;}}
+
+  /* reverse-mode result card */
+  /* inline solar helper (collapsed by default) */
+  .helperlink{color:var(--dim);text-decoration:underline;text-underline-offset:2px;
+    text-decoration-color:var(--dimmer);cursor:pointer;}
+  .helperlink:hover{color:var(--ink);text-decoration-color:var(--dim);}
+  .solarhelper{display:none;margin-top:14px;padding:16px;background:var(--field);
+    border:1px solid var(--line);border-left:2px solid var(--gold);border-radius:0 9px 9px 0;}
+  .solarhelper.open{display:block;animation:rise .3s ease;}
+  .sh-lbl{font-size:12px;color:var(--dim);line-height:1.55;margin-bottom:12px;}
+  .sh-btn{width:100%;margin-top:12px;background:transparent;color:var(--gold);
+    border:1px solid rgba(201,162,39,.4);font-family:var(--mono);font-size:13px;font-weight:600;
+    padding:11px;border-radius:8px;cursor:pointer;transition:.15s;}
+  .sh-btn:hover{background:rgba(201,162,39,.08);border-color:var(--gold);}
+  .sh-result{font-size:13px;line-height:1.6;margin-top:13px;display:none;}
+  .sh-result.show{display:block;}
+  .sh-result .found{color:var(--ink);}
+  .sh-result .leapnote{color:var(--gold);margin-top:8px;font-size:12px;line-height:1.55;}
+
+  /* preview list */
+  .preview{background:var(--field);border:1px solid var(--line2);border-radius:11px;
+    padding:18px 18px 8px;margin-bottom:14px;}
+  .preview .ttl{font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--dim);margin-bottom:6px;}
+  .nextbig{font-size:15px;color:var(--ink);padding:12px 0 14px;border-bottom:1px solid var(--line2);margin-bottom:4px;}
+  .nextbig .cnt{color:var(--gold);font-size:13px;}
+  .yr{display:flex;justify-content:space-between;align-items:baseline;
+    padding:9px 0;border-bottom:1px solid var(--line2);font-size:14px;}
+  .yr:last-child{border-bottom:none;}
+  .yr .g{color:var(--ink);}
+  .yr .meta{color:var(--dimmer);font-size:12px;}
+  .yr.skip .g{color:var(--gold);}
+
+  .dl{width:100%;background:transparent;color:var(--ok);border:1px solid var(--ok);
+    font-family:var(--mono);font-size:15px;font-weight:600;padding:15px;border-radius:10px;
+    cursor:pointer;transition:.15s;display:flex;align-items:center;justify-content:center;gap:9px;}
+  .dl:hover{background:rgba(122,155,107,.1);}
+  .icsline{text-align:center;font-size:11.5px;color:var(--dimmer);margin-top:11px;line-height:1.5;}
+
+  .steps{margin-top:26px;border-top:1px solid var(--line);padding-top:22px;}
+  .steps h3{font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--dim);margin-bottom:14px;}
+  .ptab{display:flex;gap:0;border:1px solid var(--line);border-radius:8px;overflow:hidden;margin-bottom:16px;}
+  .ptab button{flex:1;background:var(--field);border:none;border-right:1px solid var(--line);
+    color:var(--dim);font-family:var(--mono);font-size:12px;padding:9px;cursor:pointer;transition:.15s;}
+  .ptab button:last-child{border-right:none;}
+  .ptab button.on{background:#1f1a13;color:var(--ink);}
+  .stepbody{font-size:13.5px;color:var(--dim);line-height:1.7;}
+  .stepbody ol{padding-left:20px;}
+  .stepbody li{margin-bottom:7px;}
+  .stepbody b{color:var(--ink);font-weight:600;}
+
+  .foot{margin-top:34px;color:var(--dimmer);font-size:11.5px;line-height:1.7;text-align:center;}
+  @media(max-width:480px){.dategrid{grid-template-columns:1fr;}}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <span class="badge">음력 · 农历 · âm lịch</span>
+  <h1><span class="hl">Lunar birthdays</span>, converted once.</h1>
+  <p class="sub">A lunar birthday lands on a different solar date every year. Enter it once; get 60 years of the right dates as one calendar file.</p>
+
+  <div class="panel">
+    <div class="field">
+      <label>Whose birthday</label>
+      <input type="text" id="who" placeholder="e.g. 아빠 / Mom / 奶奶" autocomplete="off">
+    </div>
+
+    <div class="field">
+      <label>Which lunar calendar</label>
+      <div class="seg" id="country">
+        <button data-tz="8" data-c="KR" class="on">Korea 음력</button>
+        <button data-tz="8" data-c="CN">China 农历</button>
+        <button data-tz="7" data-c="VN">Vietnam âm lịch</button>
+      </div>
+      <div class="hint" id="cnote">Korea uses the same astronomical calculation as China for modern dates.</div>
+    </div>
+
+    <div class="field">
+      <label>The lunar birth date</label>
+      <div class="dategrid">
+        <input type="text" id="ly" placeholder="year" inputmode="numeric" maxlength="4">
+        <input type="text" id="lm" placeholder="month 1–12" inputmode="numeric" maxlength="2">
+        <input type="text" id="ld" placeholder="day 1–30" inputmode="numeric" maxlength="2">
+      </div>
+      <label class="leapwrap"><input type="checkbox" id="leap"> This was a leap month (윤달 / 闰月 / tháng nhuận)</label>
+      <div class="hint">Leave unchecked unless you specifically know it was a leap month. Most aren't. <a href="#" class="helperlink" id="helperlink">Don't know the lunar date, or unsure about the leap month?</a></div>
+
+      <div class="solarhelper" id="solarhelper">
+        <div class="sh-lbl">Enter the solar (양력) date instead. It's the one on the birth certificate. We'll work out the lunar date and leap month for you.</div>
+        <div class="dategrid">
+          <input type="text" id="sy" placeholder="year" inputmode="numeric" maxlength="4">
+          <input type="text" id="sm" placeholder="month 1–12" inputmode="numeric" maxlength="2">
+          <input type="text" id="sd" placeholder="day 1–31" inputmode="numeric" maxlength="2">
+        </div>
+        <button type="button" class="sh-btn" id="sh-btn">Fill in the lunar date ↑</button>
+        <div class="sh-result" id="sh-result"></div>
+      </div>
+    </div>
+
+    <div class="field" id="leadField">
+      <label>Remind me</label>
+      <div class="dd" id="dd">
+        <button type="button" class="dd-head" id="ddhead" aria-haspopup="listbox" aria-expanded="false">
+          <span id="ddlabel">3 days before, 9am</span>
+          <span class="dd-arrow">▾</span>
+        </button>
+        <div class="dd-list" id="ddlist" role="listbox">
+          <div class="dd-opt" data-v="0" role="option">On the day, 9am</div>
+          <div class="dd-opt on" data-v="3" role="option">3 days before, 9am</div>
+          <div class="dd-opt" data-v="7" role="option">7 days before, 9am</div>
+          <div class="dd-opt" data-v="14" role="option">2 weeks before, 9am</div>
+        </div>
+      </div>
+    </div>
+
+    <button class="go" id="go">Preview the dates</button>
+    <div class="err" id="err"></div>
+  </div>
+
+  <div class="out" id="out">
+    <div class="preview">
+      <div class="ttl">Next solar dates · preview</div>
+      <div class="nextbig" id="nextbig"></div>
+      <div id="rows"></div>
+    </div>
+    <button class="dl" id="dl">↓ <span id="dlname">download .ics</span></button>
+    <div class="icsline">This is a standard calendar file for Apple Calendar, Google Calendar, Outlook, and most calendar apps.</div>
+
+    <div class="steps">
+      <h3>Add it to your calendar once</h3>
+      <div class="ptab" id="ptab">
+        <button data-p="ios" class="on">iPhone</button>
+        <button data-p="android">Android</button>
+        <button data-p="mac">Mac</button>
+        <button data-p="gcal">Google Calendar (web)</button>
+      </div>
+      <div class="stepbody" id="stepbody"></div>
+    </div>
+  </div>
+
+  <p class="foot">
+    Everything runs in your browser. Nothing is uploaded, stored, or sent anywhere.<br>
+    Conversion uses the Hồ Ngọc Đức astronomical algorithm. UTC+8 for Korea &amp; China, UTC+7 for Vietnam, with leap-month handling. Accurate roughly 1900–2100.<br>
+    <a href="/" style="color:var(--dim);text-decoration:underline;text-underline-offset:2px">made by ajin.im</a>
+  </p>
+</div>
+
+<script>
+"use strict";
+/* ===== verified conversion engine (unchanged) ===== */
+function INT(d){return Math.floor(d);}
+function jdFromDate(dd,mm,yy){var a=INT((14-mm)/12),y=yy+4800-a,m=mm+12*a-3;
+  var jd=dd+INT((153*m+2)/5)+365*y+INT(y/4)-INT(y/100)+INT(y/400)-32045;
+  if(jd<2299161){jd=dd+INT((153*m+2)/5)+365*y+INT(y/4)-32083;}return jd;}
+function jdToDate(jd){var a,b,c,d,e,m;
+  if(jd>2299160){a=jd+32044;b=INT((4*a+3)/146097);c=a-INT((b*146097)/4);}else{b=0;c=jd+32082;}
+  d=INT((4*c+3)/1461);e=c-INT((1461*d)/4);m=INT((5*e+2)/153);
+  var day=e-INT((153*m+2)/5)+1,month=m+3-12*INT(m/10),year=b*100+d-4800+INT(m/10);
+  return [day,month,year];}
+function NewMoon(k){var T=k/1236.85,T2=T*T,T3=T2*T,dr=Math.PI/180;
+  var Jd1=2415020.75933+29.53058868*k+0.0001178*T2-0.000000155*T3;
+  Jd1+=0.00033*Math.sin((166.56+132.87*T-0.009173*T2)*dr);
+  var M=359.2242+29.10535608*k-0.0000333*T2-0.00000347*T3;
+  var Mpr=306.0253+385.81691806*k+0.0107306*T2+0.00001236*T3;
+  var F=21.2964+390.67050646*k-0.0016528*T2-0.00000239*T3;
+  var C1=(0.1734-0.000393*T)*Math.sin(M*dr)+0.0021*Math.sin(2*dr*M);
+  C1-=0.4068*Math.sin(Mpr*dr)+0.0161*Math.sin(dr*2*Mpr);C1-=0.0004*Math.sin(dr*3*Mpr);
+  C1+=0.0104*Math.sin(dr*2*F)-0.0051*Math.sin(dr*(M+Mpr));
+  C1-=0.0074*Math.sin(dr*(M-Mpr))+0.0004*Math.sin(dr*(2*F+M));
+  C1-=0.0004*Math.sin(dr*(2*F-M))-0.0006*Math.sin(dr*(2*F+Mpr));
+  C1+=0.0010*Math.sin(dr*(2*F-Mpr))+0.0005*Math.sin(dr*(2*Mpr+M));
+  var deltat;if(T<-11){deltat=0.001+0.000839*T+0.0002261*T2-0.00000845*T3-0.000000081*T*T3;}
+  else{deltat=-0.000278+0.000265*T+0.000262*T2;}return Jd1+C1-deltat;}
+function SunLongitude(jdn){var T=(jdn-2451545.0)/36525,T2=T*T,dr=Math.PI/180;
+  var M=357.52910+35999.05030*T-0.0001559*T2-0.00000048*T*T2;
+  var L0=280.46645+36000.76983*T+0.0003032*T2;
+  var DL=(1.914600-0.004817*T-0.000014*T2)*Math.sin(dr*M);
+  DL+=(0.019993-0.000101*T)*Math.sin(dr*2*M)+0.000290*Math.sin(dr*3*M);
+  var L=L0+DL;L=L*dr;L=L-Math.PI*2*INT(L/(Math.PI*2));return L;}
+function getSunLongitude(d,tz){return INT(SunLongitude(d-0.5-tz/24.0)/Math.PI*6);}
+function getNewMoonDay(k,tz){return INT(NewMoon(k)+0.5+tz/24.0);}
+function getLunarMonth11(yy,tz){var off=jdFromDate(31,12,yy)-2415021;var k=INT(off/29.530588853);
+  var nm=getNewMoonDay(k,tz);if(getSunLongitude(nm,tz)>=9){nm=getNewMoonDay(k-1,tz);}return nm;}
+function getLeapMonthOffset(a11,tz){var k=INT((a11-2415021.076998695)/29.530588853+0.5);
+  var last=0,i=1,arc=getSunLongitude(getNewMoonDay(k+i,tz),tz);
+  do{last=arc;i++;arc=getSunLongitude(getNewMoonDay(k+i,tz),tz);}while(arc!=last&&i<14);return i-1;}
+function convertLunar2Solar(lD,lM,lY,leap,tz){var a11,b11;
+  if(lM<11){a11=getLunarMonth11(lY-1,tz);b11=getLunarMonth11(lY,tz);}
+  else{a11=getLunarMonth11(lY,tz);b11=getLunarMonth11(lY+1,tz);}
+  var k=INT(0.5+(a11-2415021.076998695)/29.530588853);var off=lM-11;if(off<0){off+=12;}
+  var hasLeap=(b11-a11>365);
+  if(leap&&!hasLeap){return null;} // requested leap month, but this year has none
+  if(hasLeap){var lo=getLeapMonthOffset(a11,tz);var lmth=lo-2;if(lmth<0){lmth+=12;}
+    if(leap&&lM!=lmth){return null;} // leap requested but not for this month this year
+    else if(leap||off>=lo){off+=1;}}
+  var ms=getNewMoonDay(k+off,tz);return jdToDate(ms+lD-1);}
+
+/* solar -> lunar, same primitives, round-trip verified */
+function convertSolar2Lunar(dd,mm,yy,tz){
+  var dayNumber=jdFromDate(dd,mm,yy);
+  var k=INT((dayNumber-2415021.076998695)/29.530588853);
+  var monthStart=getNewMoonDay(k+1,tz);
+  if(monthStart>dayNumber){monthStart=getNewMoonDay(k,tz);}
+  var a11=getLunarMonth11(yy,tz);var b11=a11;var lunarYear;
+  if(a11>=monthStart){lunarYear=yy;a11=getLunarMonth11(yy-1,tz);}
+  else{lunarYear=yy+1;b11=getLunarMonth11(yy+1,tz);}
+  var lunarDay=dayNumber-monthStart+1;
+  var diff=INT((monthStart-a11)/29);
+  var lunarLeap=0;var lunarMonth=diff+11;
+  if(b11-a11>365){var lmd=getLeapMonthOffset(a11,tz);
+    if(diff>=lmd){lunarMonth=diff+10;if(diff==lmd){lunarLeap=1;}}}
+  if(lunarMonth>12){lunarMonth=lunarMonth-12;}
+  if(lunarMonth>=11&&diff<4){lunarYear-=1;}
+  return [lunarDay,lunarMonth,lunarYear,lunarLeap];
+}
+
+/* ===== UI state ===== */
+var tz=8, cc="KR", leadVal=3;
+var DOW=["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
+var MON=["","Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+var cnotes={
+  KR:"Korea uses the same astronomical calculation as China for modern dates.",
+  CN:"Standard Chinese 农历, calculated on Beijing time (UTC+8).",
+  VN:"Vietnamese âm lịch is calculated on Hanoi time (UTC+7), so it can differ from the Chinese date by a day in rare years."
+};
+function pad(n){return n<10?"0"+n:""+n;}
+function dow(d,m,y){return DOW[new Date(Date.UTC(y,m-1,d)).getUTCDay()];}
+function esc(s){return String(s).replace(/[\\;,]/g,function(c){return "\\"+c;}).replace(/\n/g,"\\n");}
+
+/* country */
+document.querySelectorAll("#country button").forEach(function(b){
+  b.onclick=function(){document.querySelectorAll("#country button").forEach(function(x){x.classList.remove("on");});
+    b.classList.add("on");tz=+b.dataset.tz;cc=b.dataset.c;document.getElementById("cnote").textContent=cnotes[cc];};
+});
+
+/* dropdown */
+var dd=document.getElementById("dd"),ddhead=document.getElementById("ddhead"),
+    ddlist=document.getElementById("ddlist"),ddlabel=document.getElementById("ddlabel");
+ddhead.onclick=function(e){e.stopPropagation();var open=dd.classList.toggle("open");
+  ddhead.setAttribute("aria-expanded",open?"true":"false");};
+ddlist.querySelectorAll(".dd-opt").forEach(function(o){
+  o.onclick=function(){ddlist.querySelectorAll(".dd-opt").forEach(function(x){x.classList.remove("on");});
+    o.classList.add("on");leadVal=+o.dataset.v;ddlabel.textContent=o.textContent;
+    dd.classList.remove("open");ddhead.setAttribute("aria-expanded","false");};
+});
+document.addEventListener("click",function(){dd.classList.remove("open");ddhead.setAttribute("aria-expanded","false");});
+
+/* inline solar helper */
+var solarhelper=document.getElementById("solarhelper");
+document.getElementById("helperlink").onclick=function(e){
+  e.preventDefault();solarhelper.classList.toggle("open");
+};
+document.getElementById("sh-btn").onclick=function(){
+  var sy=+document.getElementById("sy").value,sm=+document.getElementById("sm").value,sd=+document.getElementById("sd").value;
+  var r=document.getElementById("sh-result");
+  if(!sy||sy<1900||sy>2100||!sm||sm<1||sm>12||!sd||sd<1||sd>31){
+    r.className="sh-result show";r.innerHTML='<span style="color:var(--acc)">Enter a valid solar date (year 1900–2100, month 1–12, day 1–31).</span>';return;
+  }
+  var l=convertSolar2Lunar(sd,sm,sy,tz);
+  // fill the lunar fields above
+  document.getElementById("ly").value=l[2];
+  document.getElementById("lm").value=l[1];
+  document.getElementById("ld").value=l[0];
+  document.getElementById("leap").checked=!!l[3];
+  var leapNote = l[3]
+    ? '<div class="leapnote">⚑ This was a leap month (윤달). A leap month doesn\'t occur every year, so the birthday will only land a handful of times across 60 years. That\'s expected, not a bug.</div>'
+    : '';
+  r.className="sh-result show";
+  r.innerHTML='<span class="found">Filled in: lunar '+l[2]+' · month '+l[1]+', day '+l[0]+
+    (l[3]?' (leap)':'')+'. Adjust the reminder above if you like, then Preview.</span>'+leapNote;
+};
+
+/* resolved lunar date held for generation */
+var rLY=0,rLM=0,rLD=0,rLeap=0,lastICS="",lastFname="";
+function showErr(msg){var e=document.getElementById("err");e.textContent=msg;e.style.display="block";}
+function clrErr(){document.getElementById("err").style.display="none";}
+
+document.getElementById("go").onclick=function(){
+  clrErr();
+  rLY=+document.getElementById("ly").value;rLM=+document.getElementById("lm").value;
+  rLD=+document.getElementById("ld").value;rLeap=document.getElementById("leap").checked?1:0;
+  if(!rLY||rLY<1900||rLY>2100){return showErr("Enter a birth year between 1900 and 2100. If you only know the solar date, use the link above.");}
+  if(!rLM||rLM<1||rLM>12){return showErr("Month must be 1–12.");}
+  if(!rLD||rLD<1||rLD>30){return showErr("Day must be 1–30.");}
+  generate();
+};
+
+function generate(){
+  clrErr();
+  var who=document.getElementById("who").value.trim()||"Lunar birthday";
+  var lead=leadVal, startY=new Date().getFullYear(), events=[], rows=[], skips=0;
+  for(var y=startY;y<startY+60;y++){
+    var s=convertLunar2Solar(rLD,rLM,y,rLeap,tz);
+    if(!s||s[0]===0){skips++;continue;}
+    events.push({d:s[0],m:s[1],y:s[2]});
+    if(rows.length<6){rows.push({d:s[0],m:s[1],y:s[2]});}
+  }
+  if(events.length===0){return showErr("That leap month never recurs in the next 60 years. Try unchecking leap month.");}
+
+  // next occurrence + countdown
+  var today=new Date(); today.setHours(0,0,0,0);
+  var next=events.find(function(e){return new Date(e.y,e.m-1,e.d)>=today;})||events[0];
+  var days=Math.round((new Date(next.y,next.m-1,next.d)-today)/86400000);
+  var cnt = days===0?"today":(days===1?"tomorrow":days+" days away");
+  document.getElementById("nextbig").innerHTML='next: '+next.y+' · '+MON[next.m]+' '+pad(next.d)+
+    ' <span class="cnt">('+cnt+')</span>';
+
+  var html="";
+  rows.forEach(function(r){
+    html+='<div class="yr"><span class="g">'+r.y+' · '+MON[r.m]+' '+pad(r.d)+'</span>'+
+          '<span class="meta">'+dow(r.d,r.m,r.y)+'</span></div>';
+  });
+  if(rLeap){html+='<div class="yr skip"><span class="g">＊ '+skips+' leap-free years skipped over the 60-year span</span><span class="meta"></span></div>';}
+  document.getElementById("rows").innerHTML=html;
+
+  // ICS
+  var uid=Date.now()+"-"+Math.random().toString(36).slice(2,8);
+  var L=["BEGIN:VCALENDAR","VERSION:2.0","PRODID:-//lunar-birthday//EN","CALSCALE:GREGORIAN","METHOD:PUBLISH"];
+  events.forEach(function(e,i){
+    var dt=e.y+pad(e.m)+pad(e.d);
+    var nd=new Date(Date.UTC(e.y,e.m-1,e.d+1));
+    var de=nd.getUTCFullYear()+pad(nd.getUTCMonth()+1)+pad(nd.getUTCDate());
+    L.push("BEGIN:VEVENT","UID:"+uid+"-"+i+"@lunar-birthday",
+      "DTSTART;VALUE=DATE:"+dt,"DTEND;VALUE=DATE:"+de,
+      "SUMMARY:"+esc(who)+" 🎂",
+      "DESCRIPTION:"+esc("Lunar-calendar birthday. Auto-converted to this year's solar date."),
+      "TRANSP:TRANSPARENT");
+    if(lead>0){L.push("BEGIN:VALARM","ACTION:DISPLAY","DESCRIPTION:"+esc(who+": birthday in "+lead+" days"),"TRIGGER:"+(lead>1?"-P"+(lead-1)+"DT15H":"-PT15H"),"END:VALARM");}
+    else{L.push("BEGIN:VALARM","ACTION:DISPLAY","DESCRIPTION:"+esc(who+": birthday today"),"TRIGGER:PT9H","END:VALARM");}
+    L.push("END:VEVENT");
+  });
+  L.push("END:VCALENDAR");
+  lastICS=L.join("\r\n");
+  lastFname=(who.replace(/[^\w가-힣]+/g,"_").slice(0,30)||"lunar_birthday")+".ics";
+  document.getElementById("dlname").textContent="download "+lastFname;
+
+  document.getElementById("out").classList.add("show");
+  document.getElementById("out").scrollIntoView({behavior:"smooth",block:"nearest"});
+}
+
+document.getElementById("dl").onclick=function(){
+  var blob=new Blob([lastICS],{type:"text/calendar;charset=utf-8"});
+  var url=URL.createObjectURL(blob);var a=document.createElement("a");
+  a.href=url;a.download=lastFname;document.body.appendChild(a);a.click();
+  document.body.removeChild(a);setTimeout(function(){URL.revokeObjectURL(url);},1000);
+};
+
+var steps={
+  ios:"<ol><li>Tap <b>download</b> above. Safari shows a prompt. Tap <b>Download</b>.</li><li>Open the <b>Files</b> app, go to <b>Downloads</b>, tap the <b>.ics</b> file.</li><li>It opens in Calendar. Tap <b>Add All</b> (top right), pick which calendar, done.</li><li>The 60 years of birthdays are now in your calendar. After import, this page has done its job.</li></ol>",
+  android:"<ol><li>Tap <b>download</b> above to save the <b>.ics</b> file.</li><li>Android opens .ics files inconsistently from the phone, so the reliable route is: email the file to yourself, then follow the Google Calendar (web) steps on any computer.</li><li>If a file manager offers to open it with <b>Calendar</b>, that works too.</li></ol>",
+  mac:"<ol><li>Click <b>download</b> above.</li><li>Double-click the <b>.ics</b> file in your Downloads.</li><li>Calendar asks which calendar to add the events to. Pick one, click <b>OK</b>.</li><li>All 60 years import at once. Done.</li></ol>",
+  gcal:"<ol><li>Click <b>download</b> to save the <b>.ics</b> file.</li><li>Open <b>Google Calendar</b> on the web → gear icon → <b>Settings</b>.</li><li>Left menu → <b>Import &amp; export</b> → <b>Import</b>.</li><li>Select the .ics file, choose a calendar, click <b>Import</b>. It confirms how many events were added.</li></ol>"
+};
+document.getElementById("stepbody").innerHTML=steps.ios;
+document.querySelectorAll("#ptab button").forEach(function(b){
+  b.onclick=function(){document.querySelectorAll("#ptab button").forEach(function(x){x.classList.remove("on");});
+    b.classList.add("on");document.getElementById("stepbody").innerHTML=steps[b.dataset.p];};
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
New bespoke building piece at ajin.im/is/building/lunaronce/.

**What it is:** enter a 음력/农历/âm lịch birthday once, download 60 years of correct solar dates as one .ics for the calendar you already use. KR/CN on UTC+8, VN on UTC+7, leap months handled. Single-file, no build, runs entirely in the browser (nothing uploaded).

**Verification:** conversion engine checked against 23 published almanac dates (Seollal/Chuseok/Buddha's Birthday/Dano + KR/CN/VN leap months) and 564/564 solar→lunar→solar round-trips over 1900–2100. In-browser: no console errors, mobile-safe at 375px.

**Alarm fidelity fix:** the "N days before" reminders previously used TRIGGER:-PnD (fires midnight); now -P{n-1}DT15H so they fire at 9am on every client, matching the on-the-day alarm.

Bespoke anchors added: a3 favicon, analytics.js, made-by-ajin.im colophon. Soft-launch (not hub-listed yet).