### PR TITLE
CLAUDE.md: document the surfacing / information-architecture rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,14 @@ Within the house, `.house-title` marks **section entrances and orphan URLs** (`/
 
 **Favicon scheme:** `a1` = frame hubs (`/`, running, reading, learning, building); `a2` = error/404; `a3` = house + all generated pages; bespoke pages carry their own art. (Single 180px PNGs today; full sized-set + manifest deferred.)
 
+## Information architecture — what surfaces where
+
+Treat the apex surfaces as curated teasers, not mirrors of what sits below; surface each thing at its grain.
+
+- **Home (`/`, from `templates/root.html`) is a balanced teaser.** Each `ajin.im is ___` verb shows exactly **two** detail lines (running: 2 stats; writing: 2 worlds; building: 2 collections). To feature something new on a verb, **swap a line, don't append a third**; the two-per-verb symmetry is the device. The building lines show **collections only**, never loose tools.
+- **`/is/building`** = collection cards (container builds) up top + loose single builds under "Lately."
+- **Grain descends:** home (2/verb, collections) → section index (collections + "Lately") → hub → piece. Put each thing at its grain: a collection on the home teaser, a loose piece in "Lately," not the reverse.
+
 ## Build Scripts
 
 `_scripts/build_root.py` generates the stats-driven pages — `index.html` (the root `ajin.im is …` page), `is/running/`, `is/reading/`, `is/learning/` — from `templates/{root,running,reading,learning}.html` + `content/stats.md`. **Edit the templates, never the generated `index.html` files.** Direct edits are overwritten on the next build, and `.github/workflows/rebuild-root-on-stats.yml` rebuilds them automatically whenever a template, `stats.md`, or the script changes. Each generated file carries a `GENERATED FILE — DO NOT EDIT` banner under its doctype as an in-file reminder.


### PR DESCRIPTION
Ratifies the apex-granularity pattern surfaced this session (the hub-threshold was judged "obvious", left undocumented).

Adds an **Information architecture** section: apex surfaces are curated teasers, not mirrors; the home page shows exactly two detail lines per verb (swap, don't append); `/is/building` = collection cards + loose "Lately"; grain descends home → section → hub → piece.

Rebased onto #119's hygiene trim; text is public-safe (site structure only, no private pointers). Doc-only, no site output change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
