### PR TITLE
the Joseon files hub: trim copy, fix footer

### DIFF
--- a/is/building/joseon/index.html
+++ b/is/building/joseon/index.html
@@ -81,7 +81,8 @@
   }
   .project-desc { color: var(--text-soft); font-size: .95rem; margin-top: .35rem; }
   footer {
-    margin-top: 2.6rem; padding-top: 1.1rem; border-top: 1px solid var(--rule);
+    margin-top: 2.2rem;
+    display: flex; justify-content: space-between; align-items: baseline; gap: 1rem;
     font-family: 'DM Mono', monospace; font-size: .7rem; letter-spacing: .08em;
   }
   footer a { color: var(--text-faint); text-decoration: none; transition: color .25s; }
@@ -101,7 +102,7 @@
 <main>
   <div class="title"><span class="prefix"><a href="/" target="_self">ajin.im</a> is</span> <span class="verb">building</span></div>
   <h1 class="drawer-title">the Joseon files</h1>
-  <p class="lede">Three pieces, all built from real Joseon records. Each one takes the same history and rebuilds it as a different modern institution.</p>
+  <p class="lede">Three pieces, all built from real Joseon records.</p>
 
   <div class="projects">
     <div class="project">
@@ -123,12 +124,13 @@
         <span class="project-name"><a href="/is/building/the-joseon-review/">The Joseon Review</a></span>
         <span class="project-status">live</span>
       </div>
-      <p class="project-desc">15,151 civil-examination passers (1393&ndash;1894), built as a prestige rankings product.</p>
+      <p class="project-desc">15,151 who passed Joseon's civil examination, 1393&ndash;1894.</p>
     </div>
   </div>
 
   <footer>
     <a href="/is/building/">&larr; building</a>
+    <a href="/" target="_self">made by ajin.im</a>
   </footer>
 </main>
 </body>


### PR DESCRIPTION
Follow-up polish on the hub from owner feedback:

- **Lede** cut to one sentence ("Three pieces, all built from real Joseon records.") — dropped the overt "rebuilds it as a modern institution" gloss.
- **The Joseon Review** one-liner made content-forward: "15,151 who passed Joseon's civil examination, 1393–1894." (was "...built as a prestige rankings product" — the institution shouldn't explain its own joke).
- **Footer**: removed the redundant top border (the last row's border already divides) so it's a single rule, not a double; added the "made by ajin.im" colophon to match the three pieces it groups.

Verified at 375 / 1280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
