### PR TITLE
building: world-metros D19 dark ground fork board + card-era BUILD-SPEC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,10 +95,11 @@ for full details. Quick reference:
   deferred — single-token names like "Conrad" / "Dennis" collide with
   ordinary English.
 
-## World Metros Atlas (planning)
+## Metro Cards (was: World Metros Atlas)
 
-A planned bespoke page at `/is/building/world-metros/` (no page exists yet).
-Before touching anything metro-related, read `_scripts/world_metros/README.md`
-— reading order, product contract, data contract, and the decision log live
-there. Open forks need owner ratification before frontend work starts (see
-`_scripts/world_metros/STATUS.md`).
+A bespoke build at `/is/building/world-metros/` (soft-launched, noindex; the
+atlas-era prototype is live and gets rebuilt as a card deck per DECISIONS
+D17–D19). Before touching anything metro-related, read
+`_scripts/world_metros/README.md` — reading order, product contract, data
+contract, and the decision log live there. Open forks need owner ratification
+before frontend work starts (see `_scripts/world_metros/STATUS.md`).

--- a/_scripts/world_metros/BUILD-SPEC.md
+++ b/_scripts/world_metros/BUILD-SPEC.md
@@ -1,79 +1,106 @@
-# BUILD-SPEC — World Metros Atlas (v1, trimmed)
+# BUILD-SPEC — Metro Cards (working name "metro match"; v2 contract, supersedes the atlas)
 
-This is the product/acceptance contract. It descends from the Codex plan of 2026-06-11
-("World Metros Interactive Atlas") with deliberate trims recorded in DECISIONS.md (D2, D5–D7).
-The original user brief is the fixed judge: *"fill my curiosity about interesting metro
-systems in an easy-to-get view — not a complicated site with info scattered around."*
+This is the product/acceptance contract for the D17 card pivot, written after
+the premise gate passed (D19: owner "i like it" on the D18 v2 board). The v1
+atlas contract lives in this file's git history; its data discipline carries
+over unchanged. The original user brief stays the fixed judge, reweighted by
+the owner at D16: *fun and engaging comparison of interesting metro systems,
+in an easy-to-get view*. The four map-hero rounds (D10–D15) established what
+this site will NOT be: a cartography product.
 
-## North-Star (draft — owner to ratify)
+## North-Star (D17, ratified; name pending)
 
-A fast visual atlas for exploring the world's defining metro systems: compare their
-physical forms at a true shared scale, see why each one is interesting, and rank them
-only where a ranking can be honestly defined — without pretending there is one
-objective best.
+A collectible card deck for the world's defining metro systems. Every city is
+one designed stat card; honest dated data is the content; comparison is the
+game. Trading cards with footnotes.
 
-## Views (one URL, four tabs)
+## Surfaces (one URL)
 
-1. **Explore** — one city at a time: interactive pan/zoom map drawn from OSM geometry
-   (real line colours), plus a compact profile card:
-   opened year · reported route-km (dated) · stations · lines · reported annual
-   ridership (dated) · 2–3 curated "why it's interesting" facts.
-2. **Compare / Shape** — the signature view. All systems at one north-up
-   pixels-per-kilometre scale. Pair mode with synchronized zoom; overlay translates
-   network centres only (never rotates/resizes/warps); inline note that geography is
-   not aligned.
-3. **Rankings** — the five computed lenses (defined in DATA-CONTRACT.md), each with a
-   one-paragraph "why this is rankable" explanation, **plus** a clearly-labelled
-   "reported figures" almanac table (route-km, annual ridership) shown as dated,
-   sourced facts — labelled by source basis, never blended with computed lenses.
-4. **Method** — scope rules, definitions, sources, data as-of dates, licences, and a
-   short **"why not X"** section (Beijing, Madrid, Istanbul, …) — absence is content.
+1. **THE DECK** — the landing: all 12 cards (D3 roster), collection grid.
+   Cards flip: **front for play, back for lore** (D18).
+2. **THE BATTLE** — vs cpu, Top-Trumps loop: see your card, pick a stat, beat
+   the hidden opponent card; first to 3. Stable per-pair URLs survive from
+   D16's duel mechanics.
+3. **THE DAILY** — one guess a day ("which plots more stations?"), streak in
+   localStorage. Consciously un-defers D16's reveal-on-tap guessing.
+4. **METHOD** — scope rules, definitions, sources, as-of dates, licences, win
+   directions, and the "why not X" section (Beijing, …). Absence is content.
+   Unchanged role from the atlas contract.
 
-## Explicitly OUT of v1 (do not let these creep back without a DECISIONS entry)
+## Card grammar (D18, ratified)
 
-- The practical-traveller layer: fares / "first ride" / payment / open-loop gates /
-  registration / planner languages / disruption info / integration matrices /
-  accessibility evidence / cleanliness evidence. (D2: it's the crowded travel-utility
-  space, and it drives a freshness treadmill a curiosity site doesn't owe.)
-- Freshness SLA machinery (30/90/180-day tiers, auto-eviction from Compare).
-  Replacement: every fact carries `source + as_of`; refresh is a scripted annual pass.
-- Route planning, live positions, street basemap, official schematic reproduction.
-- Aggregate scores of any kind. No "best metro" number.
+- **Front (play side):** city name + epithet (the sprawl / the mesh / the two
+  crews / …), deck number `NN/12` in roster order, line pills carrying the
+  real refs in the operators' colours (the identity device, rendered purely
+  from OSM data), six stat rows — each with a deck-rank chip (1ST filled,
+  others hollow) and a normalized strength track — and a provenance footnote
+  naming the snapshot and the rank basis. NO map on the front.
+- **Back (lore side):** the city's familiar Commons diagram full-bleed
+  (DIAGRAM-LEDGER file, attribution verbatim, currency caveats where the
+  ledger flags them), name band, one flavor line. The D11 "map riders see"
+  obligation lives here.
+- **Deck back:** uniform pinstripes of every line colour in the deck under
+  the wordmark band; serves as the opponent's hidden card in the battle.
+- **Ground:** dark (D19; exact treatment per the D19 board pick).
+- **Trade dress:** our own card idiom in the official-map language (DM Mono
+  data labels, hairline rules, transit-blue accent). No Pokémon / Top Trumps
+  trade dress. No official map artwork anywhere.
 
-## Design direction
+## Stats (the six rows; definitions are the product)
 
-**Official-map idiom** (owner-directed 2026-06-11, supersedes Electric Cartography
-— see DECISIONS D10): white paper ground, the operators' real line colours (OSM
-`stroke`), bold solid strokes, white-fill/ink-ring station dots; selecting a line
-greys the rest of the network (the metro-app convention). Chrome: clean sans for
-UI, DM Mono for data/provenance labels, transit-blue accent `#0052a4`, city chips
-as pills, active tab underlined like a route line. The site dresses like the
-artifact it describes. Official map ARTWORK is never embedded (licensing,
-DATA-CONTRACT.md); every city card carries **"the map riders see →"** linking to
-the operator's official diagram, and Method tells the licensing story. Bespoke
-tier: own art, anchors only (way home, palette sympathy, DM Mono labels).
+| stat | basis | wins |
+|---|---|---|
+| opened | earliest regular passenger service within declared scope (operator histories, dated) | earlier |
+| lines | customer-facing line identities, not service variants (DATA-CONTRACT) | more |
+| stations | station complexes plotted from the frozen snapshot | more |
+| span | furthest-stations geodesic distance, computed | more |
+| route-km | reported, dated, sourced (almanac grade) | more |
+| ridership | reported annual, dated, sourced (almanac grade) | more |
+
+Ranks and track positions are computed across the full deck of 12 at pipeline
+stage (the mocks footnote "live deck of 3" until then); win directions are
+fixed above and explained on Method. Interchange share remains a candidate
+seventh stat if the pipeline resolves it cleanly per the lens definition.
+Missing evidence renders **Unknown** and excludes that stat from battles for
+that card; never shown as zero.
+
+## Explicitly OUT (do not creep back without a DECISIONS entry)
+
+- The practical-traveller layer (D2) — unchanged.
+- **Aggregate scores.** Rank chips are per-stat; no card carries an overall
+  power number, no "best metro".
+- Brackets / tournaments (rejected at D16; n=12).
+- Accounts, multiplayer, backend anything. Static site; the streak is
+  localStorage.
+- Official schematic artwork (licensing posture unchanged, DATA-CONTRACT.md)
+  and the maps-as-hero IA (D10–D15, judged and closed).
 
 ## Approval gates (in order)
 
-1. **Mock boards** — desktop Explore, desktop Compare/Shape (pair), mobile Explore,
-   built with real Seoul+Paris geometry. Owner approval recorded in DECISIONS.md.
-2. **Coded prototype** — Seoul Explore + Seoul/Paris Shape pair. Second approval.
-3. Scale to the full roster only after both.
+1. **D19 ground pick** (A / B / C board) — settles the visual ground.
+2. **Live-page rebuild** of `/is/building/world-metros/` as DECK + BATTLE +
+   DAILY + METHOD with the three live cities real, nine cards "soon". Owner
+   verdict on the live page.
+3. **Roster scale-up** to all 12 (D3) with frozen scope rules (Seoul L1 is
+   the hard one), per-line opened-year sourcing, full-deck ranks, lore backs
+   per DIAGRAM-LEDGER. Naming settled by the owner before this ships wide.
 
-## Soft-launch conditions (repo norm, chronogrid precedent)
+## Soft-launch conditions (repo norm, unchanged)
 
-`noindex` meta · not in sitemap · no `/is/building` hub card · no home-teaser line.
-Site-wide `/analytics.js` loads as on every page (do not fight the site default).
+`noindex` meta · not in sitemap · no `/is/building` hub card · no home-teaser
+line · site-wide `/analytics.js` loads as on every page. Lifting any of these
+is an owner call after gate 3.
 
-## Acceptance checklist (v1)
+## Acceptance checklist
 
-- Verified at 375 / 768 / 1280 widths (repo CSS rule); keyboard reachable tabs +
-  city switcher; `prefers-reduced-motion` respected (no glow pulse).
-- Per-city geometry lazy-loaded; initial payload stays light (overview index +
-  first city only). Raw OSM GeoJSON is simplified at build time, never shipped raw.
-- ODbL attribution line for OSM data visible on every view; no official schematic
-  imagery anywhere; UITP linked as background reading only, figures not republished.
-- Every displayed fact resolves to `source + as_of` (visible on Method, hover or
-  footnote elsewhere).
-- Build is a deterministic `_scripts/world_metros/build_*.py` run over committed,
-  dated data snapshots (network access only in the refresh step, never the build).
+- Verified at 375 / 768 / 1280 (repo CSS rule); battle and daily fully
+  keyboard-playable; `prefers-reduced-motion` respected (card flips degrade
+  to instant swaps).
+- Per-card lore-back diagrams lazy-load (they are the heavy assets); the deck
+  grid ships light. Raw OSM GeoJSON never ships.
+- ODbL attribution visible on every surface; per-diagram credit rendered with
+  the lore back, verbatim from DIAGRAM-LEDGER.
+- Every displayed stat resolves to `source + as_of` (Method shows the table;
+  card footnotes name snapshot + rank basis).
+- Build stays a deterministic `_scripts/world_metros/build_*.py` run over
+  committed dated snapshots (network only in the refresh step).

--- a/_scripts/world_metros/DECISIONS.md
+++ b/_scripts/world_metros/DECISIONS.md
@@ -328,3 +328,30 @@ atlas in miniature). Round 2 designs from the game outward:
 - Gate artifact: `mocks/card-game-board.html` (three v2 fronts, the flip
   exhibit front/back/deck-back, the battle restaged on v2, daily strip
   kept). Round-1 board stays in mocks/ for the record.
+
+**D19 · Premise PASSED; dark ground — RATIFIED 2026-06-12 (owner verdict on
+the D18 v2 board: "i like it", with one directed amendment: a black or other
+dark background might be better; ground treatment fork pending at the D19
+board).**
+The D17 premise kill test is passed: the archive branch is dead, and the
+commissioned follow-through lands with this entry (BUILD-SPEC.md rewritten
+around the D17 North-Star + D18 card grammar; README first paragraph
+updated). The amendment opens one visual fork, deliberately built as an
+exhibit rather than argued in prose ("background" can mean the card face or
+the table it sits on):
+- **A · round-2 reference:** white card on the light ground (as approved).
+- **B · white card, dark table:** cards stay paper-white objects; the page
+  ground goes near-black. The physical-cards-on-a-table read.
+- **C · dark card, dark table (recommendation):** the card face itself goes
+  ink-dark; the operators' line colours and the rank chips do the lighting.
+  The premium game-card read, and the strongest setting for the pills.
+Palette stays in the board's own ink family (cool near-black, not the
+site's warm house dark): ground `#0f0f12`, card `#1b1b21`, hairlines
+`#2e2e36`, light text `#f2f2ee`, transit-blue fills unchanged, light-blue
+text accents on dark. Official-map idiom elements carry over (DM Mono data
+labels, hairline rules, real line colours); D10's white-ground rule was an
+atlas-era rule about maps, and the cards are a different object.
+Gate artifact: `mocks/card-dark-board.html` (the three-way ground fork on
+swatches, then the fan / flip / battle restaged in the recommended dark
+treatment). Owner pick A / B / C settles the ground before the live-page
+rebuild; naming ("metro match", working) stays open.

--- a/_scripts/world_metros/README.md
+++ b/_scripts/world_metros/README.md
@@ -1,10 +1,15 @@
-# World Metros Atlas — dev docs + tooling
+# Metro Cards (working name "metro match") — dev docs + tooling
 
-A one-URL interactive atlas of ~10–12 category-defining metro systems, eventually at
-`/is/building/world-metros/` (bespoke tier). Signature device: every network drawn from
-real OSM geometry at **one shared scale**, north-up, so physical forms compare honestly.
+A collectible card deck for 12 category-defining metro systems at
+`/is/building/world-metros/` (bespoke tier). Every city is one designed stat
+card (front for play: rank chips + strength tracks; back for lore: the
+familiar Commons diagram, credited); comparison is the game (battle + daily).
+Pivoted from the atlas vision 2026-06-12 (DECISIONS D17–D19) after four
+map-hero rounds died at their gates; the data contracts and licensing posture
+carry over unchanged.
 
-Nothing here is live yet. No page exists under `is/building/world-metros/` yet.
+The atlas-era coded prototype is live (soft-launched, noindex) at the URL;
+it gets rebuilt as the deck after the D19 ground pick.
 
 ## Reading order (mandatory for any agent picking this up)
 

--- a/_scripts/world_metros/STATUS.md
+++ b/_scripts/world_metros/STATUS.md
@@ -84,23 +84,30 @@ _Last updated: 2026-06-12 (Claude session, branch `worktree-metro-cards-d17`)._
   uniform pinstripe deck back stays the game-hidden state. Round-1 board
   stays in mocks/ for the record.
 
-## Current gate: owner verdict on the D18 v2 card board (the premise kill test, round 2)
+- D18 v2 board judged (2026-06-12): **premise PASSED** ("i like it"). The
+  archive branch is dead. One directed amendment: a black or other dark
+  background might be better (D19). The commissioned follow-through landed
+  the same session: BUILD-SPEC.md rewritten around the D17 North-Star + D18
+  card grammar; README first paragraph updated to the card vision.
 
-The gate artifact is `mocks/card-game-board.html`: three v2 fronts (Seoul,
-Paris, Tokyo), the flip exhibit (front / lore back with the credited diagram /
-deck back), the battle restaged on v2 cards, the daily strip. If the v2 cards
-delight: D17's North-Star replaces BUILD-SPEC's and the live page rebuilds as
-the deck. If they do not: archive per D17's premise-gate clause.
+## Current gate: owner pick on the D19 ground fork (A / B / C)
 
-## Next exact action (after the v2 card gate)
+The gate artifact is `mocks/card-dark-board.html`: the same Seoul card three
+ways on ground swatches (A white-on-light reference, B white card on a dark
+table, C dark card on a dark table: the recommendation), then the fan, the
+flip and the battle restaged in the recommended dark treatment. The pick
+settles the visual ground before the live-page rebuild.
 
-If approved: rewrite BUILD-SPEC.md around the D17 North-Star with the D18
-card grammar (deck + battle + daily; honest dated stats; soft-launch norms
-unchanged), settle naming, rebuild the live page as the card deck, then scale
-to the remaining 9 roster cities (D3) with frozen scope rules (DATA-CONTRACT:
-Seoul L1 is the hard one), per-line opened-year sourcing, and full-deck rank
-computation for the stat tracks.
-If rejected: archive per D17's premise-gate clause.
+## Next exact action (after the D19 ground pick)
+
+Rebuild the live page as the card deck in the picked ground: THE DECK
+(12-card collection, flip cards), THE BATTLE (vs cpu, pick-a-stat, first to
+3), THE DAILY (one guess a day, streak), METHOD (scopes, sources, licenses,
+why-not). Then scale to the remaining 9 roster cities (D3) with frozen scope
+rules (DATA-CONTRACT: Seoul L1 is the hard one), per-line opened-year
+sourcing, full-deck rank computation, and the lore backs per DIAGRAM-LEDGER.
+Naming ("metro match", working) stays the owner's call and should be settled
+before the page ships.
 
 ## Blockers
 

--- a/_scripts/world_metros/mocks/build_card_dark_board.py
+++ b/_scripts/world_metros/mocks/build_card_dark_board.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Metro-cards D19 ground board (dark fork, judged by eye).
+
+Owner verdict on the D18 v2 board: "i like it", with one amendment: a black
+or other dark background might be better. "Background" can mean the table or
+the card face, so this board builds both readings on ground swatches:
+
+  1. THE GROUND FORK: the same Seoul card three ways.
+       A · round-2 reference: white card, light ground.
+       B · white card, dark table (cards stay paper objects).
+       C · dark card, dark table (recommendation: the card face goes
+           ink-dark; the operators' line colours do the lighting).
+  2. THE FAN, DARK: the three fronts in treatment C.
+  3. THE FLIP, DARK: front / lore back (familiar diagram, credited) /
+     pinstripe deck back, all in C.
+  4. THE BATTLE, DARK: restaged in C (span picked, Seoul takes the round).
+
+Static approval artifact, no JS. Same data discipline as the v2 board
+(committed meta.json; ranks across the live deck of three; opened years
+from operator histories). Nothing is fetched.
+Writes card-dark-board.html next to this file.
+
+Usage:
+    python3 _scripts/world_metros/mocks/build_card_dark_board.py
+"""
+
+import json
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
+ASSETS = os.path.join(REPO, "is", "building", "world-metros", "assets")
+ASSET_HREF = "../../../is/building/world-metros/assets"
+
+LIVE = ("seoul", "paris", "tokyo")
+DECK_NO = {"tokyo": "02", "seoul": "03", "paris": "09"}
+SYSTEM = {
+    "seoul": "Seoul Metropolitan Subway",
+    "paris": "Métro de Paris",
+    "tokyo": "Tokyo Metro + Toei",
+}
+OPENED = {"seoul": 1974, "paris": 1900, "tokyo": 1927}
+EPITHET = {"seoul": "the sprawl", "paris": "the mesh", "tokyo": "the two crews"}
+FLAVOR = {
+    "seoul": "58 km between its furthest stations, the deck’s longest reach.",
+    "paris": "1.1 stations per square km, the deck’s tightest grid.",
+    "tokyo": "Thirteen lines, two operators, one grid.",
+}
+LINES_EV = {"seoul": " (2–9)"}
+
+SEOUL_CREDIT = ("“Seoul Metropolitan Subway network map” by Satellizer, "
+                "Wikimedia Commons, CC BY-SA 4.0")
+
+ORDINAL = {1: "1st", 2: "2nd", 3: "3rd"}
+
+
+def load_meta():
+    return json.load(open(os.path.join(ASSETS, "meta.json")))
+
+
+def stat_values(meta):
+    c = meta["cities"]
+    return [
+        ("opened", {k: OPENED[k] for k in LIVE},
+         {k: -OPENED[k] for k in LIVE}, lambda k, v: str(v)),
+        ("lines", {k: len(c[k]["lines"]) for k in LIVE},
+         {k: len(c[k]["lines"]) for k in LIVE},
+         lambda k, v: f'{v}{LINES_EV.get(k, "")}'),
+        ("stations", {k: c[k]["stations"] for k in LIVE},
+         {k: c[k]["stations"] for k in LIVE}, lambda k, v: str(v)),
+        ("span", {k: c[k]["span_km"] for k in LIVE},
+         {k: c[k]["span_km"] for k in LIVE}, lambda k, v: f"{v:.1f} km"),
+    ]
+
+
+def stat_block(meta, city, highlight=None):
+    rows = []
+    for label, values, strength, fmt in stat_values(meta):
+        sts = sorted(strength.values(), reverse=True)
+        rank = sts.index(strength[city]) + 1
+        smin, smax = min(sts), max(sts)
+        pct = 50.0 if smax == smin else 100.0 * (strength[city] - smin) / (smax - smin)
+        chip_cls = "rk rk1" if rank == 1 else "rk"
+        hot = " hot" if highlight == label else ""
+        rows.append(
+            f'<div class="grow{hot}">'
+            f'<span class="{chip_cls}">{ORDINAL[rank]}</span>'
+            f'<span class="gl">{label}</span>'
+            f'<span class="track"><i style="left:{pct:.0f}%"></i></span>'
+            f'<span class="gv">{fmt(city, values[city])}</span></div>')
+    for label in ("route-km", "ridership"):
+        rows.append(
+            f'<div class="grow pipe">'
+            f'<span class="rk rkp">···</span>'
+            f'<span class="gl">{label}</span>'
+            f'<span class="track"></span>'
+            f'<span class="gv gvp">pipeline · dated</span></div>')
+    return "".join(rows)
+
+
+def pills(meta, city):
+    segs = "".join(f'<i style="background:{l["color"]}">{l["ref"]}</i>'
+                   for l in meta["cities"][city]["lines"])
+    return f'<div class="pills">{segs}</div>'
+
+
+def card_front(meta, city, theme, highlight=None):
+    return (f'<div class="mcard {theme}">'
+            f'<div class="mtop"><div><div class="mname">{city}</div>'
+            f'<div class="mepi">{EPITHET[city]}</div></div>'
+            f'<div class="mno">{DECK_NO[city]}/12</div></div>'
+            f'{pills(meta, city)}'
+            f'<div class="gblock">{stat_block(meta, city, highlight)}</div>'
+            f'<div class="mfoot">data: OSM snapshot {meta["as_of"]} · ODbL · '
+            f'ranks: live deck of {len(LIVE)}</div></div>')
+
+
+def card_lore_back(meta, city, theme):
+    return (f'<div class="mcard mlore {theme}">'
+            f'<div class="loreart"><img src="{ASSET_HREF}/{city}-diagram.svg" '
+            f'alt="{city} metro diagram, Wikimedia Commons recreation"></div>'
+            f'<div class="loreband"><div class="mname">{city}</div>'
+            f'<div class="loresys">{SYSTEM[city]}</div>'
+            f'<div class="loreflavor">{FLAVOR[city]}</div>'
+            f'<div class="lorecredit">{SEOUL_CREDIT}</div></div></div>')
+
+
+def card_deck_back(meta, theme):
+    colours = [l["color"] for city in LIVE for l in meta["cities"][city]["lines"]]
+    stripes = "".join(f'<i style="background:{c}"></i>' for c in colours)
+    return (f'<div class="mcard mback {theme}">'
+            f'<div class="pinstripes">{stripes}</div>'
+            f'<div class="backband"><div class="backmark">METRO MATCH</div>'
+            f'<div class="backsub">twelve systems · one deck</div></div></div>')
+
+
+CSS = """
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap');
+* { margin:0; padding:0; box-sizing:border-box; }
+body { background:#0a0a0d; color:#e8e8e3; display:flex; align-items:flex-start;
+       justify-content:center; min-height:100vh; padding:24px 0;
+       font-family:-apple-system,'Helvetica Neue','Segoe UI',Arial,sans-serif; }
+.board { width:1280px; background:#131318; outline:1px solid #26262c;
+         box-shadow:0 1px 18px rgba(0,0,0,.6); }
+header { display:flex; align-items:baseline; gap:20px; padding:14px 22px 11px;
+         border-bottom:1px solid #26262c; background:#15151a; }
+.wordmark { font-size:15px; font-weight:700; letter-spacing:.24em;
+            color:#f2f2ee; }
+.wordmark em { font-style:normal; color:#7fb0e8; }
+.mockbadge { margin-left:auto; font-family:'DM Mono',monospace; font-size:9px;
+             letter-spacing:.14em; color:#e08040; border:1px solid #e0804066;
+             padding:3px 7px; border-radius:2px; white-space:nowrap; }
+.intro { padding:9px 22px; font-size:11px; color:#8a8a85; background:#15151a;
+         border-bottom:1px solid #26262c; line-height:1.5; }
+.intro b { color:#e8e8e3; font-weight:600; }
+.seclabel { padding:16px 22px 10px; font-family:'DM Mono',monospace;
+            font-size:10px; letter-spacing:.2em; color:#7fb0e8; }
+.row { display:flex; gap:26px; justify-content:center; align-items:flex-start;
+       padding:6px 22px 10px; }
+.cell { display:flex; flex-direction:column; gap:9px; align-items:center; }
+.cap { font-family:'DM Mono',monospace; font-size:8.5px; color:#8a8a85;
+       letter-spacing:.1em; text-align:center; max-width:300px;
+       line-height:1.5; }
+.cap b { color:#e8e8e3; font-weight:700; }
+.sw { padding:26px 24px; border-radius:8px; border:1px solid #26262c;
+      display:flex; justify-content:center; }
+.swL { background:#e8e8e3; }
+.swD { background:#0f0f12; }
+
+.mcard { width:270px; height:392px; border-radius:12px; padding:16px 14px 11px;
+         display:flex; flex-direction:column; flex:none; overflow:hidden;
+         position:relative; }
+.mtop { display:flex; justify-content:space-between; align-items:flex-start;
+        gap:8px; }
+.mname { font-size:17px; font-weight:800; letter-spacing:.1em;
+         text-transform:uppercase; }
+.mepi { font-family:'DM Mono',monospace; font-size:8px; letter-spacing:.22em;
+        text-transform:uppercase; margin-top:4px; }
+.mno { font-family:'DM Mono',monospace; font-size:9px; color:#8a8a85;
+       padding-top:3px; }
+.pills { display:flex; flex-wrap:wrap; gap:4px; margin-top:13px;
+         min-height:16px; }
+.pills i { font-style:normal; font-family:'DM Mono',monospace; font-size:8px;
+           font-weight:500; color:#fff; padding:2px 6px; border-radius:999px;
+           letter-spacing:.02em; }
+.gblock { margin-top:14px; }
+.grow { display:grid; grid-template-columns:32px 1fr 56px 64px; gap:8px;
+        align-items:center; padding:11px 1px; }
+.rk { font-family:'DM Mono',monospace; font-size:6.5px; letter-spacing:.08em;
+      text-transform:uppercase; text-align:center; border-radius:999px;
+      padding:2px 0; }
+.rk1 { background:#0052a4; border-color:#0052a4 !important; color:#fff !important;
+       font-weight:500; }
+.gl { font-family:'DM Mono',monospace; font-size:7.5px; letter-spacing:.1em;
+      color:#8a8a85; text-transform:uppercase; }
+.track { position:relative; height:2px; border-radius:1px; }
+.track i { position:absolute; top:50%; width:6px; height:6px;
+           border-radius:50%; transform:translate(-3px,-50%); }
+.gv { font-family:'DM Mono',monospace; font-size:10.5px; font-weight:500;
+      text-align:right; white-space:nowrap; }
+.gvp { font-size:7px; font-weight:400; }
+.mfoot { margin-top:auto; font-family:'DM Mono',monospace; font-size:6.5px;
+         line-height:1.5; padding-top:8px; }
+
+/* light card (round-2 reference) */
+.tL { background:#fff; border:1px solid #d8d8d2;
+      box-shadow:0 2px 10px rgba(20,20,28,.13); color:#17171c; }
+.tL .mepi { color:#0052a4; }
+.tL .gblock { border-top:1px solid #d8d8d2; }
+.tL .grow { border-bottom:1px solid #f0f0ec; }
+.tL .rk { border:1px solid #c9c9c2; color:#8a8a85; }
+.tL .rkp { border-style:dashed; color:#c9c9c2; }
+.tL .track { background:#e4e4de; }
+.tL .track i { background:#17171c; }
+.tL .gvp { color:#b9b9b2; }
+.tL .grow.pipe .gl { color:#c9c9c2; }
+.tL .grow.hot { background:#0052a414; box-shadow:inset 2px 0 0 #0052a4;
+                border-radius:2px; }
+.tL .grow.hot .gl { color:#0052a4; }
+.tL .mfoot { color:#b9b9b2; }
+
+/* dark card (treatment C) */
+.tD { background:#1b1b21; border:1px solid #32323a;
+      box-shadow:0 4px 16px rgba(0,0,0,.55); color:#f2f2ee; }
+.tD .mepi { color:#7fb0e8; }
+.tD .gblock { border-top:1px solid #32323a; }
+.tD .grow { border-bottom:1px solid #232329; }
+.tD .rk { border:1px solid #43434c; color:#9a9a94; }
+.tD .rkp { border-style:dashed; border-color:#3a3a42; color:#55555e; }
+.tD .track { background:#2e2e36; }
+.tD .track i { background:#e8e8e3; }
+.tD .gvp { color:#55555e; }
+.tD .grow.pipe .gl { color:#4a4a52; }
+.tD .grow.hot { background:#0052a44d; box-shadow:inset 2px 0 0 #5b9bd5;
+                border-radius:2px; }
+.tD .grow.hot .gl { color:#9cc4ea; }
+.tD .mfoot { color:#5e5e66; }
+
+.mlore { padding:0; }
+.loreart { height:236px; overflow:hidden; position:relative; }
+.loreart img { position:absolute; inset:-20%; width:140%; height:140%;
+               object-fit:cover; }
+.loreband { padding:12px 14px 10px; display:flex; flex-direction:column;
+            flex:1; }
+.tD .loreband { border-top:1px solid #32323a; }
+.loresys { font-family:'DM Mono',monospace; font-size:7px;
+           letter-spacing:.14em; text-transform:uppercase; margin-top:4px; }
+.tD .loresys { color:#7fb0e8; }
+.loreflavor { font-size:9.5px; line-height:1.45; margin-top:9px; }
+.tD .loreflavor { color:#b9b9b4; }
+.lorecredit { margin-top:auto; font-family:'DM Mono',monospace;
+              font-size:6.5px; line-height:1.5; }
+.tD .lorecredit { color:#5e5e66; }
+
+.mback { padding:0; }
+.pinstripes { position:absolute; inset:10px; border-radius:8px;
+              overflow:hidden; display:flex; }
+.pinstripes i { flex:1; }
+.backband { position:absolute; left:0; right:0; top:50%;
+            transform:translateY(-50%); padding:14px 0; text-align:center; }
+.tD .backband { background:#1b1b21; border-top:1px solid #32323a;
+                border-bottom:1px solid #32323a; }
+.backmark { font-size:14px; font-weight:800; letter-spacing:.3em; }
+.tD .backmark { color:#f2f2ee; }
+.backsub { font-family:'DM Mono',monospace; font-size:8px; color:#8a8a85;
+           margin-top:5px; letter-spacing:.12em; }
+
+.battle { display:flex; gap:22px; justify-content:center; align-items:center;
+          padding:6px 22px 10px; }
+.bcenter { width:206px; text-align:center; flex:none; }
+.bround { font-family:'DM Mono',monospace; font-size:8.5px; color:#8a8a85;
+          letter-spacing:.16em; }
+.bcall { font-size:14px; font-weight:800; letter-spacing:.06em; margin-top:8px;
+         color:#f2f2ee; }
+.bnums { font-family:'DM Mono',monospace; font-size:10px; margin-top:6px;
+         color:#c9c9c4; }
+.bscore { font-family:'DM Mono',monospace; font-size:8.5px; color:#8a8a85;
+          margin-top:10px; }
+
+.daily { display:flex; align-items:center; gap:12px; margin:8px 22px 4px;
+         padding:11px 16px; background:#15151a; border:1px solid #26262c; }
+.dpill { font-size:10px; font-weight:800; letter-spacing:.14em;
+         border:1px solid #e8e8e3; color:#e8e8e3; padding:4px 12px;
+         border-radius:999px; text-transform:uppercase; }
+.dvs { font-family:'DM Mono',monospace; font-size:9px; color:#8a8a85; }
+.dtext { margin-left:8px; font-size:11px; color:#8a8a85; line-height:1.5; }
+.dtext b { color:#e8e8e3; font-weight:600; }
+
+footer { display:flex; justify-content:space-between; gap:20px;
+         padding:9px 22px; border-top:1px solid #26262c; margin-top:16px;
+         font-family:'DM Mono',monospace; font-size:9px; color:#8a8a85;
+         background:#15151a; }
+"""
+
+
+def main():
+    meta = load_meta()
+
+    fork = (f'<div class="cell"><div class="sw swL">'
+            f'{card_front(meta, "seoul", "tL")}</div>'
+            f'<div class="cap"><b>A · round-2 reference</b><br>white card, '
+            f'light ground</div></div>'
+            f'<div class="cell"><div class="sw swD">'
+            f'{card_front(meta, "seoul", "tL")}</div>'
+            f'<div class="cap"><b>B · white card, dark table</b><br>cards stay '
+            f'paper objects on a dark page</div></div>'
+            f'<div class="cell"><div class="sw swD">'
+            f'{card_front(meta, "seoul", "tD")}</div>'
+            f'<div class="cap"><b>C · dark card, dark table (rec)</b><br>the '
+            f'card face goes ink-dark; the line colours do the lighting</div>'
+            f'</div>')
+
+    fan = "".join(card_front(meta, c, "tD") for c in ("seoul", "paris", "tokyo"))
+
+    flip = (f'<div class="cell">{card_front(meta, "seoul", "tD")}'
+            f'<div class="cap"><b>the front</b><br>play side, treatment C</div>'
+            f'</div>'
+            f'<div class="cell">{card_lore_back(meta, "seoul", "tD")}'
+            f'<div class="cap"><b>the flip side</b><br>the familiar map stays '
+            f'an artwork window, credited</div></div>'
+            f'<div class="cell">{card_deck_back(meta, "tD")}'
+            f'<div class="cap"><b>the deck back</b><br>the opponent’s hidden '
+            f'card</div></div>')
+
+    battle = (f'{card_front(meta, "seoul", "tD", highlight="span")}'
+              f'<div class="bcenter"><div class="bround">ROUND 3 · YOU PICKED '
+              f'SPAN</div><div class="bcall">SEOUL TAKES THE ROUND</div>'
+              f'<div class="bnums">57.7 km vs 24.1 km</div>'
+              f'<div class="bscore">you 2 · cpu 1 · first to 3</div></div>'
+              f'{card_front(meta, "paris", "tD", highlight="span")}')
+
+    html = f"""<!doctype html><html><head><meta charset="utf-8">
+<title>world-metros mock: metro cards, dark ground fork</title>
+<style>{CSS}</style></head><body><div class="board">
+<header><div class="wordmark">WORLD METROS <em>ATLAS</em></div>
+<span class="mockbadge">DARK GROUND FORK · D19 · APPROVAL ARTIFACT</span></header>
+<div class="intro"><b>the D19 question:</b> the v2 card passed; would a dark
+ground serve it better? "Background" can mean the table or the card face, so
+both readings are built. B keeps the card paper-white on a dark table; C
+turns the card itself ink-dark and lets the operators' line colours do the
+lighting. A is the round-2 reference. Everything below the fork applies C,
+the recommendation.</div>
+<div class="seclabel">THE GROUND FORK · SEOUL THREE WAYS · JUDGE BY EYE</div>
+<div class="row">{fork}</div>
+<div class="seclabel">THE FAN, DARK · TREATMENT C</div>
+<div class="row">{fan}</div>
+<div class="seclabel">THE FLIP, DARK · FRONT FOR PLAY, BACK FOR LORE</div>
+<div class="row">{flip}</div>
+<div class="seclabel">THE BATTLE, DARK · RESTAGED</div>
+<div class="battle">{battle}</div>
+<div class="daily"><span class="dpill">cairo</span><span class="dvs">vs</span>
+<span class="dpill">singapore</span><span class="dtext"><b>the daily:</b>
+which plots more stations? One guess a day, keep the streak.</span></div>
+<footer><span>stats © OpenStreetMap contributors · ODbL · OSM snapshot
+{meta["as_of"]} · ranks and tracks: live deck of three, full deck at pipeline
+· lore-side diagram credited on card · opened years: operator histories,
+dated sourcing at pipeline</span>
+<span>made by ajin.im</span></footer>
+</div></body></html>"""
+    out = os.path.join(HERE, "card-dark-board.html")
+    with open(out, "w") as fh:
+        fh.write(html)
+    print(f"wrote {out}  ({os.path.getsize(out) / 1024:.0f} KB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/_scripts/world_metros/mocks/card-dark-board.html
+++ b/_scripts/world_metros/mocks/card-dark-board.html
@@ -1,0 +1,184 @@
+<!doctype html><html><head><meta charset="utf-8">
+<title>world-metros mock: metro cards, dark ground fork</title>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap');
+* { margin:0; padding:0; box-sizing:border-box; }
+body { background:#0a0a0d; color:#e8e8e3; display:flex; align-items:flex-start;
+       justify-content:center; min-height:100vh; padding:24px 0;
+       font-family:-apple-system,'Helvetica Neue','Segoe UI',Arial,sans-serif; }
+.board { width:1280px; background:#131318; outline:1px solid #26262c;
+         box-shadow:0 1px 18px rgba(0,0,0,.6); }
+header { display:flex; align-items:baseline; gap:20px; padding:14px 22px 11px;
+         border-bottom:1px solid #26262c; background:#15151a; }
+.wordmark { font-size:15px; font-weight:700; letter-spacing:.24em;
+            color:#f2f2ee; }
+.wordmark em { font-style:normal; color:#7fb0e8; }
+.mockbadge { margin-left:auto; font-family:'DM Mono',monospace; font-size:9px;
+             letter-spacing:.14em; color:#e08040; border:1px solid #e0804066;
+             padding:3px 7px; border-radius:2px; white-space:nowrap; }
+.intro { padding:9px 22px; font-size:11px; color:#8a8a85; background:#15151a;
+         border-bottom:1px solid #26262c; line-height:1.5; }
+.intro b { color:#e8e8e3; font-weight:600; }
+.seclabel { padding:16px 22px 10px; font-family:'DM Mono',monospace;
+            font-size:10px; letter-spacing:.2em; color:#7fb0e8; }
+.row { display:flex; gap:26px; justify-content:center; align-items:flex-start;
+       padding:6px 22px 10px; }
+.cell { display:flex; flex-direction:column; gap:9px; align-items:center; }
+.cap { font-family:'DM Mono',monospace; font-size:8.5px; color:#8a8a85;
+       letter-spacing:.1em; text-align:center; max-width:300px;
+       line-height:1.5; }
+.cap b { color:#e8e8e3; font-weight:700; }
+.sw { padding:26px 24px; border-radius:8px; border:1px solid #26262c;
+      display:flex; justify-content:center; }
+.swL { background:#e8e8e3; }
+.swD { background:#0f0f12; }
+
+.mcard { width:270px; height:392px; border-radius:12px; padding:16px 14px 11px;
+         display:flex; flex-direction:column; flex:none; overflow:hidden;
+         position:relative; }
+.mtop { display:flex; justify-content:space-between; align-items:flex-start;
+        gap:8px; }
+.mname { font-size:17px; font-weight:800; letter-spacing:.1em;
+         text-transform:uppercase; }
+.mepi { font-family:'DM Mono',monospace; font-size:8px; letter-spacing:.22em;
+        text-transform:uppercase; margin-top:4px; }
+.mno { font-family:'DM Mono',monospace; font-size:9px; color:#8a8a85;
+       padding-top:3px; }
+.pills { display:flex; flex-wrap:wrap; gap:4px; margin-top:13px;
+         min-height:16px; }
+.pills i { font-style:normal; font-family:'DM Mono',monospace; font-size:8px;
+           font-weight:500; color:#fff; padding:2px 6px; border-radius:999px;
+           letter-spacing:.02em; }
+.gblock { margin-top:14px; }
+.grow { display:grid; grid-template-columns:32px 1fr 56px 64px; gap:8px;
+        align-items:center; padding:11px 1px; }
+.rk { font-family:'DM Mono',monospace; font-size:6.5px; letter-spacing:.08em;
+      text-transform:uppercase; text-align:center; border-radius:999px;
+      padding:2px 0; }
+.rk1 { background:#0052a4; border-color:#0052a4 !important; color:#fff !important;
+       font-weight:500; }
+.gl { font-family:'DM Mono',monospace; font-size:7.5px; letter-spacing:.1em;
+      color:#8a8a85; text-transform:uppercase; }
+.track { position:relative; height:2px; border-radius:1px; }
+.track i { position:absolute; top:50%; width:6px; height:6px;
+           border-radius:50%; transform:translate(-3px,-50%); }
+.gv { font-family:'DM Mono',monospace; font-size:10.5px; font-weight:500;
+      text-align:right; white-space:nowrap; }
+.gvp { font-size:7px; font-weight:400; }
+.mfoot { margin-top:auto; font-family:'DM Mono',monospace; font-size:6.5px;
+         line-height:1.5; padding-top:8px; }
+
+/* light card (round-2 reference) */
+.tL { background:#fff; border:1px solid #d8d8d2;
+      box-shadow:0 2px 10px rgba(20,20,28,.13); color:#17171c; }
+.tL .mepi { color:#0052a4; }
+.tL .gblock { border-top:1px solid #d8d8d2; }
+.tL .grow { border-bottom:1px solid #f0f0ec; }
+.tL .rk { border:1px solid #c9c9c2; color:#8a8a85; }
+.tL .rkp { border-style:dashed; color:#c9c9c2; }
+.tL .track { background:#e4e4de; }
+.tL .track i { background:#17171c; }
+.tL .gvp { color:#b9b9b2; }
+.tL .grow.pipe .gl { color:#c9c9c2; }
+.tL .grow.hot { background:#0052a414; box-shadow:inset 2px 0 0 #0052a4;
+                border-radius:2px; }
+.tL .grow.hot .gl { color:#0052a4; }
+.tL .mfoot { color:#b9b9b2; }
+
+/* dark card (treatment C) */
+.tD { background:#1b1b21; border:1px solid #32323a;
+      box-shadow:0 4px 16px rgba(0,0,0,.55); color:#f2f2ee; }
+.tD .mepi { color:#7fb0e8; }
+.tD .gblock { border-top:1px solid #32323a; }
+.tD .grow { border-bottom:1px solid #232329; }
+.tD .rk { border:1px solid #43434c; color:#9a9a94; }
+.tD .rkp { border-style:dashed; border-color:#3a3a42; color:#55555e; }
+.tD .track { background:#2e2e36; }
+.tD .track i { background:#e8e8e3; }
+.tD .gvp { color:#55555e; }
+.tD .grow.pipe .gl { color:#4a4a52; }
+.tD .grow.hot { background:#0052a44d; box-shadow:inset 2px 0 0 #5b9bd5;
+                border-radius:2px; }
+.tD .grow.hot .gl { color:#9cc4ea; }
+.tD .mfoot { color:#5e5e66; }
+
+.mlore { padding:0; }
+.loreart { height:236px; overflow:hidden; position:relative; }
+.loreart img { position:absolute; inset:-20%; width:140%; height:140%;
+               object-fit:cover; }
+.loreband { padding:12px 14px 10px; display:flex; flex-direction:column;
+            flex:1; }
+.tD .loreband { border-top:1px solid #32323a; }
+.loresys { font-family:'DM Mono',monospace; font-size:7px;
+           letter-spacing:.14em; text-transform:uppercase; margin-top:4px; }
+.tD .loresys { color:#7fb0e8; }
+.loreflavor { font-size:9.5px; line-height:1.45; margin-top:9px; }
+.tD .loreflavor { color:#b9b9b4; }
+.lorecredit { margin-top:auto; font-family:'DM Mono',monospace;
+              font-size:6.5px; line-height:1.5; }
+.tD .lorecredit { color:#5e5e66; }
+
+.mback { padding:0; }
+.pinstripes { position:absolute; inset:10px; border-radius:8px;
+              overflow:hidden; display:flex; }
+.pinstripes i { flex:1; }
+.backband { position:absolute; left:0; right:0; top:50%;
+            transform:translateY(-50%); padding:14px 0; text-align:center; }
+.tD .backband { background:#1b1b21; border-top:1px solid #32323a;
+                border-bottom:1px solid #32323a; }
+.backmark { font-size:14px; font-weight:800; letter-spacing:.3em; }
+.tD .backmark { color:#f2f2ee; }
+.backsub { font-family:'DM Mono',monospace; font-size:8px; color:#8a8a85;
+           margin-top:5px; letter-spacing:.12em; }
+
+.battle { display:flex; gap:22px; justify-content:center; align-items:center;
+          padding:6px 22px 10px; }
+.bcenter { width:206px; text-align:center; flex:none; }
+.bround { font-family:'DM Mono',monospace; font-size:8.5px; color:#8a8a85;
+          letter-spacing:.16em; }
+.bcall { font-size:14px; font-weight:800; letter-spacing:.06em; margin-top:8px;
+         color:#f2f2ee; }
+.bnums { font-family:'DM Mono',monospace; font-size:10px; margin-top:6px;
+         color:#c9c9c4; }
+.bscore { font-family:'DM Mono',monospace; font-size:8.5px; color:#8a8a85;
+          margin-top:10px; }
+
+.daily { display:flex; align-items:center; gap:12px; margin:8px 22px 4px;
+         padding:11px 16px; background:#15151a; border:1px solid #26262c; }
+.dpill { font-size:10px; font-weight:800; letter-spacing:.14em;
+         border:1px solid #e8e8e3; color:#e8e8e3; padding:4px 12px;
+         border-radius:999px; text-transform:uppercase; }
+.dvs { font-family:'DM Mono',monospace; font-size:9px; color:#8a8a85; }
+.dtext { margin-left:8px; font-size:11px; color:#8a8a85; line-height:1.5; }
+.dtext b { color:#e8e8e3; font-weight:600; }
+
+footer { display:flex; justify-content:space-between; gap:20px;
+         padding:9px 22px; border-top:1px solid #26262c; margin-top:16px;
+         font-family:'DM Mono',monospace; font-size:9px; color:#8a8a85;
+         background:#15151a; }
+</style></head><body><div class="board">
+<header><div class="wordmark">WORLD METROS <em>ATLAS</em></div>
+<span class="mockbadge">DARK GROUND FORK · D19 · APPROVAL ARTIFACT</span></header>
+<div class="intro"><b>the D19 question:</b> the v2 card passed; would a dark
+ground serve it better? "Background" can mean the table or the card face, so
+both readings are built. B keeps the card paper-white on a dark table; C
+turns the card itself ink-dark and lets the operators' line colours do the
+lighting. A is the round-2 reference. Everything below the fork applies C,
+the recommendation.</div>
+<div class="seclabel">THE GROUND FORK · SEOUL THREE WAYS · JUDGE BY EYE</div>
+<div class="row"><div class="cell"><div class="sw swL"><div class="mcard tL"><div class="mtop"><div><div class="mname">seoul</div><div class="mepi">the sprawl</div></div><div class="mno">03/12</div></div><div class="pills"><i style="background:#00a23f">2</i><i style="background:#ed6c00">3</i><i style="background:#009bce">4</i><i style="background:#794698">5</i><i style="background:#7c4932">6</i><i style="background:#6e7e31">7</i><i style="background:#d11d70">8</i><i style="background:#a49d87">9</i></div><div class="gblock"><div class="grow"><span class="rk">3rd</span><span class="gl">opened</span><span class="track"><i style="left:0%"></i></span><span class="gv">1974</span></div><div class="grow"><span class="rk">3rd</span><span class="gl">lines</span><span class="track"><i style="left:0%"></i></span><span class="gv">8 (2–9)</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">stations</span><span class="track"><i style="left:100%"></i></span><span class="gv">607</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">span</span><span class="track"><i style="left:100%"></i></span><span class="gv">57.7 km</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">route-km</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">ridership</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3</div></div></div><div class="cap"><b>A · round-2 reference</b><br>white card, light ground</div></div><div class="cell"><div class="sw swD"><div class="mcard tL"><div class="mtop"><div><div class="mname">seoul</div><div class="mepi">the sprawl</div></div><div class="mno">03/12</div></div><div class="pills"><i style="background:#00a23f">2</i><i style="background:#ed6c00">3</i><i style="background:#009bce">4</i><i style="background:#794698">5</i><i style="background:#7c4932">6</i><i style="background:#6e7e31">7</i><i style="background:#d11d70">8</i><i style="background:#a49d87">9</i></div><div class="gblock"><div class="grow"><span class="rk">3rd</span><span class="gl">opened</span><span class="track"><i style="left:0%"></i></span><span class="gv">1974</span></div><div class="grow"><span class="rk">3rd</span><span class="gl">lines</span><span class="track"><i style="left:0%"></i></span><span class="gv">8 (2–9)</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">stations</span><span class="track"><i style="left:100%"></i></span><span class="gv">607</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">span</span><span class="track"><i style="left:100%"></i></span><span class="gv">57.7 km</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">route-km</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">ridership</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3</div></div></div><div class="cap"><b>B · white card, dark table</b><br>cards stay paper objects on a dark page</div></div><div class="cell"><div class="sw swD"><div class="mcard tD"><div class="mtop"><div><div class="mname">seoul</div><div class="mepi">the sprawl</div></div><div class="mno">03/12</div></div><div class="pills"><i style="background:#00a23f">2</i><i style="background:#ed6c00">3</i><i style="background:#009bce">4</i><i style="background:#794698">5</i><i style="background:#7c4932">6</i><i style="background:#6e7e31">7</i><i style="background:#d11d70">8</i><i style="background:#a49d87">9</i></div><div class="gblock"><div class="grow"><span class="rk">3rd</span><span class="gl">opened</span><span class="track"><i style="left:0%"></i></span><span class="gv">1974</span></div><div class="grow"><span class="rk">3rd</span><span class="gl">lines</span><span class="track"><i style="left:0%"></i></span><span class="gv">8 (2–9)</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">stations</span><span class="track"><i style="left:100%"></i></span><span class="gv">607</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">span</span><span class="track"><i style="left:100%"></i></span><span class="gv">57.7 km</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">route-km</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">ridership</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3</div></div></div><div class="cap"><b>C · dark card, dark table (rec)</b><br>the card face goes ink-dark; the line colours do the lighting</div></div></div>
+<div class="seclabel">THE FAN, DARK · TREATMENT C</div>
+<div class="row"><div class="mcard tD"><div class="mtop"><div><div class="mname">seoul</div><div class="mepi">the sprawl</div></div><div class="mno">03/12</div></div><div class="pills"><i style="background:#00a23f">2</i><i style="background:#ed6c00">3</i><i style="background:#009bce">4</i><i style="background:#794698">5</i><i style="background:#7c4932">6</i><i style="background:#6e7e31">7</i><i style="background:#d11d70">8</i><i style="background:#a49d87">9</i></div><div class="gblock"><div class="grow"><span class="rk">3rd</span><span class="gl">opened</span><span class="track"><i style="left:0%"></i></span><span class="gv">1974</span></div><div class="grow"><span class="rk">3rd</span><span class="gl">lines</span><span class="track"><i style="left:0%"></i></span><span class="gv">8 (2–9)</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">stations</span><span class="track"><i style="left:100%"></i></span><span class="gv">607</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">span</span><span class="track"><i style="left:100%"></i></span><span class="gv">57.7 km</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">route-km</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">ridership</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3</div></div><div class="mcard tD"><div class="mtop"><div><div class="mname">paris</div><div class="mepi">the mesh</div></div><div class="mno">09/12</div></div><div class="pills"><i style="background:#ffbe00">1</i><i style="background:#0055c8">2</i><i style="background:#6e6e00">3</i><i style="background:#a0006e">4</i><i style="background:#ff7f32">5</i><i style="background:#82dc73">6</i><i style="background:#ff82b4">7</i><i style="background:#d282be">8</i><i style="background:#b6bd00">9</i><i style="background:#dc9600">10</i><i style="background:#6e491e">11</i><i style="background:#00643c">12</i><i style="background:#82c8e6">13</i><i style="background:#640082">14</i><i style="background:#82c8e6">3bis</i><i style="background:#82dc73">7bis</i></div><div class="gblock"><div class="grow"><span class="rk rk1">1st</span><span class="gl">opened</span><span class="track"><i style="left:100%"></i></span><span class="gv">1900</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">lines</span><span class="track"><i style="left:100%"></i></span><span class="gv">16</span></div><div class="grow"><span class="rk">2nd</span><span class="gl">stations</span><span class="track"><i style="left:51%"></i></span><span class="gv">501</span></div><div class="grow"><span class="rk">3rd</span><span class="gl">span</span><span class="track"><i style="left:0%"></i></span><span class="gv">24.1 km</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">route-km</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">ridership</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3</div></div><div class="mcard tD"><div class="mtop"><div><div class="mname">tokyo</div><div class="mepi">the two crews</div></div><div class="mno">02/12</div></div><div class="pills"><i style="background:#e85298">A</i><i style="background:#00bb85">C</i><i style="background:#b6007a">E</i><i style="background:#9c5e31">F</i><i style="background:#ff9500">G</i><i style="background:#b5b5ac">H</i><i style="background:#0079c2">I</i><i style="background:#f62e36">M</i><i style="background:#00ac9b">N</i><i style="background:#6cbb5a">S</i><i style="background:#009bbf">T</i><i style="background:#c1a470">Y</i><i style="background:#8f76d6">Z</i></div><div class="gblock"><div class="grow"><span class="rk">2nd</span><span class="gl">opened</span><span class="track"><i style="left:64%"></i></span><span class="gv">1927</span></div><div class="grow"><span class="rk">2nd</span><span class="gl">lines</span><span class="track"><i style="left:62%"></i></span><span class="gv">13</span></div><div class="grow"><span class="rk">3rd</span><span class="gl">stations</span><span class="track"><i style="left:0%"></i></span><span class="gv">391</span></div><div class="grow"><span class="rk">2nd</span><span class="gl">span</span><span class="track"><i style="left:25%"></i></span><span class="gv">32.6 km</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">route-km</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">ridership</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3</div></div></div>
+<div class="seclabel">THE FLIP, DARK · FRONT FOR PLAY, BACK FOR LORE</div>
+<div class="row"><div class="cell"><div class="mcard tD"><div class="mtop"><div><div class="mname">seoul</div><div class="mepi">the sprawl</div></div><div class="mno">03/12</div></div><div class="pills"><i style="background:#00a23f">2</i><i style="background:#ed6c00">3</i><i style="background:#009bce">4</i><i style="background:#794698">5</i><i style="background:#7c4932">6</i><i style="background:#6e7e31">7</i><i style="background:#d11d70">8</i><i style="background:#a49d87">9</i></div><div class="gblock"><div class="grow"><span class="rk">3rd</span><span class="gl">opened</span><span class="track"><i style="left:0%"></i></span><span class="gv">1974</span></div><div class="grow"><span class="rk">3rd</span><span class="gl">lines</span><span class="track"><i style="left:0%"></i></span><span class="gv">8 (2–9)</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">stations</span><span class="track"><i style="left:100%"></i></span><span class="gv">607</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">span</span><span class="track"><i style="left:100%"></i></span><span class="gv">57.7 km</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">route-km</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">ridership</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3</div></div><div class="cap"><b>the front</b><br>play side, treatment C</div></div><div class="cell"><div class="mcard mlore tD"><div class="loreart"><img src="../../../is/building/world-metros/assets/seoul-diagram.svg" alt="seoul metro diagram, Wikimedia Commons recreation"></div><div class="loreband"><div class="mname">seoul</div><div class="loresys">Seoul Metropolitan Subway</div><div class="loreflavor">58 km between its furthest stations, the deck’s longest reach.</div><div class="lorecredit">“Seoul Metropolitan Subway network map” by Satellizer, Wikimedia Commons, CC BY-SA 4.0</div></div></div><div class="cap"><b>the flip side</b><br>the familiar map stays an artwork window, credited</div></div><div class="cell"><div class="mcard mback tD"><div class="pinstripes"><i style="background:#00a23f"></i><i style="background:#ed6c00"></i><i style="background:#009bce"></i><i style="background:#794698"></i><i style="background:#7c4932"></i><i style="background:#6e7e31"></i><i style="background:#d11d70"></i><i style="background:#a49d87"></i><i style="background:#ffbe00"></i><i style="background:#0055c8"></i><i style="background:#6e6e00"></i><i style="background:#a0006e"></i><i style="background:#ff7f32"></i><i style="background:#82dc73"></i><i style="background:#ff82b4"></i><i style="background:#d282be"></i><i style="background:#b6bd00"></i><i style="background:#dc9600"></i><i style="background:#6e491e"></i><i style="background:#00643c"></i><i style="background:#82c8e6"></i><i style="background:#640082"></i><i style="background:#82c8e6"></i><i style="background:#82dc73"></i><i style="background:#e85298"></i><i style="background:#00bb85"></i><i style="background:#b6007a"></i><i style="background:#9c5e31"></i><i style="background:#ff9500"></i><i style="background:#b5b5ac"></i><i style="background:#0079c2"></i><i style="background:#f62e36"></i><i style="background:#00ac9b"></i><i style="background:#6cbb5a"></i><i style="background:#009bbf"></i><i style="background:#c1a470"></i><i style="background:#8f76d6"></i></div><div class="backband"><div class="backmark">METRO MATCH</div><div class="backsub">twelve systems · one deck</div></div></div><div class="cap"><b>the deck back</b><br>the opponent’s hidden card</div></div></div>
+<div class="seclabel">THE BATTLE, DARK · RESTAGED</div>
+<div class="battle"><div class="mcard tD"><div class="mtop"><div><div class="mname">seoul</div><div class="mepi">the sprawl</div></div><div class="mno">03/12</div></div><div class="pills"><i style="background:#00a23f">2</i><i style="background:#ed6c00">3</i><i style="background:#009bce">4</i><i style="background:#794698">5</i><i style="background:#7c4932">6</i><i style="background:#6e7e31">7</i><i style="background:#d11d70">8</i><i style="background:#a49d87">9</i></div><div class="gblock"><div class="grow"><span class="rk">3rd</span><span class="gl">opened</span><span class="track"><i style="left:0%"></i></span><span class="gv">1974</span></div><div class="grow"><span class="rk">3rd</span><span class="gl">lines</span><span class="track"><i style="left:0%"></i></span><span class="gv">8 (2–9)</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">stations</span><span class="track"><i style="left:100%"></i></span><span class="gv">607</span></div><div class="grow hot"><span class="rk rk1">1st</span><span class="gl">span</span><span class="track"><i style="left:100%"></i></span><span class="gv">57.7 km</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">route-km</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">ridership</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3</div></div><div class="bcenter"><div class="bround">ROUND 3 · YOU PICKED SPAN</div><div class="bcall">SEOUL TAKES THE ROUND</div><div class="bnums">57.7 km vs 24.1 km</div><div class="bscore">you 2 · cpu 1 · first to 3</div></div><div class="mcard tD"><div class="mtop"><div><div class="mname">paris</div><div class="mepi">the mesh</div></div><div class="mno">09/12</div></div><div class="pills"><i style="background:#ffbe00">1</i><i style="background:#0055c8">2</i><i style="background:#6e6e00">3</i><i style="background:#a0006e">4</i><i style="background:#ff7f32">5</i><i style="background:#82dc73">6</i><i style="background:#ff82b4">7</i><i style="background:#d282be">8</i><i style="background:#b6bd00">9</i><i style="background:#dc9600">10</i><i style="background:#6e491e">11</i><i style="background:#00643c">12</i><i style="background:#82c8e6">13</i><i style="background:#640082">14</i><i style="background:#82c8e6">3bis</i><i style="background:#82dc73">7bis</i></div><div class="gblock"><div class="grow"><span class="rk rk1">1st</span><span class="gl">opened</span><span class="track"><i style="left:100%"></i></span><span class="gv">1900</span></div><div class="grow"><span class="rk rk1">1st</span><span class="gl">lines</span><span class="track"><i style="left:100%"></i></span><span class="gv">16</span></div><div class="grow"><span class="rk">2nd</span><span class="gl">stations</span><span class="track"><i style="left:51%"></i></span><span class="gv">501</span></div><div class="grow hot"><span class="rk">3rd</span><span class="gl">span</span><span class="track"><i style="left:0%"></i></span><span class="gv">24.1 km</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">route-km</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div><div class="grow pipe"><span class="rk rkp">···</span><span class="gl">ridership</span><span class="track"></span><span class="gv gvp">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3</div></div></div>
+<div class="daily"><span class="dpill">cairo</span><span class="dvs">vs</span>
+<span class="dpill">singapore</span><span class="dtext"><b>the daily:</b>
+which plots more stations? One guess a day, keep the streak.</span></div>
+<footer><span>stats © OpenStreetMap contributors · ODbL · OSM snapshot
+2026-06-11 · ranks and tracks: live deck of three, full deck at pipeline
+· lore-side diagram credited on card · opened years: operator histories,
+dated sourcing at pipeline</span>
+<span>made by ajin.im</span></footer>
+</div></body></html>


### PR DESCRIPTION
## What

Owner verdict on the D18 v2 board: **premise passed** ("i like it"), one amendment: a black or other dark background might be better.

- **D19 appended to DECISIONS.md (RATIFIED, owner-directed)**: premise gate passed, archive branch dead; the dark amendment opens one fork, built as an exhibit since "background" can mean the table or the card face.
- **Gate artifact**: `_scripts/world_metros/mocks/card-dark-board.html` (`build_card_dark_board.py`, static, no JS): the same Seoul card three ways on ground swatches (A white-on-light reference, B white card on dark table, C dark card on dark table: the recommendation), then the fan, the flip (lore back + deck back) and the battle restaged in C. Cool ink-family palette, not the site's warm house dark.
- **Commissioned follow-through** (the premise gate passing triggers it per STATUS): BUILD-SPEC.md rewritten as the metro-cards contract (North-Star, DECK/BATTLE/DAILY/METHOD surfaces, D18 card grammar, six stats with fixed win directions, OUT list, gates, acceptance). README and repo CLAUDE.md stanzas updated off the stale "no page exists yet" atlas framing.
- STATUS gate flipped to the D19 A/B/C pick. Live-page rebuild starts after the pick.

No live-page, publish.sh, sitemap, or hub changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)