### PR TITLE
building: metro-match D35 header polish (one frame, badge cut, wordmark home)

### DIFF
--- a/_scripts/world_metros/DECISIONS.md
+++ b/_scripts/world_metros/DECISIONS.md
@@ -994,3 +994,25 @@ but dont list on building page yet. i will be testing": publish
 authorized (push/PR/merge), soft-launch norms STAY (noindex, no
 sitemap, no /is/building hub card, no home teaser) while the owner
 tests live.
+
+**D35 · Header polish: one frame, no badge, wordmark is the way back -
+RATIFIED 2026-06-12 (owner flagged the badge, the dead wordmark and the
+horizontal misalignment; picked the recommended slate: B + cut + #deck).**
+- **Alignment (option B):** the header content moves into an `.hframe`
+  that mirrors main's column exactly (max-width 1240, same side padding),
+  so the chrome and the content share one frame at every width (measured:
+  wordmark x equals the masthead text edge at 1990 and 1280). The
+  masthead paragraph centers over the centered deck, joining the one axis
+  every other surface already uses (deck, battle, daily, method); it was
+  the page's only left-anchored stray.
+- **DECK OF 18 badge CUT:** it was the soft-launch progress badge ("3 OF
+  16 LIVE"); with the full deck live it repeated what the masthead and
+  every card number already say. Styles pruned.
+- **Wordmark clickable:** METRO MATCH links to #deck (an in-page anchor:
+  exempt from the analytics.js new-tab retarget, handled by the existing
+  hash router), so the logo acts as the app's way back to the deck from
+  battle / daily / method. The way home to ajin.im stays the footer
+  colophon, per the bespoke-tier rule.
+- Verified by DOM probe: frame alignment at 1990/1280, intro-grid axis
+  delta 0, wordmark click returns battle to deck, nav wrap at 375, no
+  overflow at 375/768/1280, console clean.

--- a/_scripts/world_metros/STATUS.md
+++ b/_scripts/world_metros/STATUS.md
@@ -215,6 +215,12 @@ _Last updated: 2026-06-12 (reconcile session: the parallel gate-3 body D25-D31 m
   authorized publish ("u can put it on metromatch... i will be
   testing"); soft-launch norms stay while the owner tests live.
 
+- D35 (2026-06-12, owner-directed during live testing): header polish.
+  The chrome joins main's column via an .hframe, the masthead centers
+  over the deck (the page's one left-anchored stray), the DECK OF 18
+  badge is cut (soft-launch leftover), and the wordmark links to #deck
+  as the in-app way back. Verified 375/768/1280/1990, console clean.
+
 ## Current gate: owner live-testing the shipped deck
 
 The deck of 18 (gate 3, D25-D31) + this session's D32-D34 are LIVE at

--- a/_scripts/world_metros/build_metro_cards.py
+++ b/_scripts/world_metros/build_metro_cards.py
@@ -723,14 +723,16 @@ def main():
 <div class="table">
 
   <header>
-    <h1 class="wordmark">METRO <em>MATCH</em></h1>
+    <div class="hframe"><!-- mirrors main's column so the chrome and the
+      content share one frame at every width (D35) -->
+    <h1 class="wordmark"><a href="#deck">METRO <em>MATCH</em></a></h1>
     <nav role="tablist" aria-label="Views" id="tabs">
       <button type="button" role="tab" id="tab-deck" aria-controls="panel-deck" aria-selected="true">THE DECK</button>
       <button type="button" role="tab" id="tab-battle" aria-controls="panel-battle" aria-selected="false" tabindex="-1">THE BATTLE</button>
       <button type="button" role="tab" id="tab-daily" aria-controls="panel-daily" aria-selected="false" tabindex="-1">THE DAILY</button>
       <button type="button" role="tab" id="tab-method" aria-controls="panel-method" aria-selected="false" tabindex="-1">METHOD</button>
     </nav>
-    <span class="livebadge">DECK OF 18</span>
+    </div>
   </header>
 
   <main>

--- a/is/building/metro-match/index.html
+++ b/is/building/metro-match/index.html
@@ -19,14 +19,16 @@
 <div class="table">
 
   <header>
-    <h1 class="wordmark">METRO <em>MATCH</em></h1>
+    <div class="hframe"><!-- mirrors main's column so the chrome and the
+      content share one frame at every width (D35) -->
+    <h1 class="wordmark"><a href="#deck">METRO <em>MATCH</em></a></h1>
     <nav role="tablist" aria-label="Views" id="tabs">
       <button type="button" role="tab" id="tab-deck" aria-controls="panel-deck" aria-selected="true">THE DECK</button>
       <button type="button" role="tab" id="tab-battle" aria-controls="panel-battle" aria-selected="false" tabindex="-1">THE BATTLE</button>
       <button type="button" role="tab" id="tab-daily" aria-controls="panel-daily" aria-selected="false" tabindex="-1">THE DAILY</button>
       <button type="button" role="tab" id="tab-method" aria-controls="panel-method" aria-selected="false" tabindex="-1">METHOD</button>
     </nav>
-    <span class="livebadge">DECK OF 18</span>
+    </div>
   </header>
 
   <main>

--- a/is/building/metro-match/style.css
+++ b/is/building/metro-match/style.css
@@ -56,12 +56,19 @@ button:focus-visible, a:focus-visible {
 
 /* ---------------------------------------------------------------- header */
 
+/* the chrome shares main's column: header paints full-bleed, its content
+   sits in an .hframe that mirrors main's box exactly (D35) */
 header {
-  display: flex; align-items: baseline; gap: 22px; flex-wrap: wrap;
-  padding: 15px 22px 11px; border-bottom: 1px solid var(--edge);
+  padding: 15px 0 11px; border-bottom: 1px solid var(--edge);
   background: var(--chrome);
 }
+.hframe {
+  display: flex; align-items: baseline; gap: 22px; flex-wrap: wrap;
+  width: 100%; max-width: 1240px; margin: 0 auto; padding: 0 22px;
+}
 .wordmark { font-size: 15px; font-weight: 700; letter-spacing: .24em; color: var(--text); }
+.wordmark a { color: inherit; text-decoration: none; }
+.wordmark a:hover em { color: var(--text); }
 .wordmark em { font-style: normal; color: var(--lblue); }
 
 nav[role="tablist"] { display: flex; gap: 6px; }
@@ -76,11 +83,6 @@ nav[role="tablist"] button[aria-selected="true"] {
   color: var(--text); border-bottom-color: var(--lblue);
 }
 
-.livebadge {
-  margin-left: auto; font-family: var(--mono); font-size: 10px;
-  letter-spacing: .12em; color: var(--lblue); border: 1px solid #7fb0e855;
-  padding: 3px 8px; border-radius: 2px; white-space: nowrap;
-}
 
 main { flex: 1; width: 100%; max-width: 1240px; margin: 0 auto; padding: 0 22px 34px; }
 
@@ -89,6 +91,7 @@ main { flex: 1; width: 100%; max-width: 1240px; margin: 0 auto; padding: 0 22px 
 .intro {
   font-size: 13px; color: var(--soft); line-height: 1.65;
   max-width: 640px; padding: 20px 2px 4px;
+  margin: 0 auto; text-align: center;
 }
 .intro b { color: var(--text); font-weight: 600; }
 
@@ -483,10 +486,10 @@ footer .made:hover { color: var(--body); }
 }
 
 @media (max-width: 640px) {
-  header { gap: 12px; padding: 13px 16px 9px; }
+  header { padding: 13px 0 9px; }
+  .hframe { gap: 12px; padding: 0 16px; }
   nav[role="tablist"] { order: 3; width: 100%; gap: 0; justify-content: space-between; }
   nav[role="tablist"] button { padding: 6px 4px 7px; font-size: 11.5px; letter-spacing: .04em; }
-  .livebadge { margin-left: auto; }
   main { padding: 0 16px 28px; }
   .deckgrid { gap: 24px 18px; }
   #panel-daily { justify-content: flex-start; min-height: auto; padding-top: 26px; }


### PR DESCRIPTION
Owner-picked slate (B + cut + #deck) during live testing:

- header content moves into an .hframe mirroring main's column, so chrome and content share one frame at every width (wordmark x == masthead text edge at 1990/1280)
- masthead paragraph centers over the centered deck (the page's only left-anchored stray joins the shared axis)
- the DECK OF 18 badge is cut (soft-launch progress leftover; the masthead and card numbers already carry the count)
- the METRO MATCH wordmark links to #deck (in-page anchor: analytics-retarget-exempt, existing hash router), the in-app way back; ajin.im home stays the footer colophon

Verified by DOM probe at 375/768/1280/1990: no overflow, nav wraps at mobile, intro-grid axis delta 0, wordmark click returns battle to deck, console clean. Soft-launch norms untouched (noindex, unlisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)