### PR TITLE
hygiene: trim public agent-docs, remove leaked email, add share card

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,6 @@
 
 Static site hosted on GitHub Pages. Contains the creative house at `ajin.im/is/writing/` and the Avian Municipal District universe.
 
-## Cross-project context — the reclassification family
-
-Most of ajin.im's creative work — this site, plus the Avian Municipal District (bird-universe), the Bureau of Interior Conditions (propagandaformyself.xyz), omen.ops, and the Instrument Bus and its instruments — shares one method: **a human feeling routed through a sincere institution that was never built for it.** The durable map of that oeuvre (voice, current state, and the strategic stances already reasoned through) lives in **`~/Documents/New project/personal/profile/creative-constellation.md`**.
-
-**Read it before any structure / strategy / cross-linking / "findability" work on a family piece**, so you build on the existing thinking instead of re-deriving it (which has already happened more than once). Two stances to know going in: the work reads as *one connected oeuvre*, but the owner's repeatedly-demonstrated line is **light cross-link, never a unifying "universe" portal/hub** (over-structuring keeps getting killed as "abstraction tax"); and a missing affordance is usually a deliberate decision (check `git log`) before it's a gap.
-
-**Hold it as informed, not bound — it is not gospel.** It is dated decisions and a point-in-time read. Challenge it, bring fresh thinking, and treat state-dependent facts (e.g. "HN is the channel," traffic numbers, "the lever is X") as **snapshots to re-verify, not standing law.** Acting against something it says is fine — just say why. "Usually a decision" isn't "always."
-
 ## Design System — typographic tiers
 
 Governing rule: **consistent chrome, free content.** The wrapper is uniform; what's inside is free to vary by tier. When adding or restyling a page, classify it first, then give it that tier's chrome.
@@ -32,23 +24,6 @@ Tier follows a page's **nature, not its URL parent** — konbini (bespoke) sits 
 - **The "made by ajin.im" colophon** is the standard form of that *way home* for Bespoke pages and standalone sites (own domain) that don't wear the title device. It's a maker's *signature* — meta, sitting outside the fiction — so it rides fiction-heavy worlds (the bird-universe, BIC) where a back-breadcrumb would break character; keep it to one discreet, muted footer line. Internal ajin.im pages link `/` (same tab); standalone sites link `https://ajin.im` (new tab, `rel=noopener`). **On:** omen.ops, BIC (propagandaformyself.xyz), seoulcrushing, bird-universe **avian-district** (in-world hub). **NOT on:** standard section pages (title device already links home), the sealed bird-universe leaf rooms, **bird-coo / The Municipal Coo** (it added footer bulk — rejected 2026-06), or archived/noindex pages. Per-site bird-universe status (front door = bird-coo, internal hub = avian-district, archived = bird-docket) lives in `_scripts/bird-universe/bird_universe_registry.json`.
 
 Within the house, `.house-title` marks **section entrances and orphan URLs** (`/is/writing` → "ajin.im *is* writing"). The writing archive is **not** in the house: `/writes` (a running log of thoughts — the essays) and `/wrote` (the sealed Medium-years comedy archive) are their own Bespoke world — `writes.css`, a monospace log index + serif reading pages, **not** `creative-house.css` — wearing only the Bespoke anchors (a way home, a thread of palette sympathy). The tense pair is load-bearing: **is writing** (the masked worlds) · **writes** (the living log) · **wrote** (the sealed archive); pieces carry no genre labels. Coo issues carry their own title as content. The device tolerates the page's tense/phrasing — a sub-hub may extend its parent's verb, e.g. Small Ware → "ajin.im *is* building small."
-
-## World Bible
-
-The world-building reference for the Avian Municipal District lives in two locations that must stay in sync:
-
-- **Local (primary working copy):** the `bird-universe/` folder in the local writing directory
-- **GitHub (backup):** `github.com/mobetter20/ajin-universe-bible` (private)
-
-Read `INDEX.md` for what to load and when. Modular files:
-- `00-foundation.md` — philosophy, tone hierarchy, house principles
-- `01-strategy.md` — current state, priorities, interconnections
-- `02-registry.md` — characters, cases, locations, objects, workflow
-- `03-coo-taxonomy.md` — 12 story categories for The Municipal Coo
-
-**Before writing content** for any bird-universe site, check `02-registry.md` for entity facts.
-
-**After publishing**, update the registry with new facts established (characters, locations, channel changes, etc.) in BOTH the local copy and the GitHub repo. Do not leave them out of sync.
 
 ## Build Scripts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,6 @@
 
 Static site hosted on GitHub Pages. Contains the creative house at `ajin.im/is/writing/` and the Avian Municipal District universe.
 
-## Cross-project context — the reclassification family
-
-Most of ajin.im's creative work — this site, plus the Avian Municipal District (bird-universe), the Bureau of Interior Conditions (propagandaformyself.xyz), omen.ops, and the Instrument Bus and its instruments — shares one method: **a human feeling routed through a sincere institution that was never built for it.** The durable map of that oeuvre (voice, current state, and the strategic stances already reasoned through) lives in **`~/Documents/New project/personal/profile/creative-constellation.md`**.
-
-**Read it before any structure / strategy / cross-linking / "findability" work on a family piece**, so you build on the existing thinking instead of re-deriving it (which has already happened more than once). Two stances to know going in: the work reads as *one connected oeuvre*, but the owner's repeatedly-demonstrated line is **light cross-link, never a unifying "universe" portal/hub** (over-structuring keeps getting killed as "abstraction tax"); and a missing affordance is usually a deliberate decision (check `git log`) before it's a gap.
-
-**Hold it as informed, not bound — it is not gospel.** It is dated decisions and a point-in-time read. Challenge it, bring fresh thinking, and treat state-dependent facts (e.g. "HN is the channel," traffic numbers, "the lever is X") as **snapshots to re-verify, not standing law.** Acting against something it says is fine — just say why. "Usually a decision" isn't "always."
-
 ## Design System — typographic tiers
 
 Governing rule: **consistent chrome, free content.** The wrapper is uniform; what's inside is free to vary by tier. When adding or restyling a page, classify it first, then give it that tier's chrome.
@@ -34,23 +26,6 @@ Tier follows a page's **nature, not its URL parent** — konbini (bespoke) sits 
 Within the house, `.house-title` marks **section entrances and orphan URLs** (`/is/writing` → "ajin.im *is* writing"). The writing archive is **not** in the house: `/writes` (a running log of thoughts — the essays) and `/wrote` (the sealed Medium-years comedy archive) are their own Bespoke world — `writes.css`, a monospace log index + serif reading pages, **not** `creative-house.css` — wearing only the Bespoke anchors (a way home, a thread of palette sympathy). The tense pair is load-bearing: **is writing** (the masked worlds) · **writes** (the living log) · **wrote** (the sealed archive); pieces carry no genre labels. Coo issues carry their own title as content. The device tolerates the page's tense/phrasing — a sub-hub may extend its parent's verb, e.g. Small Ware → "ajin.im *is* building small."
 
 **Favicon scheme:** `a1` = frame hubs (`/`, running, reading, learning, building); `a2` = error/404; `a3` = house + all generated pages; bespoke pages carry their own art. (Single 180px PNGs today; full sized-set + manifest deferred.)
-
-## World Bible
-
-The world-building reference for the Avian Municipal District lives in two locations that must stay in sync:
-
-- **Local (primary working copy):** the `bird-universe/` folder in the local writing directory
-- **GitHub (backup):** `github.com/mobetter20/ajin-universe-bible` (private)
-
-Read `INDEX.md` for what to load and when. Modular files:
-- `00-foundation.md` — philosophy, tone hierarchy, house principles
-- `01-strategy.md` — current state, priorities, interconnections
-- `02-registry.md` — characters, cases, locations, objects, workflow
-- `03-coo-taxonomy.md` — 12 story categories for The Municipal Coo
-
-**Before writing content** for any bird-universe site, check `02-registry.md` for entity facts.
-
-**After publishing**, update the registry with new facts established (characters, locations, channel changes, etc.) in BOTH the local copy and the GitHub repo. Do not leave them out of sync.
 
 ## Build Scripts
 

--- a/_scripts/notify.py
+++ b/_scripts/notify.py
@@ -22,12 +22,13 @@ CLI (for testing):
 
 from __future__ import annotations
 
+import os
 import smtplib
 import subprocess
 import sys
 from email.message import EmailMessage
 
-EMAIL_TO = "thelaughingmanslastact@gmail.com"
+EMAIL_TO = os.environ.get("NOTIFY_EMAIL", "")  # set NOTIFY_EMAIL to receive notifications; empty = email skipped, banner still fires
 EMAIL_FROM = EMAIL_TO
 GMAIL_PW_SERVICE = "mobetter-stats-gmail-app-pw"
 GMAIL_PW_ACCOUNT = "default"
@@ -44,6 +45,8 @@ def keychain_get(service: str, account: str = "default") -> str | None:
 
 
 def send_email(subject: str, body: str) -> tuple[bool, str]:
+    if not EMAIL_TO:
+        return False, "no recipient (set NOTIFY_EMAIL)"
     pw = keychain_get(GMAIL_PW_SERVICE, GMAIL_PW_ACCOUNT)
     if not pw:
         return False, "no keychain password (skipped)"

--- a/is/building/the-joseon-review/_template.html
+++ b/is/building/the-joseon-review/_template.html
@@ -5,6 +5,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Joseon Examination Rankings | The Joseon Review</title>
 <meta name="description" content="The Joseon civil service examination, ranked and profiled. 15,151 admitted officials across 800 sittings, 1393 to 1894, by the numbers.">
+<!-- text-only share card (no image, by design) -->
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ajin.im/is/building/the-joseon-review/">
+<meta property="og:title" content="Joseon Examination Rankings | The Joseon Review">
+<meta property="og:description" content="The Joseon civil service examination, ranked and profiled. 15,151 admitted officials across 800 sittings, 1393 to 1894, by the numbers.">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Joseon Examination Rankings | The Joseon Review">
+<meta name="twitter:description" content="The Joseon civil service examination, ranked and profiled. 15,151 admitted officials across 800 sittings, 1393 to 1894, by the numbers.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&family=Inter:wght@400;500;600;700&family=Noto+Serif+KR:wght@500;700&display=swap" rel="stylesheet">

--- a/is/building/the-joseon-review/index.html
+++ b/is/building/the-joseon-review/index.html
@@ -6,6 +6,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Joseon Examination Rankings | The Joseon Review</title>
 <meta name="description" content="The Joseon civil service examination, ranked and profiled. 15,151 admitted officials across 800 sittings, 1393 to 1894, by the numbers.">
+<!-- text-only share card (no image, by design) -->
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ajin.im/is/building/the-joseon-review/">
+<meta property="og:title" content="Joseon Examination Rankings | The Joseon Review">
+<meta property="og:description" content="The Joseon civil service examination, ranked and profiled. 15,151 admitted officials across 800 sittings, 1393 to 1894, by the numbers.">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Joseon Examination Rankings | The Joseon Review">
+<meta name="twitter:description" content="The Joseon civil service examination, ranked and profiled. 15,151 admitted officials across 800 sittings, 1393 to 1894, by the numbers.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&family=Inter:wght@400;500;600;700&family=Noto+Serif+KR:wght@500;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Public-scrutiny cleanup after the forum share: strip the private-asset pointers (strategy doc + bible repo) from CLAUDE.md/AGENTS.md, env-var the notify email, add text-only OG/Twitter tags to The Joseon Review. No site-behavior change.