### PR TITLE
building: world-metros D20 stat-list proposal + three row-design variants (C locked)

### DIFF
--- a/_scripts/world_metros/BUILD-SPEC.md
+++ b/_scripts/world_metros/BUILD-SPEC.md
@@ -57,9 +57,12 @@ game. Trading cards with footnotes.
 | route-km | reported, dated, sourced (almanac grade) | more |
 | ridership | reported annual, dated, sourced (almanac grade) | more |
 
-Ranks and track positions are computed across the full deck of 12 at pipeline
-stage (the mocks footnote "live deck of 3" until then); win directions are
-fixed above and explained on Method. Interchange share remains a candidate
+D20 proposes swapping `lines` for `density` (stations per km² of network
+extent; more wins): the pills already carry line count, and density restores
+winner spread. Pending owner confirm at the D20 gate; the table updates on
+ratification. Ranks and track positions are computed across the full deck of
+12 at pipeline stage (the mocks footnote "live deck of 3" until then); win
+directions are fixed above and explained on Method. Interchange share remains a candidate
 seventh stat if the pipeline resolves it cleanly per the lens definition.
 Missing evidence renders **Unknown** and excludes that stat from battles for
 that card; never shown as zero.

--- a/_scripts/world_metros/DECISIONS.md
+++ b/_scripts/world_metros/DECISIONS.md
@@ -355,3 +355,39 @@ Gate artifact: `mocks/card-dark-board.html` (the three-way ground fork on
 swatches, then the fan / flip / battle restaged in the recommended dark
 treatment). Owner pick A / B / C settles the ground before the live-page
 rebuild; naming ("metro match", working) stays open.
+*Resolution (2026-06-12):* owner picked **C** ("i meant c"): dark card, dark
+table. The ground is settled.
+
+**D20 · Stat-list review + row-design variants — RATIFIED 2026-06-12
+(owner-directed at the D19 pick: confirm the comparison items are optimal,
+content AND design; big letters, legible, strong brand identity, board-game
+card look; multiple mock versions welcomed).**
+- **Content (PROPOSED, owner to confirm): swap `lines` for `density`.**
+  The current six (opened, lines, stations, span, route-km, ridership) carry
+  three size-correlated stats; big systems would sweep them, which is poor
+  Top-Trumps balance. `lines` is also already ON the card: the pills carry
+  every ref, so the row spends a slot restating the most visible device.
+  `density` (stations per km² of network extent; bbox basis in mocks, hull
+  basis at pipeline, defined on Method) is computed from data we already
+  hold, is orthogonal to size, and gives Paris its epithet stat: the mesh
+  becomes playable. Proposed six: **opened · stations · span · density ·
+  route-km · ridership**. Live-deck winner spread improves (Seoul: stations
+  + span; Paris: opened + density; full deck projects route-km/ridership to
+  the Shanghai class and opened to London: five-plus distinct winners across
+  six stats). Line count stays visible via the pills and the lore back.
+- **Design: three stat-presentation variants, all in treatment C,** judged
+  by eye on one board (`mocks/card-row-variants-board.html`), each shown as
+  the full three-city fan. Shared across variants: bigger name (20px),
+  bigger pills, the C palette, provenance foot. The variants differ ONLY in
+  how the six stats present:
+  - **V1 · BIG LEDGER** — six rows, jumbo numerals (19px), rank tag + label
+    left, value right; the strength tracks are dropped (the rank tag alone
+    carries relative strength). Maximum legibility.
+  - **V2 · STAT TILES** — a 2×3 grid of tiles, value on top, label under,
+    rank chip in the corner. The board-game player-mat look.
+  - **V3 · HERO STAT** — the city's signature stat blown up as the card's
+    hero number (epithet-aligned: Seoul span, Paris density; Tokyo shows the
+    variant's honest weakness: no crown in the live deck, hero falls back to
+    its best rank), five compact rows below.
+- Gate: owner picks V1 / V2 / V3 (or elements to merge) AND confirms or
+  vetoes the lines→density swap. Then the live-page rebuild starts.

--- a/_scripts/world_metros/STATUS.md
+++ b/_scripts/world_metros/STATUS.md
@@ -90,15 +90,24 @@ _Last updated: 2026-06-12 (Claude session, branch `worktree-metro-cards-d17`)._
   the same session: BUILD-SPEC.md rewritten around the D17 North-Star + D18
   card grammar; README first paragraph updated to the card vision.
 
-## Current gate: owner pick on the D19 ground fork (A / B / C)
+- D19 ground fork resolved (2026-06-12): owner picked **C**, dark card on
+  dark table. Owner then asked to confirm the comparison items (content and
+  design): big letters, legible, strong brand identity, board-game card
+  look, multiple versions welcome. Recorded as **D20**: stat-list review
+  (PROPOSED: swap `lines` for `density`; pills already carry line count;
+  winner spread improves; Paris's mesh becomes playable) + three
+  stat-presentation variants in treatment C.
 
-The gate artifact is `mocks/card-dark-board.html`: the same Seoul card three
-ways on ground swatches (A white-on-light reference, B white card on a dark
-table, C dark card on a dark table: the recommendation), then the fan, the
-flip and the battle restaged in the recommended dark treatment. The pick
-settles the visual ground before the live-page rebuild.
+## Current gate: owner verdict on the D20 board (variant pick + stat-list confirm)
 
-## Next exact action (after the D19 ground pick)
+The gate artifact is `mocks/card-row-variants-board.html`: the proposed
+stat-list strip (was / proposed / why), then each variant as the full
+three-city fan in treatment C: V1 BIG LEDGER (jumbo numerals, no tracks),
+V2 STAT TILES (2×3 player-mat grid), V3 HERO STAT (signature number +
+compact rows). Owner picks a variant (or elements to merge) and confirms or
+vetoes the lines→density swap.
+
+## Next exact action (after the D20 pick)
 
 Rebuild the live page as the card deck in the picked ground: THE DECK
 (12-card collection, flip cards), THE BATTLE (vs cpu, pick-a-stat, first to

--- a/_scripts/world_metros/mocks/build_card_row_variants_board.py
+++ b/_scripts/world_metros/mocks/build_card_row_variants_board.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Metro-cards D20 board: stat-list confirm + three row-design variants.
+
+Owner picked treatment C at D19, then asked to confirm the comparison items
+(content and design): big letters, legible, strong brand identity, a real
+board-game card look, multiple versions welcome.
+
+  0. THE STAT LIST: was / proposed / why (D20 content proposal: swap
+     `lines` for `density`; the pills already carry line count; winner
+     spread improves; Paris's mesh becomes playable).
+  1. V1 · BIG LEDGER: six rows, jumbo numerals, rank tag + label left,
+     value right, no tracks. Maximum legibility.
+  2. V2 · STAT TILES: a 2x3 player-mat grid, value on top, label under,
+     rank chip in the corner.
+  3. V3 · HERO STAT: the city's signature stat blown up (epithet-aligned),
+     five compact rows below. Tokyo shows the variant's honest weakness:
+     no crown in the live deck of three.
+
+All variants share treatment C (D19), a bigger name (20px), bigger pills,
+and the provenance foot. Static, no JS, nothing fetched; stats from the
+committed meta.json (density = stations / bbox km², hull basis at pipeline).
+Writes card-row-variants-board.html next to this file.
+
+Usage:
+    python3 _scripts/world_metros/mocks/build_card_row_variants_board.py
+"""
+
+import json
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
+ASSETS = os.path.join(REPO, "is", "building", "world-metros", "assets")
+
+LIVE = ("seoul", "paris", "tokyo")
+DECK_NO = {"tokyo": "02", "seoul": "03", "paris": "09"}
+OPENED = {"seoul": 1974, "paris": 1900, "tokyo": 1927}
+EPITHET = {"seoul": "the sprawl", "paris": "the mesh", "tokyo": "the two crews"}
+HERO_STAT = {"seoul": "span", "paris": "density", "tokyo": "opened"}
+
+ORDINAL = {1: "1st", 2: "2nd", 3: "3rd"}
+
+
+def load_meta():
+    return json.load(open(os.path.join(ASSETS, "meta.json")))
+
+
+def stat_defs(meta):
+    """The PROPOSED six (D20). value, unit, strength (higher = stronger)."""
+    c = meta["cities"]
+
+    def dens(k):
+        d = c[k]
+        return d["stations"] / (d["w_km"] * d["h_km"])
+
+    return [
+        ("opened", {k: str(OPENED[k]) for k in LIVE}, "",
+         {k: -OPENED[k] for k in LIVE}),
+        ("stations", {k: str(c[k]["stations"]) for k in LIVE}, "",
+         {k: c[k]["stations"] for k in LIVE}),
+        ("span", {k: f'{c[k]["span_km"]:.1f}' for k in LIVE}, "km",
+         {k: c[k]["span_km"] for k in LIVE}),
+        ("density", {k: f"{dens(k):.2f}" for k in LIVE}, "st/km²",
+         {k: dens(k) for k in LIVE}),
+    ]
+
+
+def ranks_for(meta, city):
+    out = {}
+    for key, values, unit, strength in stat_defs(meta):
+        sts = sorted(strength.values(), reverse=True)
+        out[key] = (ORDINAL[sts.index(strength[city]) + 1],
+                    values[city], unit,
+                    sts.index(strength[city]) + 1)
+    return out
+
+
+def pills(meta, city):
+    segs = "".join(f'<i style="background:{l["color"]}">{l["ref"]}</i>'
+                   for l in meta["cities"][city]["lines"])
+    return f'<div class="pills">{segs}</div>'
+
+
+def head(meta, city):
+    return (f'<div class="mtop"><div><div class="mname">{city}</div>'
+            f'<div class="mepi">{EPITHET[city]}</div></div>'
+            f'<div class="mno">{DECK_NO[city]}/12</div></div>'
+            f'{pills(meta, city)}')
+
+
+def foot(meta):
+    return (f'<div class="mfoot">data: OSM snapshot {meta["as_of"]} · ODbL · '
+            f'ranks: live deck of {len(LIVE)} · density: bbox basis</div>')
+
+
+def chip(rank_ord, rank_n, extra=""):
+    cls = "rk rk1" if rank_n == 1 else "rk"
+    return f'<span class="{cls}{extra}">{rank_ord}</span>'
+
+
+def card_v1(meta, city):
+    r = ranks_for(meta, city)
+    rows = []
+    for key in ("opened", "stations", "span", "density"):
+        o, v, u, n = r[key]
+        unit = f"<small> {u}</small>" if u else ""
+        rows.append(f'<div class="v1row">{chip(o, n)}'
+                    f'<span class="v1lab">{key}</span>'
+                    f'<span class="v1val">{v}{unit}</span></div>')
+    for key in ("route-km", "ridership"):
+        rows.append(f'<div class="v1row pipe"><span class="rk rkp">···</span>'
+                    f'<span class="v1lab">{key}</span>'
+                    f'<span class="v1pipe">pipeline · dated</span></div>')
+    return (f'<div class="mcard">{head(meta, city)}'
+            f'<div class="v1block">{"".join(rows)}</div>{foot(meta)}</div>')
+
+
+def card_v2(meta, city):
+    r = ranks_for(meta, city)
+    tiles = []
+    for key in ("opened", "stations", "span", "density"):
+        o, v, u, n = r[key]
+        unit = f"<small> {u}</small>" if u else ""
+        tiles.append(f'<div class="tile">{chip(o, n, " tchip")}'
+                     f'<div class="tval">{v}{unit}</div>'
+                     f'<div class="tlab">{key}</div></div>')
+    for key in ("route-km", "ridership"):
+        tiles.append(f'<div class="tile pipe">'
+                     f'<span class="rk rkp tchip">···</span>'
+                     f'<div class="tval tvp">soon</div>'
+                     f'<div class="tlab">{key}</div></div>')
+    return (f'<div class="mcard">{head(meta, city)}'
+            f'<div class="tiles">{"".join(tiles)}</div>{foot(meta)}</div>')
+
+
+def card_v3(meta, city):
+    r = ranks_for(meta, city)
+    hk = HERO_STAT[city]
+    ho, hv, hu, hn = r[hk]
+    hunit = f"<small> {hu}</small>" if hu else ""
+    hero = (f'<div class="hero">{chip(ho, hn, " hchip")}'
+            f'<div class="hval">{hv}{hunit}</div>'
+            f'<div class="hlab">{hk}</div></div>')
+    rows = []
+    for key in ("opened", "stations", "span", "density"):
+        if key == hk:
+            continue
+        o, v, u, n = r[key]
+        unit = f" {u}" if u else ""
+        rows.append(f'<div class="v3row">{chip(o, n)}'
+                    f'<span class="v3lab">{key}</span>'
+                    f'<span class="v3val">{v}{unit}</span></div>')
+    for key in ("route-km", "ridership"):
+        rows.append(f'<div class="v3row pipe"><span class="rk rkp">···</span>'
+                    f'<span class="v3lab">{key}</span>'
+                    f'<span class="v3pipe">pipeline · dated</span></div>')
+    return (f'<div class="mcard">{head(meta, city)}{hero}'
+            f'<div class="v3block">{"".join(rows)}</div>{foot(meta)}</div>')
+
+
+CSS = """
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap');
+* { margin:0; padding:0; box-sizing:border-box; }
+body { background:#0a0a0d; color:#e8e8e3; display:flex; align-items:flex-start;
+       justify-content:center; min-height:100vh; padding:24px 0;
+       font-family:-apple-system,'Helvetica Neue','Segoe UI',Arial,sans-serif; }
+.board { width:1280px; background:#131318; outline:1px solid #26262c;
+         box-shadow:0 1px 18px rgba(0,0,0,.6); }
+header { display:flex; align-items:baseline; gap:20px; padding:14px 22px 11px;
+         border-bottom:1px solid #26262c; background:#15151a; }
+.wordmark { font-size:15px; font-weight:700; letter-spacing:.24em;
+            color:#f2f2ee; }
+.wordmark em { font-style:normal; color:#7fb0e8; }
+.mockbadge { margin-left:auto; font-family:'DM Mono',monospace; font-size:9px;
+             letter-spacing:.14em; color:#e08040; border:1px solid #e0804066;
+             padding:3px 7px; border-radius:2px; white-space:nowrap; }
+.intro { padding:9px 22px; font-size:11px; color:#8a8a85; background:#15151a;
+         border-bottom:1px solid #26262c; line-height:1.5; }
+.intro b { color:#e8e8e3; font-weight:600; }
+.seclabel { padding:16px 22px 10px; font-family:'DM Mono',monospace;
+            font-size:10px; letter-spacing:.2em; color:#7fb0e8; }
+.row { display:flex; gap:26px; justify-content:center; align-items:flex-start;
+       padding:6px 22px 10px; }
+.cap { font-family:'DM Mono',monospace; font-size:8.5px; color:#8a8a85;
+       letter-spacing:.1em; text-align:center; line-height:1.6;
+       padding:0 22px 6px; }
+.cap b { color:#e8e8e3; font-weight:700; }
+
+.statlist { display:flex; gap:26px; margin:4px 22px 6px; padding:13px 18px;
+            background:#15151a; border:1px solid #26262c; font-size:11px;
+            line-height:1.6; }
+.statlist .col { flex:1; }
+.statlist .k { font-family:'DM Mono',monospace; font-size:8px;
+               letter-spacing:.18em; color:#7fb0e8; text-transform:uppercase;
+               display:block; margin-bottom:4px; }
+.statlist .was { color:#8a8a85; }
+.statlist .now { color:#e8e8e3; font-weight:600; }
+.statlist .why { color:#8a8a85; font-size:10.5px; }
+.statlist .out { text-decoration:line-through; color:#55555e; }
+.statlist .in { color:#7fb0e8; font-weight:700; }
+
+.mcard { width:270px; height:392px; border-radius:12px; padding:16px 14px 11px;
+         display:flex; flex-direction:column; flex:none; overflow:hidden;
+         position:relative; background:#1b1b21; border:1px solid #32323a;
+         box-shadow:0 4px 16px rgba(0,0,0,.55); color:#f2f2ee; }
+.mtop { display:flex; justify-content:space-between; align-items:flex-start;
+        gap:8px; }
+.mname { font-size:20px; font-weight:800; letter-spacing:.08em;
+         text-transform:uppercase; }
+.mepi { font-family:'DM Mono',monospace; font-size:8.5px; letter-spacing:.22em;
+        color:#7fb0e8; text-transform:uppercase; margin-top:4px; }
+.mno { font-family:'DM Mono',monospace; font-size:9px; color:#8a8a85;
+       padding-top:4px; }
+.pills { display:flex; flex-wrap:wrap; gap:4px; margin-top:12px;
+         min-height:18px; }
+.pills i { font-style:normal; font-family:'DM Mono',monospace; font-size:9px;
+           font-weight:500; color:#fff; padding:2.5px 7px; border-radius:999px;
+           letter-spacing:.02em; }
+.rk { font-family:'DM Mono',monospace; font-size:7px; letter-spacing:.08em;
+      text-transform:uppercase; text-align:center; border-radius:999px;
+      padding:2.5px 0; width:34px; border:1px solid #43434c; color:#9a9a94;
+      flex:none; }
+.rk1 { background:#0052a4; border-color:#0052a4; color:#fff; font-weight:500; }
+.rkp { border-style:dashed; border-color:#3a3a42; color:#55555e; }
+.mfoot { margin-top:auto; font-family:'DM Mono',monospace; font-size:6.5px;
+         color:#5e5e66; line-height:1.5; padding-top:8px; }
+
+/* V1 big ledger */
+.v1block { margin-top:13px; border-top:1px solid #32323a; }
+.v1row { display:flex; align-items:center; gap:9px; padding:9px 1px;
+         border-bottom:1px solid #232329; }
+.v1lab { font-family:'DM Mono',monospace; font-size:8.5px;
+         letter-spacing:.14em; color:#8a8a85; text-transform:uppercase; }
+.v1val { margin-left:auto; font-family:'DM Mono',monospace; font-size:19px;
+         font-weight:500; letter-spacing:-.01em; white-space:nowrap; }
+.v1val small { font-size:9px; color:#8a8a85; letter-spacing:.06em; }
+.v1pipe { margin-left:auto; font-family:'DM Mono',monospace; font-size:7px;
+          color:#55555e; }
+.v1row.pipe .v1lab { color:#4a4a52; }
+
+/* V2 stat tiles */
+.tiles { margin-top:13px; display:grid; grid-template-columns:1fr 1fr;
+         gap:8px; }
+.tile { position:relative; background:#1f1f26; border:1px solid #2c2c34;
+        border-radius:8px; padding:12px 10px 9px; }
+.tile .tchip { position:absolute; top:7px; right:7px; width:30px;
+               font-size:6.5px; padding:2px 0; }
+.tval { font-family:'DM Mono',monospace; font-size:18px; font-weight:500;
+        margin-top:6px; white-space:nowrap; }
+.tval small { font-size:8.5px; color:#8a8a85; letter-spacing:.06em; }
+.tval.tvp { color:#55555e; font-size:12px; }
+.tlab { font-family:'DM Mono',monospace; font-size:7px; letter-spacing:.14em;
+        color:#8a8a85; text-transform:uppercase; margin-top:4px; }
+.tile.pipe { border-style:dashed; background:transparent; }
+.tile.pipe .tlab { color:#4a4a52; }
+
+/* V3 hero stat */
+.hero { margin-top:13px; border:1px solid #32323a; border-radius:8px;
+        background:#1f1f26; padding:13px 12px 11px; position:relative; }
+.hero .hchip { position:absolute; top:9px; right:9px; }
+.hval { font-family:'DM Mono',monospace; font-size:30px; font-weight:500;
+        letter-spacing:-.02em; line-height:1; }
+.hval small { font-size:11px; color:#8a8a85; letter-spacing:.06em; }
+.hlab { font-family:'DM Mono',monospace; font-size:8px; letter-spacing:.2em;
+        color:#7fb0e8; text-transform:uppercase; margin-top:6px; }
+.v3block { margin-top:9px; }
+.v3row { display:flex; align-items:center; gap:9px; padding:6.5px 1px;
+         border-bottom:1px solid #232329; }
+.v3lab { font-family:'DM Mono',monospace; font-size:7.5px;
+         letter-spacing:.12em; color:#8a8a85; text-transform:uppercase; }
+.v3val { margin-left:auto; font-family:'DM Mono',monospace; font-size:12px;
+         font-weight:500; white-space:nowrap; }
+.v3pipe { margin-left:auto; font-family:'DM Mono',monospace; font-size:7px;
+          color:#55555e; }
+.v3row.pipe .v3lab { color:#4a4a52; }
+
+footer { display:flex; justify-content:space-between; gap:20px;
+         padding:9px 22px; border-top:1px solid #26262c; margin-top:16px;
+         font-family:'DM Mono',monospace; font-size:9px; color:#8a8a85;
+         background:#15151a; }
+"""
+
+
+def main():
+    meta = load_meta()
+
+    statlist = (
+        '<div class="statlist">'
+        '<div class="col"><span class="k">was</span><span class="was">'
+        'opened · <span class="out">lines</span> · stations · span · '
+        'route-km · ridership</span></div>'
+        '<div class="col"><span class="k">proposed (D20)</span>'
+        '<span class="now">opened · stations · span · '
+        '<span class="in">density</span> · route-km · ridership</span></div>'
+        '<div class="col" style="flex:1.6"><span class="k">why</span>'
+        '<span class="why">three size stats let big systems sweep; the pills '
+        'already show every line, so the row restated the card’s most visible '
+        'device. Density is computed from data in hand, restores winner '
+        'spread, and makes Paris’s mesh playable.</span></div></div>')
+
+    v1 = "".join(card_v1(meta, c) for c in LIVE)
+    v2 = "".join(card_v2(meta, c) for c in LIVE)
+    v3 = "".join(card_v3(meta, c) for c in LIVE)
+
+    html = f"""<!doctype html><html><head><meta charset="utf-8">
+<title>world-metros mock: card stat variants (D20)</title>
+<style>{CSS}</style></head><body><div class="board">
+<header><div class="wordmark">WORLD METROS <em>ATLAS</em></div>
+<span class="mockbadge">STAT VARIANTS · D20 · APPROVAL ARTIFACT</span></header>
+<div class="intro"><b>the D20 question:</b> ground C is settled; are the
+comparison items optimal, and how should they present? One content proposal
+(the strip below) and three presentations of the same card, big letters
+first. Pick a variant or name elements to merge; confirm or veto the stat
+swap.</div>
+<div class="seclabel">THE STAT LIST · ONE SWAP PROPOSED</div>
+{statlist}
+<div class="seclabel">V1 · BIG LEDGER · JUMBO NUMERALS, NO TRACKS</div>
+<div class="row">{v1}</div>
+<div class="cap"><b>V1</b> maximum legibility · the rank tag alone carries
+relative strength · quietest of the three</div>
+<div class="seclabel">V2 · STAT TILES · THE PLAYER-MAT GRID</div>
+<div class="row">{v2}</div>
+<div class="cap"><b>V2</b> most board-game · tiles give every stat equal
+weight · pipeline tiles read as empty slots waiting to fill</div>
+<div class="seclabel">V3 · HERO STAT · THE SIGNATURE NUMBER</div>
+<div class="row">{v3}</div>
+<div class="cap"><b>V3</b> strongest per-card identity (epithet-aligned hero)
+· honest weakness shown: Tokyo holds no crown in the live deck of three, so
+its hero falls back to its best rank</div>
+<footer><span>stats © OpenStreetMap contributors · ODbL · OSM snapshot
+{meta["as_of"]} · ranks: live deck of three, full deck at pipeline · density:
+bbox basis in mocks, hull basis at pipeline · opened years: operator
+histories, dated sourcing at pipeline</span>
+<span>made by ajin.im</span></footer>
+</div></body></html>"""
+    out = os.path.join(HERE, "card-row-variants-board.html")
+    with open(out, "w") as fh:
+        fh.write(html)
+    print(f"wrote {out}  ({os.path.getsize(out) / 1024:.0f} KB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/_scripts/world_metros/mocks/card-row-variants-board.html
+++ b/_scripts/world_metros/mocks/card-row-variants-board.html
@@ -1,0 +1,151 @@
+<!doctype html><html><head><meta charset="utf-8">
+<title>world-metros mock: card stat variants (D20)</title>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap');
+* { margin:0; padding:0; box-sizing:border-box; }
+body { background:#0a0a0d; color:#e8e8e3; display:flex; align-items:flex-start;
+       justify-content:center; min-height:100vh; padding:24px 0;
+       font-family:-apple-system,'Helvetica Neue','Segoe UI',Arial,sans-serif; }
+.board { width:1280px; background:#131318; outline:1px solid #26262c;
+         box-shadow:0 1px 18px rgba(0,0,0,.6); }
+header { display:flex; align-items:baseline; gap:20px; padding:14px 22px 11px;
+         border-bottom:1px solid #26262c; background:#15151a; }
+.wordmark { font-size:15px; font-weight:700; letter-spacing:.24em;
+            color:#f2f2ee; }
+.wordmark em { font-style:normal; color:#7fb0e8; }
+.mockbadge { margin-left:auto; font-family:'DM Mono',monospace; font-size:9px;
+             letter-spacing:.14em; color:#e08040; border:1px solid #e0804066;
+             padding:3px 7px; border-radius:2px; white-space:nowrap; }
+.intro { padding:9px 22px; font-size:11px; color:#8a8a85; background:#15151a;
+         border-bottom:1px solid #26262c; line-height:1.5; }
+.intro b { color:#e8e8e3; font-weight:600; }
+.seclabel { padding:16px 22px 10px; font-family:'DM Mono',monospace;
+            font-size:10px; letter-spacing:.2em; color:#7fb0e8; }
+.row { display:flex; gap:26px; justify-content:center; align-items:flex-start;
+       padding:6px 22px 10px; }
+.cap { font-family:'DM Mono',monospace; font-size:8.5px; color:#8a8a85;
+       letter-spacing:.1em; text-align:center; line-height:1.6;
+       padding:0 22px 6px; }
+.cap b { color:#e8e8e3; font-weight:700; }
+
+.statlist { display:flex; gap:26px; margin:4px 22px 6px; padding:13px 18px;
+            background:#15151a; border:1px solid #26262c; font-size:11px;
+            line-height:1.6; }
+.statlist .col { flex:1; }
+.statlist .k { font-family:'DM Mono',monospace; font-size:8px;
+               letter-spacing:.18em; color:#7fb0e8; text-transform:uppercase;
+               display:block; margin-bottom:4px; }
+.statlist .was { color:#8a8a85; }
+.statlist .now { color:#e8e8e3; font-weight:600; }
+.statlist .why { color:#8a8a85; font-size:10.5px; }
+.statlist .out { text-decoration:line-through; color:#55555e; }
+.statlist .in { color:#7fb0e8; font-weight:700; }
+
+.mcard { width:270px; height:392px; border-radius:12px; padding:16px 14px 11px;
+         display:flex; flex-direction:column; flex:none; overflow:hidden;
+         position:relative; background:#1b1b21; border:1px solid #32323a;
+         box-shadow:0 4px 16px rgba(0,0,0,.55); color:#f2f2ee; }
+.mtop { display:flex; justify-content:space-between; align-items:flex-start;
+        gap:8px; }
+.mname { font-size:20px; font-weight:800; letter-spacing:.08em;
+         text-transform:uppercase; }
+.mepi { font-family:'DM Mono',monospace; font-size:8.5px; letter-spacing:.22em;
+        color:#7fb0e8; text-transform:uppercase; margin-top:4px; }
+.mno { font-family:'DM Mono',monospace; font-size:9px; color:#8a8a85;
+       padding-top:4px; }
+.pills { display:flex; flex-wrap:wrap; gap:4px; margin-top:12px;
+         min-height:18px; }
+.pills i { font-style:normal; font-family:'DM Mono',monospace; font-size:9px;
+           font-weight:500; color:#fff; padding:2.5px 7px; border-radius:999px;
+           letter-spacing:.02em; }
+.rk { font-family:'DM Mono',monospace; font-size:7px; letter-spacing:.08em;
+      text-transform:uppercase; text-align:center; border-radius:999px;
+      padding:2.5px 0; width:34px; border:1px solid #43434c; color:#9a9a94;
+      flex:none; }
+.rk1 { background:#0052a4; border-color:#0052a4; color:#fff; font-weight:500; }
+.rkp { border-style:dashed; border-color:#3a3a42; color:#55555e; }
+.mfoot { margin-top:auto; font-family:'DM Mono',monospace; font-size:6.5px;
+         color:#5e5e66; line-height:1.5; padding-top:8px; }
+
+/* V1 big ledger */
+.v1block { margin-top:13px; border-top:1px solid #32323a; }
+.v1row { display:flex; align-items:center; gap:9px; padding:9px 1px;
+         border-bottom:1px solid #232329; }
+.v1lab { font-family:'DM Mono',monospace; font-size:8.5px;
+         letter-spacing:.14em; color:#8a8a85; text-transform:uppercase; }
+.v1val { margin-left:auto; font-family:'DM Mono',monospace; font-size:19px;
+         font-weight:500; letter-spacing:-.01em; white-space:nowrap; }
+.v1val small { font-size:9px; color:#8a8a85; letter-spacing:.06em; }
+.v1pipe { margin-left:auto; font-family:'DM Mono',monospace; font-size:7px;
+          color:#55555e; }
+.v1row.pipe .v1lab { color:#4a4a52; }
+
+/* V2 stat tiles */
+.tiles { margin-top:13px; display:grid; grid-template-columns:1fr 1fr;
+         gap:8px; }
+.tile { position:relative; background:#1f1f26; border:1px solid #2c2c34;
+        border-radius:8px; padding:12px 10px 9px; }
+.tile .tchip { position:absolute; top:7px; right:7px; width:30px;
+               font-size:6.5px; padding:2px 0; }
+.tval { font-family:'DM Mono',monospace; font-size:18px; font-weight:500;
+        margin-top:6px; white-space:nowrap; }
+.tval small { font-size:8.5px; color:#8a8a85; letter-spacing:.06em; }
+.tval.tvp { color:#55555e; font-size:12px; }
+.tlab { font-family:'DM Mono',monospace; font-size:7px; letter-spacing:.14em;
+        color:#8a8a85; text-transform:uppercase; margin-top:4px; }
+.tile.pipe { border-style:dashed; background:transparent; }
+.tile.pipe .tlab { color:#4a4a52; }
+
+/* V3 hero stat */
+.hero { margin-top:13px; border:1px solid #32323a; border-radius:8px;
+        background:#1f1f26; padding:13px 12px 11px; position:relative; }
+.hero .hchip { position:absolute; top:9px; right:9px; }
+.hval { font-family:'DM Mono',monospace; font-size:30px; font-weight:500;
+        letter-spacing:-.02em; line-height:1; }
+.hval small { font-size:11px; color:#8a8a85; letter-spacing:.06em; }
+.hlab { font-family:'DM Mono',monospace; font-size:8px; letter-spacing:.2em;
+        color:#7fb0e8; text-transform:uppercase; margin-top:6px; }
+.v3block { margin-top:9px; }
+.v3row { display:flex; align-items:center; gap:9px; padding:6.5px 1px;
+         border-bottom:1px solid #232329; }
+.v3lab { font-family:'DM Mono',monospace; font-size:7.5px;
+         letter-spacing:.12em; color:#8a8a85; text-transform:uppercase; }
+.v3val { margin-left:auto; font-family:'DM Mono',monospace; font-size:12px;
+         font-weight:500; white-space:nowrap; }
+.v3pipe { margin-left:auto; font-family:'DM Mono',monospace; font-size:7px;
+          color:#55555e; }
+.v3row.pipe .v3lab { color:#4a4a52; }
+
+footer { display:flex; justify-content:space-between; gap:20px;
+         padding:9px 22px; border-top:1px solid #26262c; margin-top:16px;
+         font-family:'DM Mono',monospace; font-size:9px; color:#8a8a85;
+         background:#15151a; }
+</style></head><body><div class="board">
+<header><div class="wordmark">WORLD METROS <em>ATLAS</em></div>
+<span class="mockbadge">STAT VARIANTS · D20 · APPROVAL ARTIFACT</span></header>
+<div class="intro"><b>the D20 question:</b> ground C is settled; are the
+comparison items optimal, and how should they present? One content proposal
+(the strip below) and three presentations of the same card, big letters
+first. Pick a variant or name elements to merge; confirm or veto the stat
+swap.</div>
+<div class="seclabel">THE STAT LIST · ONE SWAP PROPOSED</div>
+<div class="statlist"><div class="col"><span class="k">was</span><span class="was">opened · <span class="out">lines</span> · stations · span · route-km · ridership</span></div><div class="col"><span class="k">proposed (D20)</span><span class="now">opened · stations · span · <span class="in">density</span> · route-km · ridership</span></div><div class="col" style="flex:1.6"><span class="k">why</span><span class="why">three size stats let big systems sweep; the pills already show every line, so the row restated the card’s most visible device. Density is computed from data in hand, restores winner spread, and makes Paris’s mesh playable.</span></div></div>
+<div class="seclabel">V1 · BIG LEDGER · JUMBO NUMERALS, NO TRACKS</div>
+<div class="row"><div class="mcard"><div class="mtop"><div><div class="mname">seoul</div><div class="mepi">the sprawl</div></div><div class="mno">03/12</div></div><div class="pills"><i style="background:#00a23f">2</i><i style="background:#ed6c00">3</i><i style="background:#009bce">4</i><i style="background:#794698">5</i><i style="background:#7c4932">6</i><i style="background:#6e7e31">7</i><i style="background:#d11d70">8</i><i style="background:#a49d87">9</i></div><div class="v1block"><div class="v1row"><span class="rk">3rd</span><span class="v1lab">opened</span><span class="v1val">1974</span></div><div class="v1row"><span class="rk rk1">1st</span><span class="v1lab">stations</span><span class="v1val">607</span></div><div class="v1row"><span class="rk rk1">1st</span><span class="v1lab">span</span><span class="v1val">57.7<small> km</small></span></div><div class="v1row"><span class="rk">3rd</span><span class="v1lab">density</span><span class="v1val">0.27<small> st/km²</small></span></div><div class="v1row pipe"><span class="rk rkp">···</span><span class="v1lab">route-km</span><span class="v1pipe">pipeline · dated</span></div><div class="v1row pipe"><span class="rk rkp">···</span><span class="v1lab">ridership</span><span class="v1pipe">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3 · density: bbox basis</div></div><div class="mcard"><div class="mtop"><div><div class="mname">paris</div><div class="mepi">the mesh</div></div><div class="mno">09/12</div></div><div class="pills"><i style="background:#ffbe00">1</i><i style="background:#0055c8">2</i><i style="background:#6e6e00">3</i><i style="background:#a0006e">4</i><i style="background:#ff7f32">5</i><i style="background:#82dc73">6</i><i style="background:#ff82b4">7</i><i style="background:#d282be">8</i><i style="background:#b6bd00">9</i><i style="background:#dc9600">10</i><i style="background:#6e491e">11</i><i style="background:#00643c">12</i><i style="background:#82c8e6">13</i><i style="background:#640082">14</i><i style="background:#82c8e6">3bis</i><i style="background:#82dc73">7bis</i></div><div class="v1block"><div class="v1row"><span class="rk rk1">1st</span><span class="v1lab">opened</span><span class="v1val">1900</span></div><div class="v1row"><span class="rk">2nd</span><span class="v1lab">stations</span><span class="v1val">501</span></div><div class="v1row"><span class="rk">3rd</span><span class="v1lab">span</span><span class="v1val">24.1<small> km</small></span></div><div class="v1row"><span class="rk rk1">1st</span><span class="v1lab">density</span><span class="v1val">1.12<small> st/km²</small></span></div><div class="v1row pipe"><span class="rk rkp">···</span><span class="v1lab">route-km</span><span class="v1pipe">pipeline · dated</span></div><div class="v1row pipe"><span class="rk rkp">···</span><span class="v1lab">ridership</span><span class="v1pipe">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3 · density: bbox basis</div></div><div class="mcard"><div class="mtop"><div><div class="mname">tokyo</div><div class="mepi">the two crews</div></div><div class="mno">02/12</div></div><div class="pills"><i style="background:#e85298">A</i><i style="background:#00bb85">C</i><i style="background:#b6007a">E</i><i style="background:#9c5e31">F</i><i style="background:#ff9500">G</i><i style="background:#b5b5ac">H</i><i style="background:#0079c2">I</i><i style="background:#f62e36">M</i><i style="background:#00ac9b">N</i><i style="background:#6cbb5a">S</i><i style="background:#009bbf">T</i><i style="background:#c1a470">Y</i><i style="background:#8f76d6">Z</i></div><div class="v1block"><div class="v1row"><span class="rk">2nd</span><span class="v1lab">opened</span><span class="v1val">1927</span></div><div class="v1row"><span class="rk">3rd</span><span class="v1lab">stations</span><span class="v1val">391</span></div><div class="v1row"><span class="rk">2nd</span><span class="v1lab">span</span><span class="v1val">32.6<small> km</small></span></div><div class="v1row"><span class="rk">2nd</span><span class="v1lab">density</span><span class="v1val">0.55<small> st/km²</small></span></div><div class="v1row pipe"><span class="rk rkp">···</span><span class="v1lab">route-km</span><span class="v1pipe">pipeline · dated</span></div><div class="v1row pipe"><span class="rk rkp">···</span><span class="v1lab">ridership</span><span class="v1pipe">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3 · density: bbox basis</div></div></div>
+<div class="cap"><b>V1</b> maximum legibility · the rank tag alone carries
+relative strength · quietest of the three</div>
+<div class="seclabel">V2 · STAT TILES · THE PLAYER-MAT GRID</div>
+<div class="row"><div class="mcard"><div class="mtop"><div><div class="mname">seoul</div><div class="mepi">the sprawl</div></div><div class="mno">03/12</div></div><div class="pills"><i style="background:#00a23f">2</i><i style="background:#ed6c00">3</i><i style="background:#009bce">4</i><i style="background:#794698">5</i><i style="background:#7c4932">6</i><i style="background:#6e7e31">7</i><i style="background:#d11d70">8</i><i style="background:#a49d87">9</i></div><div class="tiles"><div class="tile"><span class="rk tchip">3rd</span><div class="tval">1974</div><div class="tlab">opened</div></div><div class="tile"><span class="rk rk1 tchip">1st</span><div class="tval">607</div><div class="tlab">stations</div></div><div class="tile"><span class="rk rk1 tchip">1st</span><div class="tval">57.7<small> km</small></div><div class="tlab">span</div></div><div class="tile"><span class="rk tchip">3rd</span><div class="tval">0.27<small> st/km²</small></div><div class="tlab">density</div></div><div class="tile pipe"><span class="rk rkp tchip">···</span><div class="tval tvp">soon</div><div class="tlab">route-km</div></div><div class="tile pipe"><span class="rk rkp tchip">···</span><div class="tval tvp">soon</div><div class="tlab">ridership</div></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3 · density: bbox basis</div></div><div class="mcard"><div class="mtop"><div><div class="mname">paris</div><div class="mepi">the mesh</div></div><div class="mno">09/12</div></div><div class="pills"><i style="background:#ffbe00">1</i><i style="background:#0055c8">2</i><i style="background:#6e6e00">3</i><i style="background:#a0006e">4</i><i style="background:#ff7f32">5</i><i style="background:#82dc73">6</i><i style="background:#ff82b4">7</i><i style="background:#d282be">8</i><i style="background:#b6bd00">9</i><i style="background:#dc9600">10</i><i style="background:#6e491e">11</i><i style="background:#00643c">12</i><i style="background:#82c8e6">13</i><i style="background:#640082">14</i><i style="background:#82c8e6">3bis</i><i style="background:#82dc73">7bis</i></div><div class="tiles"><div class="tile"><span class="rk rk1 tchip">1st</span><div class="tval">1900</div><div class="tlab">opened</div></div><div class="tile"><span class="rk tchip">2nd</span><div class="tval">501</div><div class="tlab">stations</div></div><div class="tile"><span class="rk tchip">3rd</span><div class="tval">24.1<small> km</small></div><div class="tlab">span</div></div><div class="tile"><span class="rk rk1 tchip">1st</span><div class="tval">1.12<small> st/km²</small></div><div class="tlab">density</div></div><div class="tile pipe"><span class="rk rkp tchip">···</span><div class="tval tvp">soon</div><div class="tlab">route-km</div></div><div class="tile pipe"><span class="rk rkp tchip">···</span><div class="tval tvp">soon</div><div class="tlab">ridership</div></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3 · density: bbox basis</div></div><div class="mcard"><div class="mtop"><div><div class="mname">tokyo</div><div class="mepi">the two crews</div></div><div class="mno">02/12</div></div><div class="pills"><i style="background:#e85298">A</i><i style="background:#00bb85">C</i><i style="background:#b6007a">E</i><i style="background:#9c5e31">F</i><i style="background:#ff9500">G</i><i style="background:#b5b5ac">H</i><i style="background:#0079c2">I</i><i style="background:#f62e36">M</i><i style="background:#00ac9b">N</i><i style="background:#6cbb5a">S</i><i style="background:#009bbf">T</i><i style="background:#c1a470">Y</i><i style="background:#8f76d6">Z</i></div><div class="tiles"><div class="tile"><span class="rk tchip">2nd</span><div class="tval">1927</div><div class="tlab">opened</div></div><div class="tile"><span class="rk tchip">3rd</span><div class="tval">391</div><div class="tlab">stations</div></div><div class="tile"><span class="rk tchip">2nd</span><div class="tval">32.6<small> km</small></div><div class="tlab">span</div></div><div class="tile"><span class="rk tchip">2nd</span><div class="tval">0.55<small> st/km²</small></div><div class="tlab">density</div></div><div class="tile pipe"><span class="rk rkp tchip">···</span><div class="tval tvp">soon</div><div class="tlab">route-km</div></div><div class="tile pipe"><span class="rk rkp tchip">···</span><div class="tval tvp">soon</div><div class="tlab">ridership</div></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3 · density: bbox basis</div></div></div>
+<div class="cap"><b>V2</b> most board-game · tiles give every stat equal
+weight · pipeline tiles read as empty slots waiting to fill</div>
+<div class="seclabel">V3 · HERO STAT · THE SIGNATURE NUMBER</div>
+<div class="row"><div class="mcard"><div class="mtop"><div><div class="mname">seoul</div><div class="mepi">the sprawl</div></div><div class="mno">03/12</div></div><div class="pills"><i style="background:#00a23f">2</i><i style="background:#ed6c00">3</i><i style="background:#009bce">4</i><i style="background:#794698">5</i><i style="background:#7c4932">6</i><i style="background:#6e7e31">7</i><i style="background:#d11d70">8</i><i style="background:#a49d87">9</i></div><div class="hero"><span class="rk rk1 hchip">1st</span><div class="hval">57.7<small> km</small></div><div class="hlab">span</div></div><div class="v3block"><div class="v3row"><span class="rk">3rd</span><span class="v3lab">opened</span><span class="v3val">1974</span></div><div class="v3row"><span class="rk rk1">1st</span><span class="v3lab">stations</span><span class="v3val">607</span></div><div class="v3row"><span class="rk">3rd</span><span class="v3lab">density</span><span class="v3val">0.27 st/km²</span></div><div class="v3row pipe"><span class="rk rkp">···</span><span class="v3lab">route-km</span><span class="v3pipe">pipeline · dated</span></div><div class="v3row pipe"><span class="rk rkp">···</span><span class="v3lab">ridership</span><span class="v3pipe">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3 · density: bbox basis</div></div><div class="mcard"><div class="mtop"><div><div class="mname">paris</div><div class="mepi">the mesh</div></div><div class="mno">09/12</div></div><div class="pills"><i style="background:#ffbe00">1</i><i style="background:#0055c8">2</i><i style="background:#6e6e00">3</i><i style="background:#a0006e">4</i><i style="background:#ff7f32">5</i><i style="background:#82dc73">6</i><i style="background:#ff82b4">7</i><i style="background:#d282be">8</i><i style="background:#b6bd00">9</i><i style="background:#dc9600">10</i><i style="background:#6e491e">11</i><i style="background:#00643c">12</i><i style="background:#82c8e6">13</i><i style="background:#640082">14</i><i style="background:#82c8e6">3bis</i><i style="background:#82dc73">7bis</i></div><div class="hero"><span class="rk rk1 hchip">1st</span><div class="hval">1.12<small> st/km²</small></div><div class="hlab">density</div></div><div class="v3block"><div class="v3row"><span class="rk rk1">1st</span><span class="v3lab">opened</span><span class="v3val">1900</span></div><div class="v3row"><span class="rk">2nd</span><span class="v3lab">stations</span><span class="v3val">501</span></div><div class="v3row"><span class="rk">3rd</span><span class="v3lab">span</span><span class="v3val">24.1 km</span></div><div class="v3row pipe"><span class="rk rkp">···</span><span class="v3lab">route-km</span><span class="v3pipe">pipeline · dated</span></div><div class="v3row pipe"><span class="rk rkp">···</span><span class="v3lab">ridership</span><span class="v3pipe">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3 · density: bbox basis</div></div><div class="mcard"><div class="mtop"><div><div class="mname">tokyo</div><div class="mepi">the two crews</div></div><div class="mno">02/12</div></div><div class="pills"><i style="background:#e85298">A</i><i style="background:#00bb85">C</i><i style="background:#b6007a">E</i><i style="background:#9c5e31">F</i><i style="background:#ff9500">G</i><i style="background:#b5b5ac">H</i><i style="background:#0079c2">I</i><i style="background:#f62e36">M</i><i style="background:#00ac9b">N</i><i style="background:#6cbb5a">S</i><i style="background:#009bbf">T</i><i style="background:#c1a470">Y</i><i style="background:#8f76d6">Z</i></div><div class="hero"><span class="rk hchip">2nd</span><div class="hval">1927</div><div class="hlab">opened</div></div><div class="v3block"><div class="v3row"><span class="rk">3rd</span><span class="v3lab">stations</span><span class="v3val">391</span></div><div class="v3row"><span class="rk">2nd</span><span class="v3lab">span</span><span class="v3val">32.6 km</span></div><div class="v3row"><span class="rk">2nd</span><span class="v3lab">density</span><span class="v3val">0.55 st/km²</span></div><div class="v3row pipe"><span class="rk rkp">···</span><span class="v3lab">route-km</span><span class="v3pipe">pipeline · dated</span></div><div class="v3row pipe"><span class="rk rkp">···</span><span class="v3lab">ridership</span><span class="v3pipe">pipeline · dated</span></div></div><div class="mfoot">data: OSM snapshot 2026-06-11 · ODbL · ranks: live deck of 3 · density: bbox basis</div></div></div>
+<div class="cap"><b>V3</b> strongest per-card identity (epithet-aligned hero)
+· honest weakness shown: Tokyo holds no crown in the live deck of three, so
+its hero falls back to its best rank</div>
+<footer><span>stats © OpenStreetMap contributors · ODbL · OSM snapshot
+2026-06-11 · ranks: live deck of three, full deck at pipeline · density:
+bbox basis in mocks, hull basis at pipeline · opened years: operator
+histories, dated sourcing at pipeline</span>
+<span>made by ajin.im</span></footer>
+</div></body></html>


### PR DESCRIPTION
## What

Owner picked **C** (dark card, dark table) at the D19 gate, then asked: are the comparison items optimal (content AND design)? Big letters, legible, strong brand identity, board-game card look; multiple versions welcome.

- **D19 resolved** in DECISIONS.md (pick: C). **D20 appended**: stat-list review + row-design variants.
- **Content proposal (pending owner confirm)**: swap `lines` for `density` (stations per km², computed from data in hand). Three size-correlated stats let big systems sweep (poor Top-Trumps balance), and the pills already display every line ref. Density restores winner spread and makes Paris's mesh epithet playable. BUILD-SPEC carries the swap as pending.
- **Gate artifact**: `_scripts/world_metros/mocks/card-row-variants-board.html` (`build_card_row_variants_board.py`, static, no JS): the was/proposed/why strip, then each variant as the full three-city fan in treatment C with bigger name + pills:
  - **V1 BIG LEDGER**: jumbo numerals, rank tag + label left, no tracks.
  - **V2 STAT TILES**: 2×3 player-mat grid, pipeline stats as dashed empty slots.
  - **V3 HERO STAT**: epithet-aligned signature number (Seoul span, Paris density), five compact rows; Tokyo's no-crown weakness shown honestly.
- STATUS gate flipped to the D20 pick (variant + stat-swap confirm).

No live-page, publish.sh, sitemap, or hub changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)