### PR TITLE
Polish LunarOnce: 2-line subtitle, 3-row footer, hub-list it

### DIFF
--- a/is/building/index.html
+++ b/is/building/index.html
@@ -137,6 +137,13 @@
     <div class="section-label">Lately</div>
     <div class="project group-start">
       <div class="project-head">
+        <span class="project-name"><a href="/is/building/lunaronce/">LunarOnce</a></span>
+        <span class="project-status">live</span>
+      </div>
+      <p class="project-desc">Lunar birthdays, converted once into 60 years of solar dates.</p>
+    </div>
+    <div class="project">
+      <div class="project-head">
         <span class="project-name"><a href="/is/building/sky-over-seoul/">the sky over Seoul</a></span>
         <span class="project-status">live</span>
       </div>

--- a/is/building/lunaronce/index.html
+++ b/is/building/lunaronce/index.html
@@ -28,7 +28,7 @@
   h1{font-size:clamp(25px,5.5vw,36px);font-weight:600;letter-spacing:-.015em;
     margin:18px 0 12px;line-height:1.12;}
   h1 .hl{color:var(--acc);}
-  .sub{color:var(--dim);font-size:14px;max-width:60ch;margin-bottom:6px;line-height:1.6;}
+  .sub{color:var(--dim);font-size:14px;max-width:68ch;margin-bottom:6px;line-height:1.6;}
 
   .panel{background:var(--panel);border:1px solid var(--line);border-radius:14px;
     padding:clamp(20px,4vw,30px);margin-top:26px;
@@ -226,8 +226,7 @@
   </div>
 
   <p class="foot">
-    Everything runs in your browser. Nothing is uploaded, stored, or sent anywhere.<br>
-    Conversion uses the Hồ Ngọc Đức astronomical algorithm. UTC+8 for Korea &amp; China, UTC+7 for Vietnam, with leap-month handling. Accurate roughly 1900–2100.<br>
+    Everything runs in your browser. Nothing is uploaded, stored, or sent anywhere. Conversion uses the Hồ Ngọc Đức algorithm. UTC+8 Korea &amp; China, UTC+7 Vietnam. Accurate roughly 1900–2100.<br>
     <a href="/" style="color:var(--dim);text-decoration:underline;text-underline-offset:2px">made by ajin.im</a>
   </p>
 </div>


### PR DESCRIPTION
Follow-up polish on [#111](https://github.com/mobetter20/mobetter20.github.io/pull/111).

- **Subtitle** no longer orphans "calendar file" onto a third line (`.sub` max-width 60ch→68ch). 2 lines at desktop/tablet, no overflow at 375/768/1280.
- **Footer** trimmed 4 rows → 3: dropped the redundant "with leap-month handling" (the leap checkbox already covers it), "astronomical", and filler "for"; kept the full privacy line.
- **Listed** LunarOnce at the top of the /is/building "Lately" stream (no longer soft-launched).