### PR TITLE
hygiene: replace absolute /Users/ajin paths in tracked dev files

### DIFF
--- a/_scripts/bird-universe/BIRD-UNIVERSE-LINKING.md
+++ b/_scripts/bird-universe/BIRD-UNIVERSE-LINKING.md
@@ -1,7 +1,7 @@
 # Bird-Universe Linking Rules
 
 This document is workspace guidance for the bird-related sites under
-`/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/`.
+`is/writing/`.
 It lives in the committed dev tooling at `_scripts/bird-universe/` and is not
 served as part of the published site output.
 
@@ -10,16 +10,16 @@ served as part of the published site output.
 These rules apply only when touching the Avian Municipal District / bird-universe
 cluster:
 
-- `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/avian-district/`
-- `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/bird-coo/`
-- `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/bird-docket/`
-- `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/karen-hawk/`
-- `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/nest-court/`
-- `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/nest-court-proceedings/`
-- `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/nest-court-proceedings-pigeon/`
-- `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/nest-court-proceedings-starling/`
-- `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/perch-chat/`
-- `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/secondnest/`
+- `is/writing/avian-district/`
+- `is/writing/bird-coo/`
+- `is/writing/bird-docket/`
+- `is/writing/karen-hawk/`
+- `is/writing/nest-court/`
+- `is/writing/nest-court-proceedings/`
+- `is/writing/nest-court-proceedings-pigeon/`
+- `is/writing/nest-court-proceedings-starling/`
+- `is/writing/perch-chat/`
+- `is/writing/secondnest/`
 
 Do not apply these rules to unrelated comedy, essays, or other writing projects.
 
@@ -96,7 +96,7 @@ Before adding a new bird-universe site:
    - `meta_directory`
    - `listed_only`
 2. Add or update the registry:
-   `/Users/ajin/Documents/New project/personal/mobetter20.github.io/_scripts/bird-universe/bird_universe_registry.json`
+   `_scripts/bird-universe/bird_universe_registry.json`
 3. Decide whether it belongs in:
    - the future `avian-district` official directory
    - the `bird-docket` meta directory
@@ -115,8 +115,8 @@ Current target migration:
 
 Known migration watchpoints:
 
-- `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/index.html`
-- `/Users/ajin/Documents/New project/personal/mobetter20.github.io/is/writing/secondnest/index.html`
+- `is/writing/index.html`
+- `is/writing/secondnest/index.html`
 
 ## What Is Committed vs Local
 
@@ -135,9 +135,9 @@ Genuinely local / per-machine:
 ## Enforcement
 
 - The effective guardrail is the checker:
-  `/Users/ajin/Documents/New project/personal/mobetter20.github.io/_scripts/bird-universe/check_bird_universe_links.py`
+  `_scripts/bird-universe/check_bird_universe_links.py`
 - Push-time enforcement happens through the local Git hook at:
-  `/Users/ajin/Documents/New project/personal/mobetter20.github.io/.git/hooks/pre-push`
+  `.git/hooks/pre-push`
 - `publish.sh` is not the safety model. Treat it as an optional local helper.
 - If this repo is recloned or `.git` is replaced, the local hook and local
   excludes must be recreated.

--- a/_scripts/build_comedy.py
+++ b/_scripts/build_comedy.py
@@ -10,7 +10,7 @@ import writes_common
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-EXPORT_ROOT = Path("/Users/ajin/Documents/New project/personal/ajin.im:is:writing/archive/wrote")
+EXPORT_ROOT = Path.home() / "Documents/New project/personal/ajin.im:is:writing/archive/wrote"
 COMEDY_ROOT = REPO_ROOT / "is" / "writing" / "comedy"
 COMEDY_SOURCE_ROOT = COMEDY_ROOT / "_src"
 WROTE_ROOT = REPO_ROOT / "wrote"

--- a/_scripts/build_comedy_pilot.py
+++ b/_scripts/build_comedy_pilot.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-EXPORT_ROOT = Path("/Users/ajin/Documents/New project/personal/ajin.im:is:writing/archive/wrote")
+EXPORT_ROOT = Path.home() / "Documents/New project/personal/ajin.im:is:writing/archive/wrote"
 COMEDY_ROOT = REPO_ROOT / "is" / "writing" / "comedy"
 
 PILOT_POSTS = [

--- a/_scripts/build_essays.py
+++ b/_scripts/build_essays.py
@@ -11,7 +11,7 @@ import writes_common
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ESSAY_ROOT = REPO_ROOT / "is" / "writing" / "essays"
 SOURCE_ROOT = ESSAY_ROOT / "_src"
-EXPORT_ROOT = Path("/Users/ajin/Documents/New project/personal/ajin.im:is:writing/archive/essay")
+EXPORT_ROOT = Path.home() / "Documents/New project/personal/ajin.im:is:writing/archive/essay"
 WROTE_ROOT = REPO_ROOT / "wrote"
 WRITES_ROOT = REPO_ROOT / "writes"
 

--- a/_scripts/canary/com.ajin.canary-watcher.plist
+++ b/_scripts/canary/com.ajin.canary-watcher.plist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Documentation copy. Runtime lives at ~/.local/bin/ (see _scripts/canary/README.md).
+     LaunchAgent requires absolute paths; the /Users/ajin/... paths below are intentional. -->
 <plist version="1.0">
 <dict>
   <key>Label</key>


### PR DESCRIPTION
## Summary
- `BIRD-UNIVERSE-LINKING.md`: strip `/Users/ajin/Documents/.../mobetter20.github.io/` prefix from all paths; leaves them repo-relative throughout
- `build_comedy.py`, `build_comedy_pilot.py`, `build_essays.py`: `Path("/Users/ajin/...")` → `Path.home() / "..."` (semantically identical; archive dirs confirmed present)
- `canary/com.ajin.canary-watcher.plist`: add XML comment noting LaunchAgent requires absolute paths and this tracked copy is documentation (runtime lives at `~/.local/bin/`)

Tree hygiene only — git history retains the old paths regardless. No behavioral change: `Path.home()` resolves to the same absolute path on this machine and the archive directories exist.

## Test plan
- [ ] `Path.home() / "..."` confirmed to resolve to the same path as the old literal
- [ ] Both archive dirs (`archive/wrote`, `archive/essay`) confirmed present
- [ ] All three modified Python scripts pass `ast.parse()` syntax check
- [ ] Pre-push hook passes: bird-universe registry OK, link checks OK (1027 links, 0 broken)