### PR TITLE
building: world-metros atlas scaffold (docs, OSM audit, same-scale proof)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,3 +94,11 @@ for full details. Quick reference:
   with `generate_graph.py`). Character-name linting is intentionally
   deferred — single-token names like "Conrad" / "Dennis" collide with
   ordinary English.
+
+## World Metros Atlas (planning)
+
+A planned bespoke page at `/is/building/world-metros/` (no page exists yet).
+Before touching anything metro-related, read `_scripts/world_metros/README.md`
+— reading order, product contract, data contract, and the decision log live
+there. Open forks need owner ratification before frontend work starts (see
+`_scripts/world_metros/STATUS.md`).

--- a/_scripts/world_metros/BUILD-SPEC.md
+++ b/_scripts/world_metros/BUILD-SPEC.md
@@ -1,0 +1,76 @@
+# BUILD-SPEC — World Metros Atlas (v1, trimmed)
+
+This is the product/acceptance contract. It descends from the Codex plan of 2026-06-11
+("World Metros Interactive Atlas") with deliberate trims recorded in DECISIONS.md (D2, D5–D7).
+The original user brief is the fixed judge: *"fill my curiosity about interesting metro
+systems in an easy-to-get view — not a complicated site with info scattered around."*
+
+## North-Star (draft — owner to ratify)
+
+A fast visual atlas for exploring the world's defining metro systems: compare their
+physical forms at a true shared scale, see why each one is interesting, and rank them
+only where a ranking can be honestly defined — without pretending there is one
+objective best.
+
+## Views (one URL, four tabs)
+
+1. **Explore** — one city at a time: interactive pan/zoom map drawn from OSM geometry
+   (real line colours), plus a compact profile card:
+   opened year · reported route-km (dated) · stations · lines · reported annual
+   ridership (dated) · 2–3 curated "why it's interesting" facts.
+2. **Compare / Shape** — the signature view. All systems at one north-up
+   pixels-per-kilometre scale. Pair mode with synchronized zoom; overlay translates
+   network centres only (never rotates/resizes/warps); inline note that geography is
+   not aligned.
+3. **Rankings** — the five computed lenses (defined in DATA-CONTRACT.md), each with a
+   one-paragraph "why this is rankable" explanation, **plus** a clearly-labelled
+   "reported figures" almanac table (route-km, annual ridership) shown as dated,
+   sourced facts — labelled by source basis, never blended with computed lenses.
+4. **Method** — scope rules, definitions, sources, data as-of dates, licences, and a
+   short **"why not X"** section (Beijing, Madrid, Istanbul, …) — absence is content.
+
+## Explicitly OUT of v1 (do not let these creep back without a DECISIONS entry)
+
+- The practical-traveller layer: fares / "first ride" / payment / open-loop gates /
+  registration / planner languages / disruption info / integration matrices /
+  accessibility evidence / cleanliness evidence. (D2: it's the crowded travel-utility
+  space, and it drives a freshness treadmill a curiosity site doesn't owe.)
+- Freshness SLA machinery (30/90/180-day tiers, auto-eviction from Compare).
+  Replacement: every fact carries `source + as_of`; refresh is a scripted annual pass.
+- Route planning, live positions, street basemap, official schematic reproduction.
+- Aggregate scores of any kind. No "best metro" number.
+
+## Design direction
+
+**Electric Cartography** (working name, from the Codex session; pending the mock gate):
+luminous network geometry on near-black, hard contrast, restrained glow on active
+routes/focus states only. Palette: void `#070A14`, dark tyrian `#12354E`, cerulean
+`#0093A5`, english red `#D96629`, yellow-orange `#F99D1B`, pink `#FFB3F0`, warm text
+`#F2EAD8`. Network lines keep their real (OSM `stroke`) colours; the palette is chrome.
+Bespoke tier: carries its own art; wears only the anchors (a way home, palette
+sympathy, DM Mono if labels appear). No title device.
+
+## Approval gates (in order)
+
+1. **Mock boards** — desktop Explore, desktop Compare/Shape (pair), mobile Explore,
+   built with real Seoul+Paris geometry. Owner approval recorded in DECISIONS.md.
+2. **Coded prototype** — Seoul Explore + Seoul/Paris Shape pair. Second approval.
+3. Scale to the full roster only after both.
+
+## Soft-launch conditions (repo norm, chronogrid precedent)
+
+`noindex` meta · not in sitemap · no `/is/building` hub card · no home-teaser line.
+Site-wide `/analytics.js` loads as on every page (do not fight the site default).
+
+## Acceptance checklist (v1)
+
+- Verified at 375 / 768 / 1280 widths (repo CSS rule); keyboard reachable tabs +
+  city switcher; `prefers-reduced-motion` respected (no glow pulse).
+- Per-city geometry lazy-loaded; initial payload stays light (overview index +
+  first city only). Raw OSM GeoJSON is simplified at build time, never shipped raw.
+- ODbL attribution line for OSM data visible on every view; no official schematic
+  imagery anywhere; UITP linked as background reading only, figures not republished.
+- Every displayed fact resolves to `source + as_of` (visible on Method, hover or
+  footnote elsewhere).
+- Build is a deterministic `_scripts/world_metros/build_*.py` run over committed,
+  dated data snapshots (network access only in the refresh step, never the build).

--- a/_scripts/world_metros/DATA-CONTRACT.md
+++ b/_scripts/world_metros/DATA-CONTRACT.md
@@ -1,0 +1,88 @@
+# DATA-CONTRACT — World Metros Atlas
+
+## Geometry source of truth (verified 2026-06-11)
+
+**OSM via the subway preprocessor/validator CDN** — per-city GeoJSON, regenerated
+~hourly from OSM `route=subway` relations:
+
+- Index: `https://cdn.organicmaps.app/subway/` (321/325 networks validating clean)
+- Per city: `https://cdn.organicmaps.app/subway/<slug>.geojson` (also `.yaml` with richer
+  station/transfer detail)
+- Format: `FeatureCollection` of `LineString` (props: `ref`, `name`, `stroke` = line
+  colour) + `Point` stations. Drawable as-is.
+- Pipeline: github.com/organicmaps/subways (Apache-2.0). Data: **ODbL** — attribution
+  required ("© OpenStreetMap contributors, ODbL"); a derivative database must stay open.
+
+Audit results, all candidates **GOOD** (raw GeoJSON size; build will simplify):
+
+| city | slug | raw size |
+|---|---|---|
+| Shanghai | `shanghai` | 813 KB |
+| Tokyo | `tokyo` | 925 KB |
+| Seoul | `seoul` | 3.45 MB (capital-region net incl. through-running — see scope) |
+| Singapore | `singapore` | 333 KB |
+| Delhi | `delhi` | 330 KB |
+| London | `london` | 2.65 MB |
+| Paris | `paris` | 451 KB |
+| New York | `new_york_city` | 1.58 MB (PATH/SIR/JFK are separate networks — pre-split for us) |
+| Mexico City | `mexico_city` | 269 KB |
+| Cairo | `cairo` | 176 KB |
+| Moscow | `moscow` | 1.13 MB (proposed add, D3) |
+| Hong Kong | `hong_kong` | 1.05 MB (proposed add, D3) |
+| Beijing | `beijing` | 688 KB (proposed "why not" entry, D3) |
+
+Re-verify any time: `python3 _scripts/world_metros/audit_osm_sources.py`.
+
+## Refresh / freeze discipline
+
+`refresh` (future script) fetches dated snapshots into a committed `data/` dir with
+timestamps + checksums; `build` runs offline and deterministically over snapshots.
+Facts carry `value · unit · source · as_of`. Missing evidence renders **Unknown**,
+never "No" or zero. No SLA tiers (D6) — annual scripted refresh.
+
+## System scopes (freeze before extraction; each gets a Method entry)
+
+- Shanghai Metro — exclude maglev.
+- Tokyo — Tokyo Metro + Toei only; truncate through-running at scope boundary.
+- Seoul — **OPEN QUESTION (the hard one):** OSM network spans ~148 km north–south;
+  `ref=1` alone carries ~26 Korail through-service variants (Cheonan/Incheon/Soyosan).
+  "Lines 1–9 at marketed extents" (Codex) would still include ~200 km of Korail
+  corridor. Candidate rule: lines 1–9 truncated to Seoul-Metro-operated sections;
+  decide at pipeline stage with data in hand, record in DECISIONS.
+- Singapore MRT — exclude LRT.
+- Delhi Metro — as is.
+- London Underground — exclude Elizabeth line.
+- Paris Métro — 1–14 + 3bis/7bis; exclude RER. (Note: stray `LISA` ref and one outlier
+  segment in raw data — build-step QA filters by known refs + bbox sanity.)
+- NYC Subway — `new_york_city` network only (PATH, Staten Island, JFK already separate).
+- Mexico City Metro — as is.
+- Cairo Metro — exclude LRT + monorail.
+- Moscow Metro — exclude Central Circle (MCC) + Diameters (MCD) if added.
+- Hong Kong MTR — exclude light rail + Airport Express? (freeze before extraction).
+
+Route variants: many service patterns share a `ref` (Seoul L1: 26). For Shape
+rendering, union segments per ref. For counted lenses, count **customer-facing line
+identities**, not variants.
+
+## The five computed ranking lenses (from frozen snapshots; definitions are the product)
+
+1. **Furthest-stations span** — max geodesic distance between two station complexes.
+2. **Station complexes** — official identities; interchanges counted once.
+3. **Customer-facing lines** — primary-map identities, excluding service variants.
+4. **Interchange share** — complexes served by ≥2 counted lines ÷ all complexes.
+5. **Opening chronology** — earliest regular passenger service within declared scope.
+
+Anything whose definition can't be resolved cleanly becomes `profile_only` and leaves
+Rankings. Reported route-km and annual ridership are **profile facts** (dated, sourced,
+shown in the almanac table) — never computed lenses (D5).
+
+## Licensing exclusions (hard rules, verified in deep research 2026-06-11)
+
+- **No official schematic maps** — TfL enforces copyright via an exclusive licensing
+  partner; generalize the posture to all operators. We render our own geometry.
+- **No Transit Explorer data** — public-website use is explicitly commercial;
+  redistribution forbidden at any tier.
+- **No UITP republication** — link as background research only.
+- Stats sources: operator reports + live-checked Wikipedia (cite revision date).
+  Note: a prior research pass's scraped Wikipedia figures failed adversarial
+  verification — always re-pull from the live table, never reuse cached numbers.

--- a/_scripts/world_metros/DECISIONS.md
+++ b/_scripts/world_metros/DECISIONS.md
@@ -1,0 +1,71 @@
+# DECISIONS — World Metros Atlas (append-only, dated)
+
+Status legend: **RATIFIED** (owner said yes) · **PROPOSED** (agent recommendation,
+owner ratification pending) · **STANDING** (inherited from repo/global rules).
+
+## 2026-06-11
+
+**D0 · Project origin — RATIFIED (implicitly, by continuation).**
+Idea: Ajin, 2026-06-11 ("interactive maps + basic info of the world's top metro
+systems in one easy view, only if nothing good exists"). Claude deep-research run
+(102 agents, 20 sources, 23/25 claims verified) found the niche open: closest
+competitors Metro Bits (curiosity DNA, but sprawling, no interactive maps),
+metrolinemap.com (per-city utility, no rankings/comparison), Transit Explorer
+(exhaustive research DB, licensing excludes reuse). Codex then produced the
+"World Metros Interactive Atlas" plan (in-session only; **no files/commits ever
+landed on disk** — verified by repo/branch/filesystem sweep 2026-06-11). That plan
+is the structural reference for this doc set.
+
+**D1 · Codex plan adopted as reference, not contract — PROPOSED.**
+Keep: one-URL four-view shape, same-scale Compare invariants, five computed ranking
+lenses, scope-freeze discipline, licensing posture, approval gates, soft-launch norms.
+Trim: see D2, D5–D7. Judge for all trims: the original brief — a *simple* curiosity
+site, not a transit-data product.
+
+**D2 · Kill the practical-traveller layer for v1 — PROPOSED.**
+"First ride" / "Using It" / integration matrices / accessibility & cleanliness
+evidence are out. Why: (a) it's the crowded travel-utility space the deep-research
+explicitly said not to compete in; (b) fares/payment facts drive the 30/90/180-day
+freshness treadmill — permanent maintenance for a curiosity site; (c) it was ~4 of the
+5 sections of the Codex information model, i.e. most of the project's weight, serving
+a user need nobody stated. Replacement: a compact profile card (opened · km · stations
+· lines · ridership · 2–3 curated facts), all dated + sourced.
+
+**D3 · Roster: 12 systems = Codex 10 + Moscow + Hong Kong — PROPOSED (owner call).**
+Codex 10: Shanghai, Tokyo, Seoul, Singapore, Delhi, London, Paris, NYC, Mexico City,
+Cairo. Add Moscow (palace stations, Soviet metro tradition, top-3 busiest — its absence
+is the most glaring gap a curious reader would hit) and Hong Kong (the
+efficiency/farebox benchmark, Octopus). Keep Beijing OUT (Shanghai covers the
+China-mega category) but give it a "why not" entry on Method. 12 over 10 because the
+per-city marginal cost is low (uniform data source, all validate GOOD) and it frees the
+site from false top-10 precision. Alternatives if owner insists on 10: drop Cairo
+(loses the only Africa rep) or Singapore (HK overlaps its category).
+
+**D4 · Geometry source: OSM via subway-validator CDN — RATIFIED (verified, standing).**
+All 13 candidate cities validate GOOD on `cdn.organicmaps.app/subway/` (checked
+2026-06-11); per-city GeoJSON is drawable as-is with real line colours. ODbL
+attribution required. End-to-end proof render (Seoul 2–9 vs Paris, one shared scale)
+succeeded same day — see `proof_same_scale.py`.
+
+**D5 · Reported length/ridership: shown and rankable as a labelled almanac table —
+PROPOSED (amends Codex).** Codex banned ranking reported figures outright; but "most
+extensive" is literally what the owner asked for. Resolution: the five computed lenses
+stay the only *computed* rankings; reported route-km + annual ridership appear in a
+clearly-labelled "reported figures, as-of dates vary by source" table. Honest and
+useful beats pure.
+
+**D6 · Process trims — PROPOSED.** No Makefile (repo grain is `_scripts/*/ *.py` +
+untracked `publish.sh`); no 3-browser Playwright matrix (repo norm: verify at
+375/768/1280 + manual pass); no field-level `evidence_status` enum (every fact carries
+`source + as_of`; missing renders Unknown); no freshness SLA tiers (annual scripted
+refresh).
+
+**D7 · Design: "Electric Cartography" as working direction — PROPOSED (pending mock
+gate).** Palette + luminous-geometry character per the Codex session (its "approved"
+status lives only in that session; re-confirm at the mock-board gate). Bespoke tier:
+own art, anchors only (way home, palette sympathy, DM Mono labels). Network lines keep
+real OSM colours.
+
+**D8 · Gates before any frontend — STANDING.** Mock boards (real Seoul+Paris data) →
+owner approval → Seoul/Paris coded prototype → second approval → scale to roster.
+Matches the repo's draft-review-before-publish norm.

--- a/_scripts/world_metros/README.md
+++ b/_scripts/world_metros/README.md
@@ -1,0 +1,32 @@
+# World Metros Atlas — dev docs + tooling
+
+A one-URL interactive atlas of ~10–12 category-defining metro systems, eventually at
+`/is/building/world-metros/` (bespoke tier). Signature device: every network drawn from
+real OSM geometry at **one shared scale**, north-up, so physical forms compare honestly.
+
+Nothing here is live yet. No page exists under `is/building/world-metros/` yet.
+
+## Reading order (mandatory for any agent picking this up)
+
+1. [STATUS.md](STATUS.md) — what's done, the current gate, the next exact action.
+2. [BUILD-SPEC.md](BUILD-SPEC.md) — the product contract (views, invariants, acceptance).
+3. [DATA-CONTRACT.md](DATA-CONTRACT.md) — system scopes, data source, schema, ranking definitions, licences.
+4. [DECISIONS.md](DECISIONS.md) — append-only dated decision log. PROPOSED entries need owner (Ajin) ratification.
+
+Source of truth is these files plus git history — never a Claude/Codex session memory.
+The project registry stanza lives in `~/projects.md` (`world-metros-atlas`).
+
+## Commands
+
+```sh
+python3 _scripts/world_metros/audit_osm_sources.py    # re-verify validator status + sizes for candidate cities
+python3 _scripts/world_metros/proof_same_scale.py     # regenerate the same-scale proof SVG (writes to /tmp)
+```
+
+Both are stdlib-only (urllib + json), no venv needed.
+
+## Provenance
+
+Files in this directory are hand-maintained dev docs/tools — no generator writes here.
+The future page build will follow repo convention: a `_scripts/world_metros/build_*.py`
+generator, registered in the local `publish.sh` (untracked, main checkout only).

--- a/_scripts/world_metros/STATUS.md
+++ b/_scripts/world_metros/STATUS.md
@@ -1,0 +1,35 @@
+# STATUS — World Metros Atlas
+
+_Last updated: 2026-06-11 (Claude session, branch `claude/world-metros-scaffold`)._
+
+## Done
+
+- Deep research (2026-06-11): niche verified open; data/licensing landscape mapped.
+- Codex plan received (in-session only — produced **no files/commits**; verified).
+- Critical assessment of the plan → trimmed v1 contract (BUILD-SPEC.md, D1–D7).
+- Data audit: all 13 candidate cities GOOD on the OSM subway validator; per-city
+  GeoJSON confirmed drawable (real line colours); sizes recorded (DATA-CONTRACT.md).
+- End-to-end proof: same-scale Seoul (lines 2–9) vs Paris SVG render from raw CDN
+  GeoJSON (`proof_same_scale.py`). Seoul's through-running scope problem quantified
+  (~148 km bbox; L1 = 26 service variants).
+- This doc set + registry stanza (`world-metros-atlas` in `~/projects.md`).
+
+## Current gate — owner (Ajin) ratification of three forks
+
+1. **Scope trim (D2, D5, D6):** kill the practical-traveller layer; almanac table for
+   reported figures; lighter process. → recommendation: yes.
+2. **Roster (D3):** 12 = Codex 10 + Moscow + Hong Kong, Beijing as "why not" entry.
+   → recommendation: yes; owner may prefer strict 10.
+3. **Design (D7):** proceed to mock boards in Electric Cartography. → recommendation: yes.
+
+## Next exact action (after ratification)
+
+Build the three mock approval boards with **real Seoul + Paris geometry** in the
+Electric Cartography direction: desktop Explore, desktop Compare/Shape (pair),
+mobile Explore (375px). Static HTML/SVG, no frontend framework yet. Stop for
+approval; record the verdict in DECISIONS.md.
+
+## Blockers
+
+None. (Seoul L1 scope rule is deliberately deferred to the pipeline stage,
+DATA-CONTRACT.md — it does not block the mock boards.)

--- a/_scripts/world_metros/audit_osm_sources.py
+++ b/_scripts/world_metros/audit_osm_sources.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Audit the OSM subway-validator CDN for World Metros Atlas candidate cities.
+
+For every candidate: is the network validating GOOD on the subway preprocessor
+(cdn.organicmaps.app/subway/), and how big is its raw GeoJSON? Re-run any time;
+network access only, writes nothing. See DATA-CONTRACT.md for what this feeds.
+"""
+
+import re
+import sys
+import urllib.request
+
+CDN = "https://cdn.organicmaps.app/subway/"
+
+# city slug -> validator country page
+CITIES = {
+    "shanghai": "china.html",
+    "beijing": "china.html",
+    "hong_kong": "china.html",
+    "tokyo": "japan.html",
+    "seoul": "south-korea.html",
+    "singapore": "singapore.html",
+    "delhi": "india.html",
+    "london": "uk.html",
+    "paris": "france.html",
+    "new_york_city": "usa.html",
+    "mexico_city": "mexico.html",
+    "moscow": "russia.html",
+    "cairo": "egypt.html",
+}
+
+ROW_RE = re.compile(r'<tr id="([^"]+)">\s*<td class="bold (color\d)">')
+
+
+def fetch(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "world-metros-atlas-audit"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read()
+
+
+def main() -> int:
+    pages = {}
+    failures = 0
+    for slug, page in CITIES.items():
+        if page not in pages:
+            try:
+                pages[page] = fetch(CDN + page).decode("utf-8", "replace")
+            except OSError as e:
+                print(f"FETCH FAIL {page}: {e}")
+                pages[page] = ""
+        statuses = dict(ROW_RE.findall(pages[page]))
+        color = statuses.get(slug)
+        status = {"color1": "GOOD", "color0": "ERRORS"}.get(color, "NOT FOUND")
+        size = "?"
+        try:
+            req = urllib.request.Request(
+                f"{CDN}{slug}.geojson", method="HEAD",
+                headers={"User-Agent": "world-metros-atlas-audit"})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                size = f"{int(resp.headers.get('Content-Length', 0)) / 1024:.0f} KB"
+        except OSError:
+            status = status + " (geojson HEAD failed)"
+        if status != "GOOD":
+            failures += 1
+        print(f"{slug:16s} {status:10s} {size:>9s}  ({page})")
+    print(f"\n{len(CITIES) - failures}/{len(CITIES)} candidates GOOD")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/_scripts/world_metros/proof_same_scale.py
+++ b/_scripts/world_metros/proof_same_scale.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Proof-of-pipeline: render two metro networks at one shared scale (SVG).
+
+Fetches raw per-city GeoJSON from the OSM subway-validator CDN, projects it
+(equirectangular, km units, north-up), and draws both networks side by side at a
+single pixels-per-km scale with their real OSM line colours. This is the data
+proof behind Compare/Shape — NOT a design mock. Output goes to /tmp (binaries and
+generated art stay out of git).
+
+Usage: python3 _scripts/world_metros/proof_same_scale.py
+"""
+
+import json
+import math
+import urllib.request
+
+CDN = "https://cdn.organicmaps.app/subway/"
+OUT = "/tmp/world-metros-proof.svg"
+PX_PER_KM = 14
+PAD = 40
+
+# (title, slug, refs to draw — None = all). Seoul L1 excluded pending scope rule
+# (DATA-CONTRACT.md): its OSM network carries ~26 Korail through-running variants.
+PANELS = [
+    ("SEOUL · lines 2–9 (L1 scope TBD)", "seoul", {str(i) for i in range(2, 10)}),
+    ("PARIS · Métro 1–14", "paris",
+     {"1", "2", "3", "3bis", "4", "5", "6", "7", "7bis", "8", "9", "10", "11", "12", "13", "14"}),
+]
+
+
+def load_city(slug, ref_filter):
+    req = urllib.request.Request(f"{CDN}{slug}.geojson",
+                                 headers={"User-Agent": "world-metros-atlas-proof"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        gj = json.load(resp)
+    segs = []
+    for f in gj["features"]:
+        if f["geometry"]["type"] != "LineString":
+            continue
+        p = f["properties"]
+        if ref_filter and p.get("ref") not in ref_filter:
+            continue
+        segs.append((p.get("stroke", "#888"), f["geometry"]["coordinates"]))
+    return segs
+
+
+def project(segs):
+    """Equirectangular into km, y flipped so north is up."""
+    n = sum(len(cs) for _, cs in segs)
+    lat0 = sum(c[1] for _, cs in segs for c in cs) / n
+    k = math.cos(math.radians(lat0))
+    return [(color, [(c[0] * 111.32 * k, -c[1] * 110.57) for c in cs])
+            for color, cs in segs]
+
+
+def bbox(segs):
+    xs = [p[0] for _, cs in segs for p in cs]
+    ys = [p[1] for _, cs in segs for p in cs]
+    return min(xs), min(ys), max(xs), max(ys)
+
+
+def main():
+    cells, offx, maxh = [], PAD, 0.0
+    for title, slug, refs in PANELS:
+        segs = project(load_city(slug, refs))
+        x0, y0, x1, y1 = bbox(segs)
+        w, h = (x1 - x0) * PX_PER_KM, (y1 - y0) * PX_PER_KM
+        cells.append((title, segs, offx, x0, y0, h))
+        offx += w + PAD * 2
+        maxh = max(maxh, h)
+
+    W, H = offx, maxh + PAD * 2 + 30
+    svg = [f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W:.0f} {H:.0f}"'
+           f' font-family="monospace">',
+           f'<rect width="{W:.0f}" height="{H:.0f}" fill="#070A14"/>']
+    for title, segs, ox, x0, y0, h in cells:
+        oy = PAD + (maxh - h) / 2 + 20
+        svg.append(f'<text x="{ox:.0f}" y="{PAD - 10}" fill="#F2EAD8" font-size="15">{title}</text>')
+        for color, cs in segs:
+            pts = " ".join(f"{ox + (x - x0) * PX_PER_KM:.1f},{oy + (y - y0) * PX_PER_KM:.1f}"
+                           for x, y in cs)
+            svg.append(f'<polyline points="{pts}" fill="none" stroke="{color}"'
+                       f' stroke-width="2.2" stroke-linecap="round" opacity="0.92"/>')
+    sb = 10 * PX_PER_KM
+    svg.append(f'<line x1="{PAD}" y1="{H - 18:.0f}" x2="{PAD + sb}" y2="{H - 18:.0f}"'
+               f' stroke="#F2EAD8" stroke-width="2"/>')
+    svg.append(f'<text x="{PAD + sb + 8}" y="{H - 13:.0f}" fill="#F2EAD8" font-size="13">'
+               f'10 km · one shared scale · north-up · OSM (ODbL)</text>')
+    svg.append("</svg>")
+    with open(OUT, "w") as fh:
+        fh.write("\n".join(svg))
+    print(f"wrote {OUT} ({W:.0f}x{H:.0f})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Scaffolding for the **World Metros Atlas** (planned bespoke page at `/is/building/world-metros/` — no page exists yet, nothing live or listed):

- `_scripts/world_metros/` doc set: README (reading order), BUILD-SPEC (trimmed v1 contract), DATA-CONTRACT (scopes, source, ranking definitions, licences), DECISIONS (D0–D8, with PROPOSED markers pending owner ratification), STATUS (gate + next action)
- `audit_osm_sources.py` — reproducible check of the OSM subway-validator CDN: **13/13 candidate cities GOOD** (verified 2026-06-11)
- `proof_same_scale.py` — end-to-end pipeline proof: same-scale Seoul vs Paris SVG from raw CDN GeoJSON
- CLAUDE.md pointer section so parallel sessions find the doc set

## Context

Continues the Codex "World Metros Interactive Atlas" plan (in-session only; it landed no files — verified). Claude assessed the plan and trimmed it: travel-utility layer killed for v1, reported figures shown as a dated almanac table, repo-native scripts over Makefile. Open forks (roster, trim ratification, design direction) are recorded in STATUS.md and gate any frontend work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)