### PR TITLE
site: /admin selfd brand is the exit door (swings open onto ajin.im, same tab)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -18,12 +18,19 @@
   *{box-sizing:border-box}
   html,body{margin:0;padding:0}
   body{background:var(--bg);color:var(--text);font-family:var(--mono);font-size:13px;line-height:1.4;-webkit-font-smoothing:antialiased;padding:0 0 60px}
+  /* the exit: clicking the brand swings the whole page open onto ajin.im's warm light */
+  html{background:var(--bg)}
+  html.door-open{background:#1a1612;overflow:hidden}
+  html.door-open body{transform-origin:0 50%;animation:doorswing .7s cubic-bezier(.45,.05,.55,.2) forwards;pointer-events:none}
+  @keyframes doorswing{to{transform:perspective(1100px) rotateY(-80deg);opacity:0}}
   .wrap{max-width:1120px;margin:0 auto;padding:0 16px}
 
   header{position:sticky;top:0;z-index:10;background:linear-gradient(180deg,#0a0e14 78%,rgba(10,14,20,0.9));border-bottom:1px solid var(--border);backdrop-filter:blur(4px)}
   .bar{display:flex;align-items:center;gap:18px;flex-wrap:wrap;padding:12px 0 0}
   .brand{font-weight:700;letter-spacing:1.5px;font-size:14px}
   .brand .tag{color:var(--dim);font-weight:400;letter-spacing:0;margin-left:8px;font-size:11px}
+  .brand a{color:inherit;text-decoration:none}
+  .brand a:hover{color:#e6edf3}
   .stat{display:flex;flex-direction:column;line-height:1.25}
   .stat .k{color:var(--muted);font-size:10px;letter-spacing:.5px;text-transform:uppercase}
   .stat .v{font-size:13px;font-weight:600;font-variant-numeric:tabular-nums}
@@ -158,7 +165,7 @@
 <header>
   <div class="wrap">
     <div class="bar">
-      <div class="brand">selfd<span class="tag">unit/self · prod</span></div>
+      <div class="brand"><a id="exit" href="/" target="_self" title="exit">selfd</a><span class="tag">unit/self · prod</span></div>
       <div class="stat"><span class="k">uptime</span><span class="v" id="uptime">0d since incident</span></div>
       <div class="stat"><span class="k">build</span><span class="v" id="version">v34.7.2</span></div>
       <div class="spacer"></div>
@@ -560,6 +567,13 @@ mInput.addEventListener('input',()=>{
 });
 mInput.addEventListener('keydown',e=>{if(e.key==='Enter'&&!mExec.disabled)releaseLock();});
 mExec.onclick=()=>{if(!mExec.disabled)releaseLock();};
+
+document.getElementById('exit').addEventListener('click',e=>{
+  e.preventDefault();
+  if(matchMedia('(prefers-reduced-motion: reduce)').matches){location.href='/';return;}
+  document.documentElement.classList.add('door-open');
+  setTimeout(()=>{location.href='/';},640);
+});
 
 renderAll();
 </script>


### PR DESCRIPTION
Follow-up to #179. The brand `selfd` is now the way back: clicking it swings the whole page open like a door (CSS rotateY about the left edge) onto ajin.im's warm background, then navigates home in the same tab. Reduced-motion users get an instant navigation. Hover brightens the handle; the tooltip whispers `exit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)