### PR TITLE
building: canary copy, last frequency fix

### DIFF
--- a/is/building/did-claude-just-reset-usage/index.html
+++ b/is/building/did-claude-just-reset-usage/index.html
@@ -87,7 +87,7 @@ pre{background:var(--codebg);border:1px solid var(--rule);border-radius:4px;
 
   <section>
     <div class="label">what this is</div>
-    <p>anthropic sometimes zeroes pro/max usage counters mid-week. usually it is quiet compensation after an incident or a metering bug. sometimes it gets a post on x. often it does not. either way there is no in-app notice, no email, nothing in the status-page incident text.</p>
+    <p>anthropic sometimes zeroes pro/max usage counters mid-week. often it is quiet compensation after an incident or a metering bug. sometimes it gets a post on x. often it does not. either way there is no in-app notice, no email, nothing in the status-page incident text.</p>
     <p>this page watches <strong>one heavy reference account</strong> (the canary), whose official meter is polled every ~30 minutes, and answers from that. a mid-week reset looks like this: used% plunges to zero while the week keeps elapsing and the reset date stays put.</p>
   </section>
 


### PR DESCRIPTION
One remaining 'usually' in the what-is opener, same 'often' fix as #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)