### PR TITLE
CLAUDE.md: document the surfacing / information-architecture rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,14 @@ Within the house, `.house-title` marks **section entrances and orphan URLs** (`/
 
 **Favicon scheme:** `a1` = frame hubs (`/`, running, reading, learning, building); `a2` = error/404; `a3` = house + all generated pages; bespoke pages carry their own art. (Single 180px PNGs today; full sized-set + manifest deferred.)
 
+## Information architecture — what surfaces where
+
+Treat the apex surfaces as curated teasers, not mirrors of what sits below; surface each thing at its grain.
+
+- **Home (`/`, from `templates/root.html`) is a balanced teaser.** Each `ajin.im is ___` verb shows exactly **two** detail lines (running: 2 stats; writing: 2 worlds; building: 2 collections). To feature something new on a verb, **swap a line, don't append a third**; the two-per-verb symmetry is the device. The building lines show **collections only**, never loose tools.
+- **`/is/building`** = collection cards (container builds) up top + loose single builds under "Lately."
+- **Grain descends:** home (2/verb, collections) → section index (collections + "Lately") → hub → piece. Put each thing at its grain: a collection on the home teaser, a loose piece in "Lately," not the reverse.
+
 ## World Bible
 
 The world-building reference for the Avian Municipal District lives in two locations that must stay in sync:


### PR DESCRIPTION
Ratifies one of the two patterns surfaced this session (the owner judged the hub-threshold "obvious", so it's left undocumented).

Adds an **Information architecture** section to `CLAUDE.md`:
- Apex surfaces are curated teasers, not mirrors.
- The home page shows exactly **two detail lines per verb** (swap a line, don't append a third); building lines are **collections only**.
- `/is/building` = collection cards + loose "Lately" builds.
- Grain descends: home → section index → hub → piece.

Doc-only; no site output changes. (The companion `Status:` vocabulary, incl. first-class `soft-launch`, was added to `~/projects.md` out-of-repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
