### PR TITLE
building: world-metros cut the Why-sixteen Method section (D23 revision)

### DIFF
--- a/_scripts/world_metros/BUILD-SPEC.md
+++ b/_scripts/world_metros/BUILD-SPEC.md
@@ -24,10 +24,10 @@ game. Trading cards with footnotes.
    D16's duel mechanics.
 3. **THE DAILY** — one guess a day ("which plots more stations?"), streak in
    localStorage. Consciously un-defers D16's reveal-on-tap guessing.
-4. **METHOD** — scope rules, definitions, sources, as-of dates, licences, win
-   directions, per-city "why it's in" reasons ("Why sixteen", D23), and the
-   absence note (Shenzhen, Osaka, São Paulo, Istanbul, Mumbai). Absence is
-   content. Unchanged role from the atlas contract.
+4. **METHOD** — scope rules, definitions, sources, as-of dates, licences,
+   win directions, and the diagram licensing story. Method is method: no
+   roster editorial (the per-city "why it's in" rationale was cut at the
+   owner's D23 revision; it reaches visitors as lore-back facts instead).
 
 ## Card grammar (D18, ratified)
 

--- a/_scripts/world_metros/DECISIONS.md
+++ b/_scripts/world_metros/DECISIONS.md
@@ -503,6 +503,14 @@ the cpu; one guess a day in the daily."), nav tabs to the sans stack at
 12.5px/600 (owner disliked the mono nav font and its legibility), and a
 further daily type bump (the iOS-legibility flag: head/stat/meta/verdict
 /streak/note all up one step).
+*Revision (2026-06-12, owner on the live page):* the "Why sixteen" Method
+section is CUT ("is this part even necessary?"), and the absence note
+("def not necessary") with it. The per-city rationale was the wrong grain
+for the page: it lives here in this entry as working material, and
+surfaces for visitors as each card's own lore-back facts at scale-up.
+With Beijing in the deck, no absence demands an on-page explanation;
+"absence is content" retires with D3's roster. Method ends on the
+licensing story.
 
 **D24 · Themed stat sets ride the scale-up — RATIFIED 2026-06-12 (owner
 idea at the D22 review; sequencing pick recorded).**

--- a/_scripts/world_metros/STATUS.md
+++ b/_scripts/world_metros/STATUS.md
@@ -133,8 +133,9 @@ _Last updated: 2026-06-12 (Claude session, branch `claude/exciting-shaw-1ae32b`)
 - D23 + D24 (2026-06-12): owner reviewed the D22 page and recurated the
   roster with a ranked 15-list + reasons; picks: keep Cairo (deck of 16),
   Guangzhou for the PRD seat, deck order = the ranking. Beijing's "why
-  not" reverses; Method now carries per-city reasons ("Why sixteen") and
-  the new absence list (Shenzhen, Osaka, São Paulo, Istanbul, Mumbai).
+  not" reverses. (A "Why sixteen" Method section + absence note shipped
+  with this round, then was cut at the owner's revision the same day:
+  Method is method; the rationale reaches visitors as lore-back facts.)
   Newcomers' soon cards say "diagram audit pending" (dual audit due at
   scale-up). Same round: masthead replaced (premise + verbs), nav tabs to
   sans 12.5px/600, daily type up a step (iOS flag). Themes (frequency /

--- a/_scripts/world_metros/build_metro_cards.py
+++ b/_scripts/world_metros/build_metro_cards.py
@@ -393,25 +393,6 @@ def method_panel(meta, stats):
       familiar map. Twelve of the sixteen backs are already sourced and
       licence-verified this way; Madrid, Copenhagen, Beijing and Guangzhou
       get the same audit before their cards land (their slots say so).</p>
-
-      <h2>Why sixteen</h2>
-      <p>The deck is sixteen systems, each here for a different reason, not
-      a top-N: <b>Tokyo</b> (the integration story: metro, JR and private
-      rail as one ecosystem), <b>Seoul</b> (the strongest daily-use megacity
-      metro), <b>Singapore</b> (the controlled-system model), <b>Hong
-      Kong</b> (reliability and the rail-plus-property model), <b>Paris</b>
-      (the dense core), <b>Shanghai</b> (21st-century scale), <b>Beijing</b>
-      (the capital mega-system, the longest network), <b>London</b> (the
-      original), <b>New York</b> (the 24-hour giant), <b>Madrid</b> (the
-      most network for its size), <b>Moscow</b> (the palace stations),
-      <b>Copenhagen</b> (the small automated counter-example to
-      biggest-equals-best), <b>Delhi</b> (the rapid-growth story outside
-      China), <b>Guangzhou</b> (the Pearl River Delta seat), <b>Mexico
-      City</b> (Latin America&rsquo;s essential workhorse), <b>Cairo</b>
-      (the African pioneer, 1987).</p>
-      <p>Absence is still content: <b>Shenzhen</b> lost the Pearl River
-      Delta seat to Guangzhou; Osaka, S&atilde;o Paulo, Istanbul and Mumbai
-      wait outside the deck.</p>
     </div>"""
 
 

--- a/is/building/world-metros/index.html
+++ b/is/building/world-metros/index.html
@@ -164,25 +164,6 @@
       familiar map. Twelve of the sixteen backs are already sourced and
       licence-verified this way; Madrid, Copenhagen, Beijing and Guangzhou
       get the same audit before their cards land (their slots say so).</p>
-
-      <h2>Why sixteen</h2>
-      <p>The deck is sixteen systems, each here for a different reason, not
-      a top-N: <b>Tokyo</b> (the integration story: metro, JR and private
-      rail as one ecosystem), <b>Seoul</b> (the strongest daily-use megacity
-      metro), <b>Singapore</b> (the controlled-system model), <b>Hong
-      Kong</b> (reliability and the rail-plus-property model), <b>Paris</b>
-      (the dense core), <b>Shanghai</b> (21st-century scale), <b>Beijing</b>
-      (the capital mega-system, the longest network), <b>London</b> (the
-      original), <b>New York</b> (the 24-hour giant), <b>Madrid</b> (the
-      most network for its size), <b>Moscow</b> (the palace stations),
-      <b>Copenhagen</b> (the small automated counter-example to
-      biggest-equals-best), <b>Delhi</b> (the rapid-growth story outside
-      China), <b>Guangzhou</b> (the Pearl River Delta seat), <b>Mexico
-      City</b> (Latin America&rsquo;s essential workhorse), <b>Cairo</b>
-      (the African pioneer, 1987).</p>
-      <p>Absence is still content: <b>Shenzhen</b> lost the Pearl River
-      Delta seat to Guangzhou; Osaka, S&atilde;o Paulo, Istanbul and Mumbai
-      wait outside the deck.</p>
     </div>
     </section>
 


### PR DESCRIPTION
Owner verdict on the live Method tab: the 'Why sixteen' per-city rationale section is unnecessary, and the absence note definitely so. Both cut; Method now ends on the diagram licensing story.

The rationale lives on in DECISIONS (D23) as working material and surfaces for visitors as each card's lore-back facts at the scale-up. BUILD-SPEC's Method line updated to match ('Method is method: no roster editorial').

Verified by DOM probe: section and Shenzhen reference gone, five Method sections remain, 16 cards intact, no em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)