### PR TITLE
building: metro-match D40 hub card on /is/building

### DIFF
--- a/_scripts/world_metros/DECISIONS.md
+++ b/_scripts/world_metros/DECISIONS.md
@@ -1153,3 +1153,17 @@ one last safety check" + "clean repos or any trees").**
   factcheck worktree (its work landed on master; branch is an orphan),
   and the prepublish-namefix worktree (UNMERGED privacy fix, owner call
   pending).
+
+**D40 · Hub-listed: the /is/building norm lifts - RATIFIED 2026-06-13
+(owner: "i think now it can be listed on is/building too", after the
+zero-blocker D39 sweep).**
+- Metro Match leads the "Lately" stream on /is/building as a loose
+  single build (the IA rule: collections up top, loose builds in
+  Lately; new entries do not auto-promote to Featured). Card copy in
+  the page's plain one-liner register: "18 metro systems as trading
+  cards; pick a stat, beat the cpu." Status tag: live.
+- The OTHER soft-launch norms hold until called separately: noindex
+  stays on, the sitemap keeps skipping it (the builder auto-skips
+  noindex pages), no home-teaser line.
+- Verified: card renders at the top of Lately, link root-relative to
+  /is/building/metro-match/, one group-start, no overflow at 375/1280.

--- a/_scripts/world_metros/STATUS.md
+++ b/_scripts/world_metros/STATUS.md
@@ -241,12 +241,18 @@ _Last updated: 2026-06-12 (reconcile session: the parallel gate-3 body D25-D31 m
   the page itself and the wordmark is the way home. Nav = the four
   views; home state selects no tab; mobile tabs back to 11.5px.
 
+- D40 (2026-06-13, owner call): HUB-LISTED. The owner lifted the
+  /is/building norm after the zero-blocker D39 sweep: Metro Match now
+  leads the "Lately" stream on /is/building ("18 metro systems as
+  trading cards; pick a stat, beat the cpu."). Noindex, the sitemap and
+  the home teaser stay until called separately.
+
 ## Current gate: owner live-testing the shipped deck
 
-The deck of 18 (gate 3, D25-D31) + this session's D32-D34 are LIVE at
-https://ajin.im/is/building/metro-match/ (still noindex/unlisted; the
-old world-metros URL redirects). Listing it on /is/building, the
-sitemap or the home teaser is a SEPARATE owner call. Items carried to
+The deck of 18 (gate 3, D25-D31) + D32-D39 are LIVE at
+https://ajin.im/is/building/metro-match/ and hub-listed on /is/building
+(D40; the old world-metros URL redirects). Still noindex; the sitemap
+and the home teaser are SEPARATE owner calls. Items carried to
 the live review: the 15 new epithets; the Istanbul scope call (Marmaray
 excluded, could be pulled in); the Seoul-tops-ridership claim
 (full-capital scope, sourced); Osaka's two soft spots (c.2011 diagram

--- a/is/building/index.html
+++ b/is/building/index.html
@@ -137,6 +137,13 @@
     <div class="section-label">Lately</div>
     <div class="project group-start">
       <div class="project-head">
+        <span class="project-name"><a href="/is/building/metro-match/">Metro Match</a></span>
+        <span class="project-status">live</span>
+      </div>
+      <p class="project-desc">18 metro systems as trading cards; pick a stat, beat the cpu.</p>
+    </div>
+    <div class="project">
+      <div class="project-head">
         <span class="project-name"><a href="/is/building/did-claude-just-reset-usage/">did claude just reset usage?</a></span>
         <span class="project-status">live</span>
       </div>


### PR DESCRIPTION
Owner lifted the hub-listing norm after the zero-blocker D39 sweep. Metro Match leads the Lately stream as a loose single build per the IA rule (not Featured, per the no-auto-promote norm), in the page's plain one-liner register: '18 metro systems as trading cards; pick a stat, beat the cpu.' Status: live.

Other soft-launch norms hold: noindex stays, the sitemap builder keeps auto-skipping it, no home-teaser line.

Probe-verified: card at the top of Lately, root-relative link, single group-start, no overflow at 375/1280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)