### PR TITLE
building: world-metros D20 resolved (V1 ledger, density ratified)

### DIFF
--- a/_scripts/world_metros/BUILD-SPEC.md
+++ b/_scripts/world_metros/BUILD-SPEC.md
@@ -32,16 +32,22 @@ game. Trading cards with footnotes.
 - **Front (play side):** city name + epithet (the sprawl / the mesh / the two
   crews / …), deck number `NN/12` in roster order, line pills carrying the
   real refs in the operators' colours (the identity device, rendered purely
-  from OSM data), six stat rows — each with a deck-rank chip (1ST filled,
-  others hollow) and a normalized strength track — and a provenance footnote
-  naming the snapshot and the rank basis. NO map on the front.
+  from OSM data; compact above 12 lines) with a line-count + scope tag beside
+  them ("8 lines · 2–9 shown": pills never silently claim completeness), six
+  stat rows in the **V1 big-ledger presentation** (D20: bold near-white stat
+  label leading each row, jumbo mono value right, deck-rank chip 1ST filled /
+  others hollow; no strength tracks), and a provenance footnote naming the
+  snapshot and the rank basis. NO map on the front.
 - **Back (lore side):** the city's familiar Commons diagram full-bleed
   (DIAGRAM-LEDGER file, attribution verbatim, currency caveats where the
-  ledger flags them), name band, one flavor line. The D11 "map riders see"
+  ledger flags them), name band, one flavor line, and 2-3 curated "why it's
+  interesting" facts (the D2 profile-card content; evergreen, no
+  traveller-utility layer). The D11 "map riders see"
   obligation lives here.
 - **Deck back:** uniform pinstripes of every line colour in the deck under
   the wordmark band; serves as the opponent's hidden card in the battle.
-- **Ground:** dark (D19; exact treatment per the D19 board pick).
+- **Ground:** treatment C (D19, picked): ink-dark card `#1b1b21` on
+  near-black table `#0f0f12`; the line colours do the lighting.
 - **Trade dress:** our own card idiom in the official-map language (DM Mono
   data labels, hairline rules, transit-blue accent). No Pokémon / Top Trumps
   trade dress. No official map artwork anywhere.
@@ -51,16 +57,15 @@ game. Trading cards with footnotes.
 | stat | basis | wins |
 |---|---|---|
 | opened | earliest regular passenger service within declared scope (operator histories, dated) | earlier |
-| lines | customer-facing line identities, not service variants (DATA-CONTRACT) | more |
+| density | stations per km² of network extent (bbox in mocks, hull at pipeline) | more |
 | stations | station complexes plotted from the frozen snapshot | more |
 | span | furthest-stations geodesic distance, computed | more |
 | route-km | reported, dated, sourced (almanac grade) | more |
 | ridership | reported annual, dated, sourced (almanac grade) | more |
 
-D20 proposes swapping `lines` for `density` (stations per km² of network
-extent; more wins): the pills already carry line count, and density restores
-winner spread. Pending owner confirm at the D20 gate; the table updates on
-ratification. Ranks and track positions are computed across the full deck of
+The lines→density swap is D20-ratified (the pills + a header count tag
+carry line identity; density restores winner spread and makes the mesh
+playable). Ranks and track positions are computed across the full deck of
 12 at pipeline stage (the mocks footnote "live deck of 3" until then); win
 directions are fixed above and explained on Method. Interchange share remains a candidate
 seventh stat if the pipeline resolves it cleanly per the lens definition.
@@ -80,7 +85,8 @@ that card; never shown as zero.
 
 ## Approval gates (in order)
 
-1. **D19 ground pick** (A / B / C board) — settles the visual ground.
+1. **D19 ground pick** — DONE (C: dark card, dark table) + **D20** — DONE
+   (V1 big ledger; density swap ratified).
 2. **Live-page rebuild** of `/is/building/world-metros/` as DECK + BATTLE +
    DAILY + METHOD with the three live cities real, nine cards "soon". Owner
    verdict on the live page.

--- a/_scripts/world_metros/DECISIONS.md
+++ b/_scripts/world_metros/DECISIONS.md
@@ -400,3 +400,15 @@ pill compaction above 12 lines (every ref kept, no overflow hiding), V2 rank
 chip to tile bottom-right, dashed treatment so pending rows read as slots not
 broken data, quieter deck number. Rejected: re-dimming labels (contradicts
 the owner's flag; game hierarchy wants stat names scannable first).
+*Resolution (2026-06-12):* owner picked **V1 (big ledger)**; the
+lines→density swap is confirmed (owner: line info should live somewhere, but
+not at stat level, that would be redundant). Ratified defaults for the
+rebuild: line count as header metadata beside the pills ("8 lines · 2–9
+shown"), a scope tag so pills never silently claim completeness, and 2-3
+curated "why it's interesting" facts on the lore back (the D2 profile-card
+content finds its home; the traveller-utility layer stays out, D2 holds).
+Still open: per-city declared scope (A operator-proper vs B rider-scope, rec
+B: each card covers the network its own familiar map draws; owner flagged
+Seoul's missing lines), due before roster scale-up, recorded on Method when
+decided. Naming ("metro match") still the owner's call before wide ship.
+Next gate artifact: the live page rebuilt as the deck.

--- a/_scripts/world_metros/STATUS.md
+++ b/_scripts/world_metros/STATUS.md
@@ -98,14 +98,22 @@ _Last updated: 2026-06-12 (Claude session, branch `worktree-metro-cards-d17`)._
   winner spread improves; Paris's mesh becomes playable) + three
   stat-presentation variants in treatment C.
 
-## Current gate: owner verdict on the D20 board (variant pick + stat-list confirm)
+- D20 resolved (2026-06-12): owner picked **V1 (big ledger)** after the r3
+  type pass (labels lead in bold near-white; designer-critique agent round;
+  its label re-dimming rejected). Density swap confirmed; ratified defaults:
+  line-count + scope tag beside the pills, 2-3 curated facts on lore backs.
+  Still open: per-city declared scope (A operator vs B rider-scope, rec B),
+  due before roster scale-up. BUILD-SPEC updated to the resolved state.
 
-The gate artifact is `mocks/card-row-variants-board.html`: the proposed
-stat-list strip (was / proposed / why), then each variant as the full
-three-city fan in treatment C: V1 BIG LEDGER (jumbo numerals, no tracks),
-V2 STAT TILES (2×3 player-mat grid), V3 HERO STAT (signature number +
-compact rows). Owner picks a variant (or elements to merge) and confirms or
-vetoes the lines→density swap.
+## Current gate: build the live page, then owner verdict on it
+
+All design gates are resolved (C ground, V1 ledger, density swap). Next
+build is the real one: `/is/building/world-metros/` rebuilt as DECK +
+BATTLE + DAILY + METHOD per BUILD-SPEC (three cities real, nine "soon",
+soft-launch norms kept). The rebuild session should ask the owner two
+things before shipping wide: naming ("metro match" working) and the scope
+pick if still unanswered (default: ship with the scope tag, decide before
+scale-up).
 
 ## Next exact action (after the D20 pick)
 


### PR DESCRIPTION
Owner picked **V1 (big ledger)**; the lines→density swap is confirmed (line info returns as header metadata: count + scope tag beside the pills, so pills never silently claim completeness). Lore backs gain 2-3 curated facts (the D2 profile-card content). DECISIONS carries the resolution; BUILD-SPEC updated to resolved state (C ground + V1 grammar + ratified stat table; gates 'D19/D20 DONE'). STATUS gate moves to the live-page rebuild. Open before scale-up: per-city declared scope (rec rider-scope); naming before wide ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)