### PR TITLE
LunarOnce footer: break after the privacy line, drop the UTC summary

### DIFF
--- a/is/building/lunaronce/index.html
+++ b/is/building/lunaronce/index.html
@@ -226,7 +226,8 @@
   </div>
 
   <p class="foot">
-    Everything runs in your browser. Nothing is uploaded, stored, or sent anywhere. Conversion uses the Hồ Ngọc Đức algorithm. UTC+8 Korea &amp; China, UTC+7 Vietnam. Accurate roughly 1900–2100.<br>
+    Everything runs in your browser. Nothing is uploaded, stored, or sent anywhere.<br>
+    Conversion uses the Hồ Ngọc Đức algorithm. Accurate roughly 1900–2100.<br>
     <a href="/" style="color:var(--dim);text-decoration:underline;text-underline-offset:2px">made by ajin.im</a>
   </p>
 </div>


### PR DESCRIPTION
Footer reads as 3 clean rows instead of one dense flow ("Conversion" was dangling onto line 1):

```
Everything runs in your browser. Nothing is uploaded, stored, or sent anywhere.
Conversion uses the Hồ Ngọc Đức algorithm. Accurate roughly 1900–2100.
made by ajin.im
```

Dropped "UTC+8 Korea & China, UTC+7 Vietnam" (the timezone basis already shows in the form's per-country note). Verified 3 rows at desktop, no overflow at mobile.