### PR TITLE
building: Seoul Crushing 4 → 6 pieces

### DIFF
--- a/is/building/index.html
+++ b/is/building/index.html
@@ -121,7 +121,7 @@
     <div class="project">
       <div class="project-head">
         <span class="project-name"><a href="https://seoulcrushing.com" target="_blank" rel="noopener">Seoul Crushing</a></span>
-        <span class="project-status is-collection">4 pieces &rarr;</span>
+        <span class="project-status is-collection">6 pieces &rarr;</span>
       </div>
       <p class="project-desc">Korea, made legible. With bite.</p>
     </div>


### PR DESCRIPTION
Bumps the Seoul Crushing collection chip on `is/building/` from **4** to **6 pieces** — the count was stale (missed `every-few-years`, already live) and now picks up **korea-in-motion** at `/motion`.

**Merge once /motion is live** — i.e. after [seoulcrushing.com#37](https://github.com/mobetter20/seoulcrushing.com/pull/37) merges and Cloudflare deploys — so the chip and the live federation stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)