### PR TITLE
building: metro-match ranks podium flattened to uniform rows (owner)

### DIFF
--- a/is/building/metro-match/style.css
+++ b/is/building/metro-match/style.css
@@ -462,12 +462,13 @@ button.crow[aria-disabled="true"]:hover { background: none; }
   display: flex; align-items: center; gap: 12px;
   padding: 9px 1px; border-bottom: 1px solid var(--rowline);
 }
-.rkrow.podium { padding: 13px 1px; }
+/* Podium emphasis flattened (owner, 2026-06-13): the top-3 bigger font read
+   as weird; all rows are uniform now, the 1ST/2ND/3RD chip carries rank. The
+   .podium class hook stays inert in the markup. */
 .rkname {
   font-size: 13px; font-weight: 700; letter-spacing: .05em;
   text-transform: uppercase; color: var(--body);
 }
-.rkrow.podium .rkname { font-size: 16px; color: var(--text); }
 .rkband {
   display: flex; width: 64px; height: 8px; border-radius: 4px;
   overflow: hidden; margin-left: auto; flex: none;
@@ -477,7 +478,6 @@ button.crow[aria-disabled="true"]:hover { background: none; }
   font-family: var(--mono); font-size: 15px; font-weight: 500;
   white-space: nowrap; min-width: 86px; text-align: right;
 }
-.rkrow.podium .rkval { font-size: 19px; }
 .rkval small { font-size: 9px; color: var(--grey); letter-spacing: .04em; font-weight: 400; }
 .rkrace {
   font-family: var(--mono); font-size: 10.5px; color: var(--grey);


### PR DESCRIPTION
Owner found the THE RANKS podium top-3 (bigger name + value font, taller rows) visually weird and wanted uniform rows.

Flattens the three `.rkrow.podium` style overrides so all 18 rows are identical in font size and height; the 1ST/2ND/3RD rank chip is now the only winner cue. style.css only (the `.podium` markup hook is left inert). Reverts the podium emphasis from #172.

Verified at 1280: all names 13px, all values 15px, all rows 41px, no wrapping; picker still switches across SCALE/CHARACTER; console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)