### PR TITLE
site: /admin revert whole-page exit swing; selfd exit stays a plain same-tab link

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -18,11 +18,6 @@
   *{box-sizing:border-box}
   html,body{margin:0;padding:0}
   body{background:var(--bg);color:var(--text);font-family:var(--mono);font-size:13px;line-height:1.4;-webkit-font-smoothing:antialiased;padding:0 0 60px}
-  /* the exit: clicking the brand swings the whole page open onto ajin.im's warm light */
-  html{background:var(--bg)}
-  html.door-open{background:#1a1612;overflow:hidden}
-  html.door-open body{transform-origin:0 50%;animation:doorswing .7s cubic-bezier(.45,.05,.55,.2) forwards;pointer-events:none}
-  @keyframes doorswing{to{transform:perspective(1100px) rotateY(-80deg);opacity:0}}
   .wrap{max-width:1120px;margin:0 auto;padding:0 16px}
 
   header{position:sticky;top:0;z-index:10;background:linear-gradient(180deg,#0a0e14 78%,rgba(10,14,20,0.9));border-bottom:1px solid var(--border);backdrop-filter:blur(4px)}
@@ -567,13 +562,6 @@ mInput.addEventListener('input',()=>{
 });
 mInput.addEventListener('keydown',e=>{if(e.key==='Enter'&&!mExec.disabled)releaseLock();});
 mExec.onclick=()=>{if(!mExec.disabled)releaseLock();};
-
-document.getElementById('exit').addEventListener('click',e=>{
-  e.preventDefault();
-  if(matchMedia('(prefers-reduced-motion: reduce)').matches){location.href='/';return;}
-  document.documentElement.classList.add('door-open');
-  setTimeout(()=>{location.href='/';},640);
-});
 
 renderAll();
 </script>


### PR DESCRIPTION
Owner review verdict on #180's door animation: too much (WordArt territory). This strips the whole-page rotateY swing and its handler; `selfd` remains a plain same-tab exit link. A subtler element-scoped transition is being mocked separately and ships only after owner confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)