### PR TITLE
Group the three Joseon-data pieces under 'the Joseon files'

### DIFF
--- a/is/building/index.html
+++ b/is/building/index.html
@@ -132,6 +132,13 @@
       </div>
       <p class="project-desc">Diagnostic instruments for interior conditions.</p>
     </div>
+    <div class="project">
+      <div class="project-head">
+        <span class="project-name"><a href="/is/building/joseon/">the Joseon files</a></span>
+        <span class="project-status is-collection">3 live &rarr;</span>
+      </div>
+      <p class="project-desc">Real Joseon records, each rebuilt as a modern institution.</p>
+    </div>
 
     <!-- Lately: the growing stream of single public builds, newest first -->
     <div class="section-label">Lately</div>
@@ -141,20 +148,6 @@
         <span class="project-status">live</span>
       </div>
       <p class="project-desc">Lunar birthdays, converted once into 60 years of solar dates.</p>
-    </div>
-    <div class="project">
-      <div class="project-head">
-        <span class="project-name"><a href="/is/building/sky-over-seoul/">the sky over Seoul</a></span>
-        <span class="project-status">live</span>
-      </div>
-      <p class="project-desc">130 years of real daily weather over Joseon Seoul.</p>
-    </div>
-    <div class="project">
-      <div class="project-head">
-        <span class="project-name"><a href="/is/building/omen.ops/">omen.ops</a></span>
-        <span class="project-status">live</span>
-      </div>
-      <p class="project-desc">The Joseon court's omens, rendered as an observability dashboard.</p>
     </div>
     <div class="project">
       <div class="project-head">

--- a/is/building/joseon/index.html
+++ b/is/building/joseon/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>the Joseon files</title>
+<meta name="description" content="Three pieces built from real Joseon records, each rebuilt as a modern institution: an observability console, a weather diary, a rankings product.">
+<link rel="canonical" href="https://ajin.im/is/building/joseon/">
+<meta property="og:site_name" content="ajin.im">
+<meta property="og:title" content="the Joseon files">
+<meta property="og:description" content="Three pieces built from real Joseon records, each rebuilt as a modern institution.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ajin.im/is/building/joseon/">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="the Joseon files">
+<meta name="twitter:description" content="Three pieces built from real Joseon records, each rebuilt as a modern institution.">
+<link rel="icon" type="image/png" href="/img/a1.png">
+<link rel="apple-touch-icon" href="/img/a1.png">
+<script src="/analytics.js" defer></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=DM+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #1a1612;
+    --text: #e8e0d0;
+    --text-soft: #a89c87;
+    --text-faint: #8f8473;
+    --accent: #c9a876;
+    --accent-soft: rgba(201, 168, 118, 0.25);
+    --rule: rgba(138, 127, 112, 0.18);
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body {
+    background: var(--bg); color: var(--text);
+    font-family: 'EB Garamond', Georgia, serif;
+    font-weight: 400; font-size: 18px; line-height: 1.6;
+    -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
+  }
+  body::before {
+    content: ''; position: fixed; inset: 0; pointer-events: none;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.85 0 0 0 0 0.78 0 0 0 0 0.66 0 0 0 0.06 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    opacity: 0.4; mix-blend-mode: overlay; z-index: 1;
+  }
+  main {
+    position: relative; z-index: 2;
+    max-width: 560px; margin: 0 auto; padding: 10vh 8vw 8vh;
+  }
+  /* title device as locator (smaller); the drawer name is the hero */
+  .title {
+    font-size: 1.05rem; font-weight: 400; letter-spacing: .01em; margin-bottom: .2rem;
+    animation: fade 0.9s ease-out 0.1s both;
+  }
+  .title .prefix { color: var(--text-faint); }
+  .title .verb { font-style: italic; color: var(--text-soft); }
+  .title a { color: var(--text-soft); text-decoration: none; border-bottom: 1px solid rgba(106,96,85,0.4); transition: color .25s, border-color .25s; }
+  .title a:hover, .title a:focus-visible { color: var(--text); border-bottom-color: rgba(106,96,85,0.8); }
+  .drawer-title {
+    font-size: 1.9rem; font-weight: 500; font-style: italic; letter-spacing: -0.01em;
+    color: var(--text); margin-bottom: .85rem;
+    animation: fade 0.9s ease-out 0.18s both;
+  }
+  .lede {
+    color: var(--text-soft); font-size: 1.02rem; max-width: 48ch; margin-bottom: 2.6rem;
+    animation: fade 0.9s ease-out 0.25s both;
+  }
+  .projects { animation: fade 0.9s ease-out 0.32s both; }
+  .project { padding: 1.15rem 0; border-bottom: 1px solid var(--rule); }
+  .project:first-child { border-top: 1px solid var(--rule); }
+  .project-head { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; }
+  .project-name { font-size: 1.25rem; }
+  .project-name a {
+    color: var(--accent); text-decoration: none;
+    border-bottom: 1px solid var(--accent-soft); transition: color .25s, border-color .25s;
+  }
+  .project-name a:hover, .project-name a:focus-visible { color: #d8b884; border-bottom-color: rgba(201,168,118,.7); }
+  .project-status {
+    font-family: 'DM Mono', monospace; font-size: .68rem;
+    letter-spacing: .16em; text-transform: uppercase; color: var(--text-faint); white-space: nowrap;
+  }
+  .project-desc { color: var(--text-soft); font-size: .95rem; margin-top: .35rem; }
+  footer {
+    margin-top: 2.6rem; padding-top: 1.1rem; border-top: 1px solid var(--rule);
+    font-family: 'DM Mono', monospace; font-size: .7rem; letter-spacing: .08em;
+  }
+  footer a { color: var(--text-faint); text-decoration: none; transition: color .25s; }
+  footer a:hover { color: var(--text-soft); }
+  @keyframes fade { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); } }
+  @media (max-width: 600px) {
+    main { padding: 7vh 7vw 6vh; }
+    .title { font-size: 1rem; }
+    .drawer-title { font-size: 1.6rem; }
+    .lede { font-size: .96rem; }
+    .project-name { font-size: 1.12rem; }
+    .project-desc { font-size: .9rem; }
+  }
+</style>
+</head>
+<body>
+<main>
+  <div class="title"><span class="prefix"><a href="/" target="_self">ajin.im</a> is</span> <span class="verb">building</span></div>
+  <h1 class="drawer-title">the Joseon files</h1>
+  <p class="lede">Three pieces, all built from real Joseon records. Each one takes the same history and rebuilds it as a different modern institution.</p>
+
+  <div class="projects">
+    <div class="project">
+      <div class="project-head">
+        <span class="project-name"><a href="/is/building/omen.ops/">omen.ops</a></span>
+        <span class="project-status">live</span>
+      </div>
+      <p class="project-desc">The Joseon court's omens, rendered as an observability dashboard.</p>
+    </div>
+    <div class="project">
+      <div class="project-head">
+        <span class="project-name"><a href="/is/building/sky-over-seoul/">the sky over Seoul</a></span>
+        <span class="project-status">live</span>
+      </div>
+      <p class="project-desc">130 years of real daily weather over Joseon Seoul.</p>
+    </div>
+    <div class="project">
+      <div class="project-head">
+        <span class="project-name"><a href="/is/building/the-joseon-review/">The Joseon Review</a></span>
+        <span class="project-status">live</span>
+      </div>
+      <p class="project-desc">15,151 civil-examination passers (1393&ndash;1894), built as a prestige rankings product.</p>
+    </div>
+  </div>
+
+  <footer>
+    <a href="/is/building/">&larr; building</a>
+  </footer>
+</main>
+</body>
+</html>


### PR DESCRIPTION
Takes the recommended Option A: omen.ops, the sky over Seoul, and The Joseon Review now sit under one **the Joseon files** collection card on /is/building, fanning out to a new frame hub at /is/building/joseon/.

- Reuses the existing collection-card pattern (Seoul Crushing, Instrument Bus), so it reads as consistency rather than new structure.
- omen.ops and the sky over Seoul move out of "Lately"; The Joseon Review is surfaced for the first time. LunarOnce stays as the lead Lately item.
- The hub wears the building index frame chrome (calm), not a second console: the three pieces share a source (real Joseon records), so the grouping itself is the seal-safe cross-link. No sideways links go inside the sealed pieces.

Rebased on latest master (incl. LunarOnce #111/#112). Verified at 375 / 768 / 1280 widths; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
