### PR TITLE
prepublish: genericize full name to the ajin.im brand (titles + meta)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>ajin im</title>
+<title>ajin.im</title>
 <meta name="description" content="A creative house of rooms: essays, comedy, and the Avian Municipal District, where divorced birds file for clean separations.">
 <link rel="canonical" href="https://ajin.im/">
 <meta property="og:site_name" content="ajin.im">

--- a/is/learning/index.html
+++ b/is/learning/index.html
@@ -5,17 +5,17 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ajin.im is learning</title>
-<meta name="description" content="Languages Ajin Im is learning, and self-made study tools.">
+<meta name="description" content="Languages ajin is learning, and self-made study tools.">
 <link rel="canonical" href="https://ajin.im/is/learning/">
 <meta property="og:site_name" content="ajin.im">
 <meta property="og:title" content="ajin.im is learning">
-<meta property="og:description" content="Languages Ajin Im is learning, and self-made study tools.">
+<meta property="og:description" content="Languages ajin is learning, and self-made study tools.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://ajin.im/is/learning/">
 
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="ajin.im is learning">
-<meta name="twitter:description" content="Languages Ajin Im is learning, and self-made study tools.">
+<meta name="twitter:description" content="Languages ajin is learning, and self-made study tools.">
 
 <link rel="icon" type="image/png" href="/img/a1.png">
 <link rel="apple-touch-icon" href="/img/a1.png">

--- a/is/reading/index.html
+++ b/is/reading/index.html
@@ -5,17 +5,17 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ajin.im is reading</title>
-<meta name="description" content="What Ajin Im is reading now and has read this year.">
+<meta name="description" content="What ajin is reading now and has read this year.">
 <link rel="canonical" href="https://ajin.im/is/reading/">
 <meta property="og:site_name" content="ajin.im">
 <meta property="og:title" content="ajin.im is reading">
-<meta property="og:description" content="What Ajin Im is reading now and has read this year.">
+<meta property="og:description" content="What ajin is reading now and has read this year.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://ajin.im/is/reading/">
 
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="ajin.im is reading">
-<meta name="twitter:description" content="What Ajin Im is reading now and has read this year.">
+<meta name="twitter:description" content="What ajin is reading now and has read this year.">
 
 <link rel="icon" type="image/png" href="/img/a1.png">
 <link rel="apple-touch-icon" href="/img/a1.png">

--- a/templates/learning.html
+++ b/templates/learning.html
@@ -4,17 +4,17 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ajin.im is learning</title>
-<meta name="description" content="Languages Ajin Im is learning, and self-made study tools.">
+<meta name="description" content="Languages ajin is learning, and self-made study tools.">
 <link rel="canonical" href="https://ajin.im/is/learning/">
 <meta property="og:site_name" content="ajin.im">
 <meta property="og:title" content="ajin.im is learning">
-<meta property="og:description" content="Languages Ajin Im is learning, and self-made study tools.">
+<meta property="og:description" content="Languages ajin is learning, and self-made study tools.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://ajin.im/is/learning/">
 
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="ajin.im is learning">
-<meta name="twitter:description" content="Languages Ajin Im is learning, and self-made study tools.">
+<meta name="twitter:description" content="Languages ajin is learning, and self-made study tools.">
 
 <link rel="icon" type="image/png" href="/img/a1.png">
 <link rel="apple-touch-icon" href="/img/a1.png">

--- a/templates/reading.html
+++ b/templates/reading.html
@@ -4,17 +4,17 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ajin.im is reading</title>
-<meta name="description" content="What Ajin Im is reading now and has read this year.">
+<meta name="description" content="What ajin is reading now and has read this year.">
 <link rel="canonical" href="https://ajin.im/is/reading/">
 <meta property="og:site_name" content="ajin.im">
 <meta property="og:title" content="ajin.im is reading">
-<meta property="og:description" content="What Ajin Im is reading now and has read this year.">
+<meta property="og:description" content="What ajin is reading now and has read this year.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://ajin.im/is/reading/">
 
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="ajin.im is reading">
-<meta name="twitter:description" content="What Ajin Im is reading now and has read this year.">
+<meta name="twitter:description" content="What ajin is reading now and has read this year.">
 
 <link rel="icon" type="image/png" href="/img/a1.png">
 <link rel="apple-touch-icon" href="/img/a1.png">

--- a/templates/root.html
+++ b/templates/root.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>ajin im</title>
+<title>ajin.im</title>
 <meta name="description" content="A creative house of rooms: essays, comedy, and the Avian Municipal District, where divorced birds file for clean separations.">
 <link rel="canonical" href="https://ajin.im/">
 <meta property="og:site_name" content="ajin.im">


### PR DESCRIPTION
Privacy hygiene pass (already-public repo). Removes the full name 'Ajin Im' / 'ajin im' from the working tree: homepage title to 'ajin.im', learning + reading meta descriptions to 'ajin'. Templates edited, root pages regenerated.

The name remains in git history (the archived résumé + old meta) and is accepted there as a documented decision, not worth a history rewrite on a live multi-worktree repo. Recorded in the prepublish token list.

prepublish-audit: CLEAN (no findings; 2 review-only warnings for served build scripts + large diagram assets).