### PR TITLE
building: revert the Joseon files grouping, archive the hub

### DIFF
--- a/_archive/README.md
+++ b/_archive/README.md
@@ -10,6 +10,23 @@ and what it would take to bring it back.
 
 ## Paused entries
 
+### `joseon/` (the Joseon files)
+
+- **Was at**: `ajin.im/is/building/joseon/`
+- **Now at**: `_archive/joseon/index.html` (with `<meta name="robots" content="noindex, nofollow">` added as belt-and-braces)
+- **Paused**: 2026-06-08
+- **Why**: a "collection card + hub" that grouped the three Joseon-data pieces (omen.ops, the sky over Seoul, The Joseon Review). The Joseon Review was pulled back to soft-launch, leaving only two pieces, short of earning a separate hub (the Instrument Bus has 9, Seoul Crushing 4). Kept for revival if a third Joseon piece lands or The Joseon Review ships for real.
+- **What it was**: a calm frame hub (building-index chrome) listing the three pieces; the grouping itself was the seal-safe cross-link between them, no sideways links inside the sealed pieces. Lede: "Three pieces, all built from real Joseon records."
+- **Was linked from**: a collection card on `/is/building/` ("the Joseon files · 3 live →"). That card has been removed; omen.ops + the sky over Seoul are back as individual rows under "Lately".
+
+#### To revive
+
+1. `git mv _archive/joseon/ is/building/joseon/`
+2. Optional: remove the `<meta name="robots" content="noindex, nofollow">` line from `is/building/joseon/index.html`
+3. Re-add the collection card to `is/building/index.html` (a `.project` with an `is-collection` chip linking `/is/building/joseon/`), and move omen.ops + the sky over Seoul out of "Lately" back into the hub.
+4. Re-list The Joseon Review in the hub once it is out of soft-launch.
+5. Update `~/projects.md` (`the-joseon-files` stanza) + `creative-constellation.md`, and remove this entry.
+
 ### `works/`
 
 - **Was at**: `ajin.im/works`

--- a/_archive/joseon/index.html
+++ b/_archive/joseon/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="noindex, nofollow">
 <title>the Joseon files</title>
 <meta name="description" content="Three pieces built from real Joseon records, each rebuilt as a modern institution: an observability console, a weather diary, a rankings product.">
 <link rel="canonical" href="https://ajin.im/is/building/joseon/">

--- a/is/building/index.html
+++ b/is/building/index.html
@@ -132,13 +132,6 @@
       </div>
       <p class="project-desc">Diagnostic instruments for interior conditions.</p>
     </div>
-    <div class="project">
-      <div class="project-head">
-        <span class="project-name"><a href="/is/building/joseon/">the Joseon files</a></span>
-        <span class="project-status is-collection">3 live &rarr;</span>
-      </div>
-      <p class="project-desc">Real Joseon records, each rebuilt as a modern institution.</p>
-    </div>
 
     <!-- Lately: the growing stream of single public builds, newest first -->
     <div class="section-label">Lately</div>
@@ -148,6 +141,20 @@
         <span class="project-status">live</span>
       </div>
       <p class="project-desc">Lunar birthdays, converted once into 60 years of solar dates.</p>
+    </div>
+    <div class="project">
+      <div class="project-head">
+        <span class="project-name"><a href="/is/building/sky-over-seoul/">the sky over Seoul</a></span>
+        <span class="project-status">live</span>
+      </div>
+      <p class="project-desc">130 years of real daily weather over Joseon Seoul.</p>
+    </div>
+    <div class="project">
+      <div class="project-head">
+        <span class="project-name"><a href="/is/building/omen.ops/">omen.ops</a></span>
+        <span class="project-status">live</span>
+      </div>
+      <p class="project-desc">The Joseon court's omens, rendered as an observability dashboard.</p>
     </div>
     <div class="project">
       <div class="project-head">


### PR DESCRIPTION
Sleeping on it, the owner decided **The Joseon Review isn't ready to surface yet** — back to soft-launch. With only omen.ops + the sky over Seoul left, a two-item collection hub isn't worth the abstraction tax.

- `/is/building`: dropped the "the Joseon files" card; **omen.ops + the sky over Seoul return as individual "Lately" rows** (omen.ops back at top level, not a click deeper).
- Hub **archived, not deleted** → `_archive/joseon/` (per the repo's `_archive` convention: `noindex` meta added, excluded by Jekyll so `/is/building/joseon/` 404s). Revive steps logged in `_archive/README.md` for when a third Joseon piece lands or The Joseon Review ships for real.
- The Joseon Review: soft-launched, unlinked (its own page untouched).

Registry + creative-constellation notes updated out-of-repo (the grouping attempt + revert recorded, not erased).

Verified: card gone, omen.ops + sky back in the index, `/is/building/joseon/` 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
