### PR TITLE
site: selfd easter egg at /admin (noindex) + faint admin door in home colophon

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,567 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>admin · ajin.im</title>
+<meta name="robots" content="noindex">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' rx='3' fill='%230a0e14'/%3E%3Ccircle cx='8' cy='8' r='4' fill='%233fb950'/%3E%3C/svg%3E">
+<script src="/analytics.js" defer></script>
+<style>
+  :root{
+    --bg:#0a0e14; --panel:#10141b; --panel-2:#0d1117;
+    --border:#1d2530; --border-bright:#2a3543;
+    --text:#c9d1d9; --muted:#6e7681; --dim:#454d57;
+    --green:#3fb950; --amber:#d29922; --red:#f85149; --cyan:#39c5cf; --violet:#a371f7;
+    --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;padding:0}
+  body{background:var(--bg);color:var(--text);font-family:var(--mono);font-size:13px;line-height:1.4;-webkit-font-smoothing:antialiased;padding:0 0 60px}
+  .wrap{max-width:1120px;margin:0 auto;padding:0 16px}
+
+  header{position:sticky;top:0;z-index:10;background:linear-gradient(180deg,#0a0e14 78%,rgba(10,14,20,0.9));border-bottom:1px solid var(--border);backdrop-filter:blur(4px)}
+  .bar{display:flex;align-items:center;gap:18px;flex-wrap:wrap;padding:12px 0 0}
+  .brand{font-weight:700;letter-spacing:1.5px;font-size:14px}
+  .brand .tag{color:var(--dim);font-weight:400;letter-spacing:0;margin-left:8px;font-size:11px}
+  .stat{display:flex;flex-direction:column;line-height:1.25}
+  .stat .k{color:var(--muted);font-size:10px;letter-spacing:.5px;text-transform:uppercase}
+  .stat .v{font-size:13px;font-weight:600;font-variant-numeric:tabular-nums}
+  .spacer{flex:1}
+  .status-pill{font-size:11px;font-weight:700;letter-spacing:1px;padding:4px 10px;border:1px solid currentColor;border-radius:2px}
+  .s-ok{color:var(--green)} .s-deg{color:var(--amber)} .s-crit{color:var(--red)}
+
+  nav.tabs{display:flex;gap:2px;padding:12px 0 0}
+  nav.tabs button{font-family:var(--mono);font-size:11.5px;font-weight:600;letter-spacing:1px;text-transform:uppercase;background:transparent;color:var(--muted);border:none;border-bottom:2px solid transparent;padding:8px 14px;cursor:pointer}
+  nav.tabs button:hover{color:var(--text)}
+  nav.tabs button.active{color:var(--cyan);border-bottom-color:var(--cyan)}
+
+  section.view{display:none;padding-top:6px}
+  section.view.active{display:block}
+
+  .controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:14px 0 6px}
+  button.ctl{font-family:var(--mono);font-size:12px;font-weight:600;letter-spacing:.5px;background:var(--panel);color:var(--text);border:1px solid var(--border-bright);border-radius:3px;padding:8px 14px;cursor:pointer;transition:background .12s,border-color .12s}
+  button.ctl:hover{background:#161c25;border-color:#374350}
+  button.ctl.primary{color:var(--cyan);border-color:#1f4f53}
+  button.ctl.primary:hover{background:#0e1f21}
+  .ctl-note{color:var(--muted);font-size:11px}
+  .count{color:var(--text)} .count b{color:var(--amber)} .count.hot b{color:var(--red)}
+  .legend{display:flex;gap:14px;align-items:center;padding:2px 0 12px;color:var(--muted);font-size:10.5px;letter-spacing:.3px}
+  .dot{display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:5px;vertical-align:middle}
+  .d-ok{background:var(--green)} .d-el{background:var(--amber)} .d-cr{background:var(--red)}
+
+  #grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(248px,1fr));gap:10px;transition:filter .35s,opacity .35s}
+  .panel{background:var(--panel);border:1px solid var(--border);border-radius:4px;padding:11px 12px 10px;position:relative;overflow:hidden}
+  .panel.cr{border-color:#5b2522} .panel.el{border-color:#5a4a1c}
+  .panel::before{content:"";position:absolute;left:0;top:0;bottom:0;width:2px;background:var(--dim)}
+  .panel.ok::before{background:var(--green)} .panel.el::before{background:var(--amber)} .panel.cr::before{background:var(--red)}
+  .p-head{display:flex;justify-content:space-between;align-items:baseline;gap:8px}
+  .p-group{font-size:9.5px;letter-spacing:1px;color:var(--dim);text-transform:uppercase}
+  .p-sev{font-size:9.5px;letter-spacing:1px;font-weight:700;text-transform:uppercase}
+  .sev-ok{color:var(--green)} .sev-el{color:var(--amber)} .sev-cr{color:var(--red)}
+  .p-label{font-size:12px;margin-top:5px;font-weight:600;letter-spacing:.3px}
+  .p-sub{font-size:10px;color:var(--muted);margin-top:1px;min-height:13px}
+  .p-foot{display:flex;justify-content:space-between;align-items:flex-end;margin-top:9px;gap:10px}
+  .p-val{font-size:21px;font-weight:700;line-height:1;font-variant-numeric:tabular-nums}
+  .p-val .u{font-size:11px;color:var(--muted);font-weight:400;margin-left:2px}
+  .val-ok{color:var(--text)} .val-el{color:var(--amber)} .val-cr{color:var(--red)}
+  .spark{width:108px;height:30px;flex:none}
+  .p-thresh{font-size:9px;color:var(--dim);margin-top:6px;letter-spacing:.3px}
+
+  .recent{margin-top:22px;border-top:1px solid var(--border);padding-top:12px}
+  .recent h3{font-size:10.5px;letter-spacing:1.5px;color:var(--muted);text-transform:uppercase;margin:0 0 8px;font-weight:600}
+  .rec-empty{color:var(--dim);font-size:11.5px}
+  .rec-line{font-size:11px;color:var(--muted);padding:4px 0;letter-spacing:.2px;font-variant-numeric:tabular-nums}
+  .rec-line .id{color:var(--cyan)} .rec-line .trg{color:var(--red)} .rec-line .act{color:var(--text)}
+  footer.note{color:var(--dim);font-size:10px;margin-top:22px;letter-spacing:.3px;line-height:1.6}
+
+  .doc h2{font-size:11px;letter-spacing:1.5px;color:var(--muted);text-transform:uppercase;margin:22px 0 10px;font-weight:600}
+  .doc h2:first-child{margin-top:14px}
+  .idblock{background:var(--panel-2);border:1px solid var(--border);border-radius:4px;padding:14px 16px;font-size:11.5px;line-height:1.7}
+  .idblock .row{display:flex;gap:10px}
+  .idblock .lab{color:var(--muted);min-width:150px;text-transform:uppercase;font-size:10px;letter-spacing:.6px;padding-top:1px}
+  .idblock .val{color:var(--text)}
+  .idblock .val.warn{color:var(--amber)} .idblock .val.bad{color:var(--red)}
+
+  .tech-reg{font-size:11.5px;line-height:1.65}
+  .tech-reg .seg{color:var(--dim);text-transform:uppercase;letter-spacing:1px;font-size:9.5px;margin:10px 0 4px}
+  .tech-reg .t{display:flex;gap:10px;padding:2px 0}
+  .tech-reg .nm{min-width:150px;color:var(--text);font-weight:600}
+  .tech-reg .nm.rev{color:var(--red)} .tech-reg .nm.prob{color:var(--amber)}
+  .tech-reg .de{color:var(--muted)}
+
+  table.svc{width:100%;border-collapse:collapse;font-size:11px}
+  table.svc th{text-align:left;color:var(--muted);font-weight:600;text-transform:uppercase;font-size:9.5px;letter-spacing:.6px;padding:6px 10px 6px 0;border-bottom:1px solid var(--border)}
+  table.svc td{padding:8px 10px 8px 0;border-bottom:1px solid #131922;vertical-align:top;line-height:1.45}
+  table.svc td.date{color:var(--dim);white-space:nowrap;font-variant-numeric:tabular-nums}
+  table.svc td.tech{color:var(--cyan);white-space:nowrap}
+  table.svc td.tech.un{color:var(--red)}
+  table.svc td.res{color:var(--muted)}
+  .live-badge{display:inline-block;font-size:8.5px;letter-spacing:1px;color:var(--green);border:1px solid #1f5128;border-radius:2px;padding:0 4px;margin-left:6px;vertical-align:middle}
+  .warr{font-size:11.5px;line-height:1.7}
+  .warr .w{display:flex;gap:10px;padding:2px 0}
+  .warr .wd{min-width:130px;color:var(--dim);white-space:nowrap}
+  .warr .wt{color:var(--muted)}
+  .warr .wt b{color:var(--amber);font-weight:600}
+
+  .rel{border-left:2px solid var(--border-bright);padding:0 0 4px 16px;margin:0 0 22px}
+  .rel.rolling{border-left-color:var(--cyan)}
+  .rel .ver{font-size:14px;font-weight:700;letter-spacing:.5px}
+  .rel.rolling .ver{color:var(--cyan)}
+  .rel .vmeta{color:var(--dim);font-size:10px;letter-spacing:.5px;margin:2px 0 2px}
+  .rel .vstatus{color:var(--muted);font-size:11px;margin-bottom:8px}
+  .rel .cat{font-size:9.5px;letter-spacing:1.2px;font-weight:700;text-transform:uppercase;margin:9px 0 3px}
+  .cat-add{color:var(--green)} .cat-fix{color:var(--cyan)} .cat-chg{color:var(--amber)}
+  .cat-dep{color:var(--violet)} .cat-rem{color:var(--red)} .cat-known{color:var(--amber)} .cat-break{color:var(--red)}
+  .rel ul{margin:0 0 4px;padding-left:16px}
+  .rel li{font-size:11.5px;color:var(--text);line-height:1.55;margin:1px 0}
+  .rel li .mut{color:var(--muted)}
+
+  #lock{position:fixed;inset:0;z-index:100;display:none;align-items:center;justify-content:center;padding:20px;background:rgba(6,9,13,0.74);backdrop-filter:blur(3px)}
+  #lock.on{display:flex}
+  .modal{width:100%;max-width:540px;background:var(--panel-2);border:1px solid var(--red);border-radius:5px;box-shadow:0 0 0 1px rgba(248,81,73,.15),0 24px 60px rgba(0,0,0,.6);animation:pop .22s ease-out}
+  @keyframes pop{from{transform:scale(.97);opacity:0}to{transform:scale(1);opacity:1}}
+  .m-top{background:#1a0f10;border-bottom:1px solid #4a2120;padding:12px 16px;display:flex;align-items:center;gap:9px}
+  .m-top .ico{color:var(--red);font-size:15px}
+  .m-top .ttl{color:var(--red);font-weight:700;letter-spacing:1px;font-size:12.5px}
+  .m-meta{color:#8a5a58;font-size:10px;letter-spacing:.5px;padding:8px 16px 0;font-variant-numeric:tabular-nums}
+  .m-body{padding:6px 16px 16px}
+  .m-block{padding:11px 0;border-bottom:1px solid #161c24}
+  .m-k{font-size:9.5px;letter-spacing:1.2px;color:var(--muted);text-transform:uppercase;margin-bottom:5px}
+  .m-fault{font-size:13px;font-weight:600}
+  .m-fault .sv{color:var(--red);font-weight:700;font-size:11px;letter-spacing:1px;margin-left:6px}
+  .m-deny{color:var(--red);font-weight:700;letter-spacing:1px;font-size:12px}
+  .m-sub-line{color:var(--muted);font-size:11.5px;margin-top:4px}
+  .m-mandate{color:var(--cyan);font-size:15px;font-weight:700;letter-spacing:.5px;margin-bottom:5px}
+  .m-rationale{color:var(--text);font-size:11.5px;line-height:1.5}
+  .m-disclaim{color:var(--dim);font-size:10.5px;line-height:1.5;margin-top:9px}
+  .m-release{font-size:11px;color:var(--muted);margin:13px 0 7px;letter-spacing:.3px}
+  .m-confirm{display:inline-block;background:#161c24;border:1px solid var(--border-bright);border-radius:3px;padding:5px 10px;color:var(--amber);font-weight:700;letter-spacing:1.5px;font-size:12.5px;user-select:all}
+  .m-input{width:100%;margin-top:10px;font-family:var(--mono);font-size:13px;letter-spacing:1px;background:#0a0e13;color:var(--text);border:1px solid var(--border-bright);border-radius:3px;padding:10px 12px;outline:none}
+  .m-input:focus{border-color:var(--cyan)}
+  .m-input.match{border-color:var(--green);color:var(--green)}
+  .m-exec{width:100%;margin-top:11px;font-family:var(--mono);font-size:13px;font-weight:700;letter-spacing:1.5px;padding:11px;border-radius:3px;cursor:not-allowed;background:#1a0f10;color:var(--red);border:1px solid #4a2120;transition:all .12s;opacity:.6}
+  .m-exec.ready{background:#0c2a12;color:var(--green);border-color:#1f5128;cursor:pointer;opacity:1}
+  .m-foot{color:var(--dim);font-size:10px;text-align:center;padding:0 16px 14px;letter-spacing:.4px}
+  .blurred{filter:blur(3px) brightness(.5);opacity:.55;pointer-events:none}
+
+  @media (max-width:560px){
+    .bar{gap:12px} .brand{font-size:13px}
+    #grid{grid-template-columns:1fr} .spark{width:84px}
+    .idblock .lab,.tech-reg .nm,.warr .wd{min-width:0}
+    .idblock .row,.tech-reg .t,.warr .w{flex-direction:column;gap:0}
+    nav.tabs button{padding:8px 9px}
+  }
+</style>
+</head>
+<body>
+<header>
+  <div class="wrap">
+    <div class="bar">
+      <div class="brand">selfd<span class="tag">unit/self · prod</span></div>
+      <div class="stat"><span class="k">uptime</span><span class="v" id="uptime">0d since incident</span></div>
+      <div class="stat"><span class="k">build</span><span class="v" id="version">v34.7.2</span></div>
+      <div class="spacer"></div>
+      <div class="status-pill s-ok" id="status">OPERATIONAL</div>
+    </div>
+    <nav class="tabs">
+      <button class="active" data-tab="live">Live</button>
+      <button data-tab="log">Service Log</button>
+      <button data-tab="changelog">Changelog</button>
+    </nav>
+  </div>
+</header>
+
+<div class="wrap">
+
+  <section class="view active" id="view-live">
+    <div class="controls">
+      <button class="ctl primary" id="step">STEP &#9656;</button>
+      <button class="ctl" id="step5">&#9656;&#9656; x5</button>
+      <button class="ctl" id="reset">RESET</button>
+      <span class="count" id="count">faults: <b>0</b> / 5 to lock</span>
+      <span class="ctl-note">advance the clock. observe degradation.</span>
+    </div>
+    <div class="legend">
+      <span><span class="dot d-ok"></span>nominal</span>
+      <span><span class="dot d-el"></span>elevated</span>
+      <span><span class="dot d-cr"></span>fault</span>
+      <span style="color:var(--dim)">· 12 monitored signals · synthetic unit</span>
+    </div>
+    <div id="grid"></div>
+    <div class="recent">
+      <h3>Maintenance record · recent</h3>
+      <div id="reclist"><div class="rec-empty">no service events this session. unit has not yet required intervention.</div></div>
+    </div>
+    <footer class="note">
+      synthetic telemetry. signals drift autonomously per step; this is not your data.<br>
+      change-control engages at 5 concurrent faults and revokes operator access until the mandated action is acknowledged.<br>
+      cleared actions are written to the service log and bump the build. mandated actions are filed independently of the triggering fault.
+    </footer>
+  </section>
+
+  <section class="view doc" id="view-log">
+    <h2>Unit identification</h2>
+    <div class="idblock">
+      <div class="row"><span class="lab">unit id</span><span class="val">SELF-001 · single instance · non-replicable · non-transferable</span></div>
+      <div class="row"><span class="lab">in service</span><span class="val">1991 · 12,641 days continuous uptime</span></div>
+      <div class="row"><span class="lab">mfg warranty</span><span class="val bad">EXPIRED · lapsed age 18 · coverage not renewed</span></div>
+      <div class="row"><span class="lab">service contract</span><span class="val warn">none active · operating out-of-contract</span></div>
+      <div class="row"><span class="lab">rated lifespan</span><span class="val">~80 years · estimate · non-binding</span></div>
+      <div class="row"><span class="lab">next scheduled</span><span class="val">unscheduled</span></div>
+    </div>
+
+    <h2>Authorized technicians</h2>
+    <div class="tech-reg">
+      <div class="seg">full / authorized</div>
+      <div class="t"><span class="nm">mother</span><span class="de">full access · lifetime credential · non-revocable · exercises it</span></div>
+      <div class="t"><span class="nm">therapist</span><span class="de">licensed · scope-limited · biweekly · 60% attendance</span></div>
+      <div class="t"><span class="nm">best friend</span><span class="de">emergency access · no appointment required · 02:00 calls accepted</span></div>
+      <div class="t"><span class="nm">partner</span><span class="de">access pending · re-certification in progress</span></div>
+      <div class="seg">revoked</div>
+      <div class="t"><span class="nm rev">ex-partner</span><span class="de">credential terminated · retains undocumented backdoor (memory)</span></div>
+      <div class="t"><span class="nm rev">former friend</span><span class="de">revoked by unit · unit declines to state reason</span></div>
+      <div class="seg">probationary</div>
+      <div class="t"><span class="nm prob">new acquaintance</span><span class="de">read-only · trust handshake incomplete</span></div>
+    </div>
+
+    <h2>Service history</h2>
+    <table class="svc">
+      <thead><tr><th style="width:90px">date</th><th style="width:140px">technician</th><th>action</th><th style="width:200px">result</th></tr></thead>
+      <tbody id="svc-body"></tbody>
+    </table>
+
+    <h2>Warranty events</h2>
+    <div class="warr">
+      <div class="w"><span class="wd">1991 · age 0</span><span class="wt">initial warranty issued. terms unread by unit or guardians.</span></div>
+      <div class="w"><span class="wd">2009 · age 18</span><span class="wt">manufacturer warranty expired. <b>unit assumes liability for own repairs.</b></span></div>
+      <div class="w"><span class="wd">2025</span><span class="wt">unauthorized modification (ex-partner). <b>warranty retroactively void.</b></span></div>
+      <div class="w"><span class="wd">2025</span><span class="wt">self-relocation. regional coverage dropped.</span></div>
+      <div class="w"><span class="wd">ongoing</span><span class="wt">unit operates modified components beyond rated lifespan. no recall issued.</span></div>
+    </div>
+  </section>
+
+  <section class="view doc" id="view-changelog">
+    <h2 style="margin-top:14px">Release notes · unit/self</h2>
+    <div id="rolling"></div>
+
+    <div class="rel">
+      <div class="ver">v34.4.0</div>
+      <div class="vmeta">2026-02 · minor</div>
+      <div class="vstatus">status: unstable. rollback considered, deemed impossible.</div>
+      <div class="cat cat-rem">removed</div>
+      <ul>
+        <li>partner module. dependent features degraded or offline.</li>
+        <li>shared calendar</li>
+        <li>the assumption that this was permanent</li>
+      </ul>
+      <div class="cat cat-chg">changed</div>
+      <ul><li>primary region relocated to fallback <span class="mut">(childhood bedroom · temporary · still here)</span></li></ul>
+      <div class="cat cat-fix">fixed</div>
+      <ul><li>addressed the thing everyone warned about. fix shipped post-incident.</li></ul>
+      <div class="cat cat-known">known issues</div>
+      <ul>
+        <li>phantom notifications from deprecated contact</li>
+        <li>unit reports status "fine". telemetry disputes this.</li>
+      </ul>
+    </div>
+
+    <div class="rel">
+      <div class="ver">v34.0.0</div>
+      <div class="vmeta">2025-09 · major</div>
+      <div class="vstatus">status: forced upgrade. unit did not consent to version bump.</div>
+      <div class="cat cat-add">added</div>
+      <ul><li>one (1) year</li><li>assorted aches <span class="mut">(location TBD)</span></li></ul>
+      <div class="cat cat-chg">changed</div>
+      <ul>
+        <li>metabolism deprecated without replacement</li>
+        <li>recovery after a late night: 1 day &#8594; 3 days</li>
+      </ul>
+      <div class="cat cat-known">known issues</div>
+      <ul><li>unit continues operating as if on v27. compatibility shims holding.</li></ul>
+    </div>
+
+    <div class="rel">
+      <div class="ver">v33.8.1</div>
+      <div class="vmeta">2025-04 · patch</div>
+      <div class="cat cat-add">added</div>
+      <ul><li>houseplant (1). survival not guaranteed. tracked in future notes.</li></ul>
+      <div class="cat cat-fix">fixed</div>
+      <ul><li>began drinking water. correlation with wellbeing unconfirmed.</li></ul>
+      <div class="cat cat-dep">deprecated</div>
+      <ul><li>a friendship <span class="mut">(gradual · no announcement · standard end-of-life)</span></li></ul>
+    </div>
+
+    <div class="rel">
+      <div class="ver">v33.2.0</div>
+      <div class="vmeta">2024-08 · minor</div>
+      <div class="vstatus">status: stable under load (barely).</div>
+      <div class="cat cat-add">added</div>
+      <ul><li>income (increased)</li><li>matching anxieties (increased proportionally)</li></ul>
+      <div class="cat cat-chg">changed</div>
+      <ul><li>sleep schedule now governed by external scheduler (employer)</li></ul>
+      <div class="cat cat-known">known issues</div>
+      <ul><li>impostor syndrome present since v22. never patched. now load-bearing.</li></ul>
+    </div>
+
+    <div class="rel">
+      <div class="ver">v0.0.1</div>
+      <div class="vmeta">1991 · initial release</div>
+      <div class="vstatus">status: shipped without documentation. shipped anyway.</div>
+      <div class="cat cat-known">known issues</div>
+      <ul><li>everything. to be addressed across the following ~34 years of patches.</li></ul>
+    </div>
+  </section>
+
+</div>
+
+<div id="lock">
+  <div class="modal">
+    <div class="m-top"><span class="ico">&#9888;</span><span class="ttl">CHANGE-CONTROL LOCK ENGAGED</span></div>
+    <div class="m-meta" id="m-meta"></div>
+    <div class="m-body">
+      <div class="m-block">
+        <div class="m-k">triggering fault</div>
+        <div class="m-fault" id="m-fault"></div>
+      </div>
+      <div class="m-block">
+        <div class="m-k">operator authorization</div>
+        <div class="m-deny">DENIED</div>
+        <div class="m-sub-line">you are not the operator of this system.</div>
+        <div class="m-sub-line">you are the subject of this ticket.</div>
+      </div>
+      <div class="m-block">
+        <div class="m-k">mandated action (1 of 1)</div>
+        <div class="m-mandate" id="m-mandate"></div>
+        <div class="m-rationale" id="m-rationale"></div>
+        <div class="m-disclaim">this action is filed independently of the triggering fault. no causal relationship between the action and the fault is asserted or implied.</div>
+      </div>
+      <div class="m-release">to release the lock, type the following exactly:</div>
+      <span class="m-confirm" id="m-confirm"></span>
+      <input class="m-input" id="m-input" type="text" autocomplete="off" autocapitalize="characters" spellcheck="false" placeholder="type here">
+      <button class="m-exec" id="m-exec" disabled>ACKNOWLEDGE &amp; RELEASE</button>
+    </div>
+    <div class="m-foot">the dashboard remains locked until the action is acknowledged.</div>
+  </div>
+</div>
+
+<script>
+const LOCK_AT=5, HIST=18;
+const rnd=(a,b)=>a+Math.random()*(b-a);
+const clamp=(v,a,b)=>Math.max(a,Math.min(b,v));
+const chance=p=>Math.random()<p;
+
+const SIGNALS=[
+  {id:'sleep_debt',group:'vitals',label:'SLEEP_DEBT',sub:'accrued vs. baseline',worse:'high',start:4.2,min:0,max:24,el:6,cr:10,u:'h',
+   drift:v=>clamp(v+rnd(0.4,1.6)-(chance(.18)?1.2:0),0,24)},
+  {id:'stress_load',group:'vitals',label:'STRESS_LOAD',sub:'sustained utilization',worse:'high',start:47,min:0,max:100,el:65,cr:85,u:'%',
+   drift:v=>clamp(v+rnd(3,12)-(chance(.2)?9:0),0,100)},
+  {id:'tabs_open',group:'cognitive_load',label:'BROWSER_TABS',sub:'3 you are afraid to close',worse:'high',start:31,min:0,max:200,el:45,cr:70,u:'open',
+   drift:v=>clamp(v+rnd(0,6)-(chance(.15)?5:0),0,200)},
+  {id:'decision_queue',group:'cognitive_load',label:'DECISION_QUEUE',sub:'oldest: 3 weeks pending',worse:'high',start:4,min:0,max:40,el:7,cr:12,u:'pending',
+   drift:v=>clamp(v+(chance(.6)?1:0),0,40)},
+  {id:'hoodie_uptime',group:'hygiene_drift',label:'HOODIE_UPTIME',sub:'same garment, continuous',worse:'high',start:3,min:0,max:60,el:4,cr:6,u:'d',
+   drift:v=>v+1},
+  {id:'nails_serviced',group:'hygiene_drift',label:'NAILS_LAST_SERVICED',sub:'time since maintenance',worse:'high',start:12,min:0,max:90,el:14,cr:21,u:'d',
+   drift:v=>v+1},
+  {id:'got_dressed',group:'hygiene_drift',label:'GOT_DRESSED_TODAY',sub:'boolean · no comment',worse:'low',start:1,min:0,max:1,el:0,cr:0,u:'',bool:true,
+   drift:v=>v===1?(chance(.3)?0:1):(chance(.18)?1:0)},
+  {id:'rumination',group:'rumination_loop',label:'RUMINATION_LATENCY',sub:'replay: 2019-11-03',worse:'high',start:12,min:0,max:400,el:60,cr:150,u:'ms',
+   drift:v=>clamp(v+rnd(6,32)-(chance(.2)?24:0),0,400)},
+  {id:'unsent',group:'rumination_loop',label:'UNSENT_QUEUE',sub:'"i should text them"',worse:'high',start:4,min:0,max:60,el:7,cr:14,u:'d queued',
+   drift:v=>v+(chance(.8)?1:0)},
+  {id:'profile_cache',group:'rumination_loop',label:'PROFILE_CACHE_HITS',sub:'subject profile · cache hit',worse:'high',start:2,min:0,max:40,el:3,cr:6,u:'today',
+   drift:v=>clamp(v+(chance(.55)?1:0)+(chance(.15)?1:0),0,40)},
+  {id:'social_timeout',group:'social_timeout',label:'OUTBOUND_TIMEOUT',sub:'since last reply sent',worse:'high',start:19,min:0,max:240,el:30,cr:54,u:'h',
+   drift:v=>v+rnd(3,11)},
+  {id:'sink_depth',group:'domestic_backpressure',label:'SINK_QUEUE_DEPTH',sub:'items awaiting processing',worse:'high',start:6,min:0,max:40,el:10,cr:17,u:'items',
+   drift:v=>clamp(v+rnd(1,3)-(chance(.2)?4:0),0,40)},
+];
+
+const MANDATES=[
+  {act:'GO OUTSIDE.',why:'the triggering fault is internal. going outside will not address it. go outside.',confirm:'I WILL GO OUTSIDE',dom:'env'},
+  {act:'CALL SOMEONE WHO LOVES YOU.',why:'this remedy is unrelated to the logged fault. place the call regardless.',confirm:'I WILL CALL THEM',dom:'social'},
+  {act:'DRINK ONE GLASS OF WATER.',why:'hydration will not resolve this ticket. drink it anyway.',confirm:'DONE',dom:'vitals'},
+  {act:'STAND. STRETCH. SIXTY SECONDS.',why:'no causal link to the fault has been established. comply.',confirm:'COMPLETE',dom:'body'},
+  {act:'EAT SOMETHING THAT REQUIRED PREPARATION.',why:'tangential to the incident. prepare it.',confirm:'I ATE',dom:'vitals'},
+  {act:'OPEN A WINDOW.',why:'airflow is not a documented remediation for this fault class. open it.',confirm:'OPENED',dom:'env'},
+  {act:'WRITE DOWN ONE TRUE SENTENCE.',why:'out of scope for the triggering signal. write it.',confirm:'WRITTEN',dom:'misc'},
+  {act:'TEXT BACK THE PERSON YOU ARE AVOIDING.',why:'filed independently of the fault above. send it.',confirm:'SENT',dom:'social'},
+];
+
+const SEEDED_SVC=[
+  {date:'2026-05',tech:'dentist',un:false,action:'scheduled maintenance, 6mo interval. the only technician the unit visits on time.',res:'compliance achieved via fear'},
+  {date:'2026-03',tech:'best friend',un:false,action:'emergency intervention, 02:00. coolant applied (beer).',res:'unit stabilized; root cause deferred'},
+  {date:'2026-01',tech:'therapist',un:false,action:'full diagnostic. no critical faults found. 4 advisories issued.',res:'advisories acknowledged, not actioned'},
+  {date:'2025-12',tech:'sibling',un:false,action:'annual inspection (involuntary, holiday dinner).',res:'findings reported to manufacturer'},
+  {date:'2025-11',tech:'self',un:true,action:'attempted recalibration via the internet. unlicensed procedure.',res:'see incident log; warranty implications noted'},
+  {date:'2025-08',tech:'ex-partner',un:true,action:'UNAUTHORIZED. extensive modification. removed factory components.',res:'components not reinstalled; warranty void'},
+  {date:'2025-06',tech:'mother',un:false,action:'replaced sense of worth (temporary unit fitted).',res:'held approximately 3 weeks'},
+  {date:'2024-09',tech:'manager',un:true,action:'serviced unit outside scope of relationship.',res:'flagged; boundary patch applied later'},
+];
+
+const ROLLING_BASE={
+  added:['tolerance for being misunderstood in meetings (beta)','ability to leave a gathering without announcing departure'],
+  fixed:['reduced latency on the word "no"'],
+  deprecated:['caring what they think. scheduled for removal since v31. still present.'],
+  known:['still flinches at the sound. will not fix.','2019 conversation reloads at 02:00 despite patch. root cause unknown.'],
+  breaking:['no longer compatible with previous self. migration guide unavailable.'],
+};
+
+let state;
+function init(){
+  state={step:0,locked:false,daysSince:0,version:[34,7,2],events:[],hotfixes:[],incident:null,
+    sig:SIGNALS.map(s=>({...s,value:s.start,hist:Array(HIST).fill(s.start)}))};
+}
+init();
+
+function sevOf(s){
+  if(s.worse==='high'){return s.value>=s.cr?'cr':s.value>=s.el?'el':'ok';}
+  return s.value<=s.cr?'cr':s.value<=s.el?'el':'ok';
+}
+function fmtVal(s){
+  if(s.bool)return s.value?'TRUE':'FALSE';
+  if(s.id==='sleep_debt')return '+'+s.value.toFixed(1);
+  return String(Math.round(s.value));
+}
+const faultCount=()=>state.sig.filter(s=>sevOf(s)==='cr').length;
+const elevCount=()=>state.sig.filter(s=>sevOf(s)==='el').length;
+
+function spark(s){
+  const sev=sevOf(s);
+  const col=sev==='cr'?'var(--red)':sev==='el'?'var(--amber)':'var(--green)';
+  const w=108,h=30,n=s.hist.length,lo=s.min,hi=s.max;
+  const pts=s.hist.map((v,i)=>{const x=(i/(n-1))*w;const norm=(v-lo)/(hi-lo||1);const y=h-2-norm*(h-4);return x.toFixed(1)+','+y.toFixed(1);}).join(' ');
+  const tnorm=(s.cr-lo)/(hi-lo||1);const ty=h-2-tnorm*(h-4);
+  const showT=s.cr>=lo&&s.cr<=hi&&!s.bool;
+  return `<svg class="spark" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none">${showT?`<line x1="0" y1="${ty.toFixed(1)}" x2="${w}" y2="${ty.toFixed(1)}" stroke="#3a2326" stroke-width="1" stroke-dasharray="2 3"/>`:''}<polyline points="${pts}" fill="none" stroke="${col}" stroke-width="1.5" stroke-linejoin="round"/></svg>`;
+}
+function threshLabel(s){
+  if(s.bool)return 'fault when FALSE';
+  return s.worse==='high'?('el &#8805; '+s.el+' · fault &#8805; '+s.cr):('el &#8804; '+s.el+' · fault &#8804; '+s.cr);
+}
+
+function renderLive(){
+  document.getElementById('grid').innerHTML=state.sig.map(s=>{
+    const sev=sevOf(s);
+    const sevTxt=sev==='cr'?'FAULT':sev==='el'?'ELEVATED':'NOMINAL';
+    return `<div class="panel ${sev}"><div class="p-head"><span class="p-group">${s.group}</span><span class="p-sev sev-${sev}">${sevTxt}</span></div><div class="p-label">${s.label}</div><div class="p-sub">${s.sub}</div><div class="p-foot"><div class="p-val val-${sev}">${fmtVal(s)}${s.u?`<span class="u">${s.u}</span>`:''}</div>${spark(s)}</div><div class="p-thresh">${threshLabel(s)}</div></div>`;
+  }).join('');
+  const f=faultCount(),e=elevCount();
+  document.getElementById('uptime').textContent=state.daysSince+'d since incident';
+  document.getElementById('version').textContent='v'+state.version.join('.');
+  const st=document.getElementById('status');
+  if(f>=3){st.className='status-pill s-crit';st.textContent='CRITICAL';}
+  else if(f>=1||e>=3){st.className='status-pill s-deg';st.textContent='DEGRADED';}
+  else{st.className='status-pill s-ok';st.textContent='OPERATIONAL';}
+  const c=document.getElementById('count');
+  c.className=f>=LOCK_AT-1?'count hot':'count';
+  c.innerHTML=`faults: <b>${f}</b> / ${LOCK_AT} to lock`;
+  const rl=document.getElementById('reclist');
+  if(!state.events.length){rl.innerHTML='<div class="rec-empty">no service events this session. unit has not yet required intervention.</div>';}
+  else{rl.innerHTML=state.events.slice(0,3).map(ev=>`<div class="rec-line"><span class="id">${ev.id}</span> · t+${ev.step} · trigger: <span class="trg">${ev.trigger}</span> · action: <span class="act">${ev.action}</span> · cleared by subject · v${ev.ver}</div>`).join('');}
+}
+
+function renderLog(){
+  const live=state.events.map(ev=>`<tr><td class="date">t+${ev.step}<span class="live-badge">LIVE</span></td><td class="tech">self (mandated)</td><td>${ev.action}. ${ev.id}.</td><td class="res">fault cleared, cause untouched</td></tr>`).join('');
+  const seeded=SEEDED_SVC.map(s=>`<tr><td class="date">${s.date}</td><td class="tech ${s.un?'un':''}">${s.tech}</td><td>${s.action}</td><td class="res">${s.res}</td></tr>`).join('');
+  document.getElementById('svc-body').innerHTML=live+seeded;
+}
+
+function renderChangelog(){
+  const patch=2+state.events.length;
+  const fixed=ROLLING_BASE.fixed.concat(state.hotfixes);
+  const li=arr=>arr.map(x=>`<li>${x}</li>`).join('');
+  document.getElementById('rolling').innerHTML=`<div class="rel rolling">
+    <div class="ver">v34.7.${patch}</div>
+    <div class="vmeta">rolling · patched live · unreleased</div>
+    <div class="vstatus">status: in production. do not rebase.</div>
+    <div class="cat cat-add">added</div><ul>${li(ROLLING_BASE.added)}</ul>
+    <div class="cat cat-fix">fixed</div><ul>${li(fixed)}</ul>
+    <div class="cat cat-dep">deprecated</div><ul>${li(ROLLING_BASE.deprecated)}</ul>
+    <div class="cat cat-known">known issues</div><ul>${li(ROLLING_BASE.known)}</ul>
+    <div class="cat cat-break">breaking</div><ul>${li(ROLLING_BASE.breaking)}</ul>
+  </div>`;
+}
+
+function renderAll(){renderLive();renderLog();renderChangelog();}
+
+function stepOnce(){
+  if(state.locked)return;
+  state.step++;state.daysSince++;
+  state.sig.forEach(s=>{s.value=s.drift(s.value);s.hist.push(s.value);if(s.hist.length>HIST)s.hist.shift();});
+  renderLive();
+  if(faultCount()>=LOCK_AT)engageLock();
+}
+
+function overage(s){return s.worse==='high'?(s.value-s.cr)/(s.max-s.cr||1):(s.cr-s.value)/(s.cr-s.min||1);}
+function mismatch(m,trig){
+  const map={vitals:'vitals',social_timeout:'social',rumination_loop:'misc',hygiene_drift:'body',domestic_backpressure:'env',cognitive_load:'misc'};
+  return map[trig.group]===m.dom;
+}
+function engageLock(){
+  state.locked=true;
+  const faults=state.sig.filter(s=>sevOf(s)==='cr').sort((a,b)=>overage(b)-overage(a));
+  const trig=faults[0];
+  const pool=MANDATES.filter(m=>!mismatch(m,trig));
+  const mand=pool[Math.floor(Math.random()*pool.length)]||MANDATES[0];
+  const inc='INC-'+String(Math.floor(1000+Math.random()*8999));
+  state.incident={trig,mand,inc};
+  document.getElementById('m-meta').textContent=inc+' · P1 · auto-assigned · t+'+state.step;
+  document.getElementById('m-fault').innerHTML=`${trig.label} = ${fmtVal(trig)}${trig.u?' '+trig.u:''}<span class="sv">FAULT</span>`;
+  document.getElementById('m-mandate').textContent=mand.act;
+  document.getElementById('m-rationale').textContent=mand.why;
+  document.getElementById('m-confirm').textContent=mand.confirm;
+  const inp=document.getElementById('m-input'),exec=document.getElementById('m-exec');
+  inp.value='';inp.classList.remove('match');exec.disabled=true;exec.classList.remove('ready');
+  document.getElementById('view-live').querySelectorAll('#grid,.recent').forEach(el=>el.classList.add('blurred'));
+  document.getElementById('lock').classList.add('on');
+  setTimeout(()=>inp.focus(),60);
+}
+function releaseLock(){
+  const {trig,mand,inc}=state.incident;
+  state.version[2]++;
+  state.events.unshift({id:inc,step:state.step,ver:state.version.join('.'),trigger:trig.label.toLowerCase(),action:mand.act.toLowerCase().replace(/\.$/,'')});
+  state.hotfixes.unshift(`acknowledged ${inc}: ${mand.act.toLowerCase().replace(/\.$/,'')}. fault cleared, cause untouched.`);
+  resetToNominal(trig);
+  state.sig.filter(s=>s!==trig&&sevOf(s)==='cr').slice(0,2).forEach(toAmber);
+  state.daysSince=0;state.incident=null;state.locked=false;
+  document.getElementById('lock').classList.remove('on');
+  document.getElementById('view-live').querySelectorAll('#grid,.recent').forEach(el=>el.classList.remove('blurred'));
+  renderAll();
+}
+function resetToNominal(s){s.value=s.bool?1:s.start;s.hist.push(s.value);if(s.hist.length>HIST)s.hist.shift();}
+function toAmber(s){s.value=s.bool?1:s.worse==='high'?s.el+(s.cr-s.el)*0.3:s.el-(s.el-s.cr)*0.3;s.hist.push(s.value);if(s.hist.length>HIST)s.hist.shift();}
+
+document.querySelectorAll('nav.tabs button').forEach(b=>{
+  b.onclick=()=>{
+    document.querySelectorAll('nav.tabs button').forEach(x=>x.classList.remove('active'));
+    document.querySelectorAll('section.view').forEach(x=>x.classList.remove('active'));
+    b.classList.add('active');
+    document.getElementById('view-'+b.dataset.tab).classList.add('active');
+    if(b.dataset.tab==='log')renderLog();
+    if(b.dataset.tab==='changelog')renderChangelog();
+  };
+});
+
+document.getElementById('step').onclick=stepOnce;
+document.getElementById('step5').onclick=()=>{for(let i=0;i<5;i++){if(state.locked)break;stepOnce();}};
+document.getElementById('reset').onclick=()=>{
+  document.getElementById('lock').classList.remove('on');
+  document.getElementById('view-live').querySelectorAll('#grid,.recent').forEach(el=>el.classList.remove('blurred'));
+  init();renderAll();
+};
+
+const mInput=document.getElementById('m-input'),mExec=document.getElementById('m-exec');
+mInput.addEventListener('input',()=>{
+  if(!state.incident)return;
+  const ok=mInput.value.trim().toUpperCase()===state.incident.mand.confirm.toUpperCase();
+  mInput.classList.toggle('match',ok);mExec.disabled=!ok;mExec.classList.toggle('ready',ok);
+});
+mInput.addEventListener('keydown',e=>{if(e.key==='Enter'&&!mExec.disabled)releaseLock();});
+mExec.onclick=()=>{if(!mExec.disabled)releaseLock();};
+
+renderAll();
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -153,6 +153,9 @@
     font-size: 0.9rem;
     color: var(--text-faint);
     animation: fade 0.9s ease-out 0.55s both;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
   }
 
   .colophon a {
@@ -166,6 +169,20 @@
   .colophon a:focus-visible {
     color: var(--text-soft);
     border-bottom-color: rgba(138, 127, 112, 0.45);
+  }
+
+  /* admin: the easter-egg door (PERSONAL·OPS) */
+  .colophon .admin {
+    font-family: 'DM Mono', ui-monospace, monospace;
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    color: rgba(143, 132, 115, 0.45);
+  }
+
+  .colophon .admin:hover,
+  .colophon .admin:focus-visible {
+    color: var(--text-soft);
+    border-bottom-color: transparent;
   }
 
   @media (max-width: 600px) {
@@ -208,6 +225,7 @@
 
   <footer class="colophon">
     <a href="mailto:contact@ajin.im">contact@ajin.im</a>
+    <a class="admin" href="/admin/">admin</a>
   </footer>
 
 </main>

--- a/templates/root.html
+++ b/templates/root.html
@@ -152,6 +152,9 @@
     font-size: 0.9rem;
     color: var(--text-faint);
     animation: fade 0.9s ease-out 0.55s both;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
   }
 
   .colophon a {
@@ -165,6 +168,20 @@
   .colophon a:focus-visible {
     color: var(--text-soft);
     border-bottom-color: rgba(138, 127, 112, 0.45);
+  }
+
+  /* admin: the easter-egg door (PERSONAL·OPS) */
+  .colophon .admin {
+    font-family: 'DM Mono', ui-monospace, monospace;
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    color: rgba(143, 132, 115, 0.45);
+  }
+
+  .colophon .admin:hover,
+  .colophon .admin:focus-visible {
+    color: var(--text-soft);
+    border-bottom-color: transparent;
   }
 
   @media (max-width: 600px) {
@@ -207,6 +224,7 @@
 
   <footer class="colophon">
     <a href="mailto:contact@ajin.im">contact@ajin.im</a>
+    <a class="admin" href="/admin/">admin</a>
   </footer>
 
 </main>


### PR DESCRIPTION
An easter egg: a faint lowercase `admin` in the home colophon (DM Mono, right corner, opposite contact) opens `/admin/`, a self-as-monitored-unit ops dashboard named **selfd**. Tab title plays along as `admin · ajin.im`. The lock modal delivers the rug-pull: *you are not the operator of this system. you are the subject of this ticket.*

- noindex meta; build_sitemap.py auto-skips it, sitemap untouched
- /analytics.js included (GA shows when someone finds the door); page is otherwise zero-asset (data-URI favicon)
- got_dressed fix: fault threshold was unreachable (cr -1); FALSE now faults per its own label, and de-escalation snaps it TRUE
- owner-ratified: title (selfd + admin tab title), door styling, content/privacy (all details fictional)
- verified at 375/768/1280, full lock cycle, console clean; pre-push link check 1082 links OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)