### PR TITLE
building: world-metros deck grid locked to 1/2/4 columns (D23 rev 2)

### DIFF
--- a/_scripts/world_metros/DECISIONS.md
+++ b/_scripts/world_metros/DECISIONS.md
@@ -511,6 +511,17 @@ surfaces for visitors as each card's own lore-back facts at scale-up.
 With Beijing in the deck, no absence demands an on-page explanation;
 "absence is content" retires with D3's roster. Method ends on the
 licensing story.
+*Revision 2 (2026-06-12, owner: "to fill up the row, how about 18 cards
+instead of 16?"):* measured first: the deck grid was even at 4-col
+desktop and 2-col tablet; only the 3-column band (~906-1200px windows)
+orphaned one card, and 18 would have evened that band while breaking
+full desktop (4-4-4-4-2; only multiples of 12 are even at both). Owner
+picked the grid fix over the roster change: **deck stays 16; the grid's
+column count is locked to 1 / 2 / 4 and never renders 3 columns**
+(style.css media queries replace auto-fit). Verified even rows with no
+overflow at 375 / 768 / 1000 / 1280. Bench note, should the deck ever
+grow: the owner's picks for two more seats are **Osaka and Istanbul**
+(over São Paulo and Mumbai).
 
 **D24 · Themed stat sets ride the scale-up — RATIFIED 2026-06-12 (owner
 idea at the D22 review; sequencing pick recorded).**

--- a/is/building/world-metros/style.css
+++ b/is/building/world-metros/style.css
@@ -91,9 +91,17 @@ main { flex: 1; width: 100%; max-width: 1240px; margin: 0 auto; padding: 0 22px 
 }
 .intro b { color: var(--text); font-weight: 600; }
 
+/* Column count is locked to 1 / 2 / 4 (never 3): 16 cards land in even
+   rows at every width. The 3-col band (~906-1200px) would orphan one card. */
 .deckgrid {
-  display: grid; grid-template-columns: repeat(auto-fit, 270px);
+  display: grid; grid-template-columns: repeat(1, 270px);
   justify-content: center; gap: 30px 26px; padding: 22px 0 8px;
+}
+@media (min-width: 612px) {
+  .deckgrid { grid-template-columns: repeat(2, 270px); }
+}
+@media (min-width: 1206px) {
+  .deckgrid { grid-template-columns: repeat(4, 270px); }
 }
 
 .cardunit { display: flex; flex-direction: column; gap: 9px; align-items: center; }


### PR DESCRIPTION
Owner asked for 18 cards to even out the deck rows. Measured first: the grid was already even at 4-column desktop (16 = four rows) and 2-column tablet; only the 3-column band (~906-1200px windows) orphaned one card, and 18 would have evened that band while breaking full desktop (4-4-4-4-2; only multiples of 12 satisfy both). Owner picked the grid fix.

style.css: the deck grid's auto-fit is replaced with explicit column counts (1 / 2 / 4) so a 3-column layout never renders. Verified by DOM probes at 375 / 768 / 1000 / 1280: even rows, zero orphans, no overflow.

DECISIONS: revision 2 under D23, including the bench note (Osaka + Istanbul are the owner's picks if the deck ever grows past 16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)