### PR TITLE
building: metro-match D37 remove THE DECK tab (wordmark is home)

### DIFF
--- a/_scripts/world_metros/DECISIONS.md
+++ b/_scripts/world_metros/DECISIONS.md
@@ -1097,3 +1097,22 @@ assessment's yes + guardrails, then "ok do it now").**
   at 0-0 with that pair, fare list shows the Guangzhou - Mexico City
   dead heat, keyboard arrow-cycle covers all five tabs, no overflow at
   375/768/1280, console clean.
+
+**D37 · THE DECK tab removed: the deck is the page, the wordmark is home -
+RATIFIED 2026-06-12 (owner: "THE DECK and METRO MATCH is basically the
+same thing, what if we remove THE DECK"; assessment agreed; "do it").**
+- Since D35 made the wordmark link #deck, the tab and the logo were two
+  controls for one destination. The nav drops to the four VIEWS (THE
+  BATTLE, THE DAILY, THE RANKS, METHOD); the deck panel loses its
+  tabpanel role and becomes the page's base content; at home no tab is
+  selected and the first tab keeps tabindex 0 so the tablist stays
+  keyboard-reachable. #deck stays routable (wordmark, old links).
+- The D36 mobile squeeze relaxes: four tabs go back to 11.5px at 640.
+- Known watch item (accepted): with W4 (no hover) there is no visual cue
+  that the wordmark is the way home until tried; logo-as-home is the
+  standard pattern, revisit only if live testing shows people stranded.
+- Verified by DOM probe: home = deck visible with nothing selected;
+  view tabs select and underline; wordmark returns home from ranks and
+  battle; direct loads of #battle/seoul-vs-paris and #ranks route
+  correctly; arrow-cycle covers the four tabs; nav one line at 375;
+  no overflow; console clean.

--- a/_scripts/world_metros/STATUS.md
+++ b/_scripts/world_metros/STATUS.md
@@ -236,6 +236,10 @@ _Last updated: 2026-06-12 (reconcile session: the parallel gate-3 body D25-D31 m
   top three, card-grammar rows, tightest-race battle links, no combined
   score ever. Verified 375/768/1280, keyboard cycle, console clean.
 
+- D37 (2026-06-12, owner-directed): THE DECK tab removed; the deck is
+  the page itself and the wordmark is the way home. Nav = the four
+  views; home state selects no tab; mobile tabs back to 11.5px.
+
 ## Current gate: owner live-testing the shipped deck
 
 The deck of 18 (gate 3, D25-D31) + this session's D32-D34 are LIVE at

--- a/_scripts/world_metros/build_metro_cards.py
+++ b/_scripts/world_metros/build_metro_cards.py
@@ -810,9 +810,9 @@ def main():
     <div class="hframe"><!-- mirrors main's column so the chrome and the
       content share one frame at every width (D35) -->
     <h1 class="wordmark"><a href="#deck">METRO <em>MATCH</em></a></h1>
-    <nav role="tablist" aria-label="Views" id="tabs">
-      <button type="button" role="tab" id="tab-deck" aria-controls="panel-deck" aria-selected="true">THE DECK</button>
-      <button type="button" role="tab" id="tab-battle" aria-controls="panel-battle" aria-selected="false" tabindex="-1">THE BATTLE</button>
+    <nav role="tablist" aria-label="Views" id="tabs"><!-- the deck has no
+      tab: it is the page itself, reached by the wordmark (D37) -->
+      <button type="button" role="tab" id="tab-battle" aria-controls="panel-battle" aria-selected="false">THE BATTLE</button>
       <button type="button" role="tab" id="tab-daily" aria-controls="panel-daily" aria-selected="false" tabindex="-1">THE DAILY</button>
       <button type="button" role="tab" id="tab-ranks" aria-controls="panel-ranks" aria-selected="false" tabindex="-1">THE RANKS</button>
       <button type="button" role="tab" id="tab-method" aria-controls="panel-method" aria-selected="false" tabindex="-1">METHOD</button>
@@ -822,7 +822,7 @@ def main():
 
   <main>
 
-    <section id="panel-deck" role="tabpanel" aria-labelledby="tab-deck">
+    <section id="panel-deck" aria-label="The deck">
       <p class="intro">Stat cards for the world&rsquo;s great metro systems,
       every number dated and sourced. Each card has three faces: scale,
       character, the map. <b>Flip to cycle them; pick a stat and beat the

--- a/is/building/metro-match/app.js
+++ b/is/building/metro-match/app.js
@@ -15,17 +15,24 @@ const upper = (k) => CITIES[k].name.toUpperCase();
 
 // ------------------------------------------------------------------- tabs
 
-const TAB_NAMES = ['deck', 'battle', 'daily', 'ranks', 'method'];
-const tabs = TAB_NAMES.map((n) => $('tab-' + n));
-const panels = TAB_NAMES.map((n) => $('panel-' + n));
+/* The deck is the page itself, not a view: the four view tabs overlay it
+   and the wordmark (#deck) is the way home (D37). At home no tab is
+   selected; the first tab keeps tabindex 0 so the tablist stays
+   keyboard-reachable. */
+const VIEW_NAMES = ['battle', 'daily', 'ranks', 'method'];
+const tabs = VIEW_NAMES.map((n) => $('tab-' + n));
+const panels = VIEW_NAMES.map((n) => $('panel-' + n));
+const deckPanel = $('panel-deck');
 
 function selectTab(name) {
-  TAB_NAMES.forEach((n, i) => {
+  const home = name === 'deck';
+  VIEW_NAMES.forEach((n, i) => {
     const on = n === name;
     tabs[i].setAttribute('aria-selected', String(on));
-    tabs[i].tabIndex = on ? 0 : -1;
+    tabs[i].tabIndex = (on || (home && i === 0)) ? 0 : -1;
     panels[i].hidden = !on;
   });
+  deckPanel.hidden = !home;
   if (name === 'battle' && !battle.started) dealRound(battle.seed);
   if (name === 'daily') renderDaily();
 }
@@ -39,7 +46,7 @@ function go(name, hash) {
 }
 
 tabs.forEach((tab, i) => {
-  tab.addEventListener('click', () => go(TAB_NAMES[i]));
+  tab.addEventListener('click', () => go(VIEW_NAMES[i]));
   tab.addEventListener('keydown', (e) => {
     let j = null;
     if (e.key === 'ArrowRight') j = (i + 1) % tabs.length;
@@ -48,7 +55,7 @@ tabs.forEach((tab, i) => {
     if (e.key === 'End') j = tabs.length - 1;
     if (j !== null) {
       e.preventDefault();
-      go(TAB_NAMES[j]);
+      go(VIEW_NAMES[j]);
       tabs[j].focus();
     }
   });
@@ -67,7 +74,7 @@ function routeFromHash() {
     selectTab('battle');
     return;
   }
-  selectTab(TAB_NAMES.includes(h) ? h : 'deck');
+  selectTab(VIEW_NAMES.includes(h) ? h : 'deck');
 }
 
 window.addEventListener('hashchange', routeFromHash);

--- a/is/building/metro-match/index.html
+++ b/is/building/metro-match/index.html
@@ -22,9 +22,9 @@
     <div class="hframe"><!-- mirrors main's column so the chrome and the
       content share one frame at every width (D35) -->
     <h1 class="wordmark"><a href="#deck">METRO <em>MATCH</em></a></h1>
-    <nav role="tablist" aria-label="Views" id="tabs">
-      <button type="button" role="tab" id="tab-deck" aria-controls="panel-deck" aria-selected="true">THE DECK</button>
-      <button type="button" role="tab" id="tab-battle" aria-controls="panel-battle" aria-selected="false" tabindex="-1">THE BATTLE</button>
+    <nav role="tablist" aria-label="Views" id="tabs"><!-- the deck has no
+      tab: it is the page itself, reached by the wordmark (D37) -->
+      <button type="button" role="tab" id="tab-battle" aria-controls="panel-battle" aria-selected="false">THE BATTLE</button>
       <button type="button" role="tab" id="tab-daily" aria-controls="panel-daily" aria-selected="false" tabindex="-1">THE DAILY</button>
       <button type="button" role="tab" id="tab-ranks" aria-controls="panel-ranks" aria-selected="false" tabindex="-1">THE RANKS</button>
       <button type="button" role="tab" id="tab-method" aria-controls="panel-method" aria-selected="false" tabindex="-1">METHOD</button>
@@ -34,7 +34,7 @@
 
   <main>
 
-    <section id="panel-deck" role="tabpanel" aria-labelledby="tab-deck">
+    <section id="panel-deck" aria-label="The deck">
       <p class="intro">Stat cards for the world&rsquo;s great metro systems,
       every number dated and sourced. Each card has three faces: scale,
       character, the map. <b>Flip to cycle them; pick a stat and beat the

--- a/is/building/metro-match/style.css
+++ b/is/building/metro-match/style.css
@@ -555,7 +555,7 @@ footer .made:hover { color: var(--body); }
   header { padding: 13px 0 9px; }
   .hframe { gap: 12px; padding: 0 16px; }
   nav[role="tablist"] { order: 3; width: 100%; gap: 0; justify-content: space-between; }
-  nav[role="tablist"] button { padding: 6px 2px 7px; font-size: 10.5px; letter-spacing: .02em; }
+  nav[role="tablist"] button { padding: 6px 4px 7px; font-size: 11.5px; letter-spacing: .04em; }
   main { padding: 0 16px 28px; }
   .deckgrid { gap: 24px 18px; }
   #panel-daily { justify-content: flex-start; min-height: auto; padding-top: 26px; }


### PR DESCRIPTION
Owner call: since D35 the wordmark links #deck, so THE DECK tab was a duplicate control. The deck panel becomes the page's base content (tabpanel role dropped); nav holds the four views; at home no tab is selected (first tab keeps tabindex 0 for keyboard reach); #deck stays routable; the D36 mobile type squeeze relaxes back to 11.5px.

Probe-verified: home/no-selection state, wordmark return from ranks and battle, direct loads of #battle/seoul-vs-paris and #ranks, 4-tab arrow cycle, one-line nav at 375, no overflow, console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)