### PR TITLE
building: unlist All At Once from Lately (soft-launch)

### DIFF
--- a/is/building/index.html
+++ b/is/building/index.html
@@ -137,13 +137,6 @@
     <div class="section-label">Lately</div>
     <div class="project group-start">
       <div class="project-head">
-        <span class="project-name"><a href="/is/building/all-at-once/">All At Once</a></span>
-        <span class="project-status">live</span>
-      </div>
-      <p class="project-desc">Every civilization on one timeline. Slide to any moment to see what was happening everywhere at once.</p>
-    </div>
-    <div class="project">
-      <div class="project-head">
         <span class="project-name"><a href="/is/building/lunaronce/">LunarOnce</a></span>
         <span class="project-status">live</span>
       </div>


### PR DESCRIPTION
Reverts the `/is/building` "Lately" listing for **All At Once** ([#125](https://github.com/mobetter20/mobetter20.github.io/pull/125)). Per owner: the page stays live at the public URL, just not surfaced on the building index.

This is the **soft-launch** state (mirrors `the-joseon-review`):
- ✅ Page kept at `/is/building/all-at-once/` (public URL remains)
- ✅ `sitemap.xml` entry kept (matches the-joseon-review soft-launch)
- ❌ Card removed from the building "Lately" stream; LunarOnce restored to the `group-start` slot

Registry stanza + Project Atlas updated separately (outside the repo) to reflect soft-launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)