### PR TITLE
building: metro-match masthead M3 + wordmark W4 (owner picks)

### DIFF
--- a/_scripts/world_metros/DECISIONS.md
+++ b/_scripts/world_metros/DECISIONS.md
@@ -1016,6 +1016,14 @@ horizontal misalignment; picked the recommended slate: B + cut + #deck).**
 - Verified by DOM probe: frame alignment at 1990/1280, intro-grid axis
   delta 0, wordmark click returns battle to deck, nav wrap at 375, no
   overflow at 375/768/1280, console clean.
+_Revision (2026-06-12, owner on the live page): the centered masthead
+read weird and the MATCH-only hover read awkward. Judged on
+`mocks/masthead-board.html` (build_masthead_board.py): owner picked
+**M3** (masthead left-aligned in a block exactly as wide as the deck
+grid per tier, 270/566/862, so its left edge locks to the first card's
+edge at every column count) and **W4** (no hover change at all; the
+cursor is the affordance). Both applied; lock verified at 375/768/1280
+(intro edge == card edge exactly), hover rule removed, console clean._
 
 
 **D36 · Fact-check pass: data + lore corrections - RATIFIED 2026-06-13

--- a/is/building/metro-match/style.css
+++ b/is/building/metro-match/style.css
@@ -67,8 +67,9 @@ header {
   width: 100%; max-width: 1240px; margin: 0 auto; padding: 0 22px;
 }
 .wordmark { font-size: 15px; font-weight: 700; letter-spacing: .24em; color: var(--text); }
+/* the wordmark links #deck (the in-app way back); no hover change, the
+   cursor is the affordance (owner pick W4, masthead board) */
 .wordmark a { color: inherit; text-decoration: none; }
-.wordmark a:hover em { color: var(--text); }
 .wordmark em { font-style: normal; color: var(--lblue); }
 
 nav[role="tablist"] { display: flex; gap: 6px; }
@@ -90,9 +91,11 @@ main { flex: 1; width: 100%; max-width: 1240px; margin: 0 auto; padding: 0 22px 
 
 .intro {
   font-size: 13px; color: var(--soft); line-height: 1.65;
-  max-width: 640px; padding: 20px 2px 4px;
-  margin: 0 auto; text-align: center;
+  padding: 20px 2px 4px; margin: 0 auto; text-align: left;
+  max-width: 270px;  /* the grid's width at each tier; tiers below */
 }
+@media (min-width: 612px) { .intro { max-width: 566px; } }
+@media (min-width: 906px) { .intro { max-width: 862px; } }
 .intro b { color: var(--text); font-weight: 600; }
 
 /* theme switch (D24): three stat sets on the same cards */


### PR DESCRIPTION
Owner verdict off the masthead board (PR #169): M3 + W4.

- masthead: left-aligned block exactly as wide as the deck grid per tier (270/566/862), so its left edge locks to the first card's edge at every column count; centered text gone
- wordmark: no hover change at all (the MATCH-only color flip is removed); the cursor is the affordance, the #deck link behavior stays

Probe-verified: intro edge == card edge at 375/768/1280, no overflow, console clean. D35 revision recorded in DECISIONS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)