### PR TITLE
building: metro-match D41 indexable + sitemapped

### DIFF
--- a/_scripts/world_metros/DECISIONS.md
+++ b/_scripts/world_metros/DECISIONS.md
@@ -1167,3 +1167,19 @@ zero-blocker D39 sweep).**
   noindex pages), no home-teaser line.
 - Verified: card renders at the top of Lately, link root-relative to
   /is/building/metro-match/, one group-start, no overflow at 375/1280.
+
+**D41 · Indexable + sitemapped: hub-listed means default visibility -
+RATIFIED 2026-06-13 (owner: "if its on building page list it can be
+indexed, thats by default and others are like that too right?").**
+- Premise verified before lifting: all four neighbouring Lately builds
+  (the canary, LunarOnce, sky-over-seoul, omen.ops) carry no robots meta
+  and sit in sitemap.xml. Hub-listed and noindexed was the inconsistent
+  state.
+- The noindex meta leaves the generator; sitemap regenerated
+  (107 urls): /is/building/metro-match/ enters. The world-metros
+  redirect stub KEEPS its noindex + canonical (redirect pages stay out
+  of the index by design) and stays out of the sitemap.
+- Soft-launch ledger after D40/D41: hub card LISTED, noindex LIFTED,
+  sitemap IN. The home teaser is the one remaining norm, a separate
+  curation call (the IA rule: swap one of building's two teaser lines,
+  never add a third).

--- a/_scripts/world_metros/STATUS.md
+++ b/_scripts/world_metros/STATUS.md
@@ -251,8 +251,9 @@ _Last updated: 2026-06-12 (reconcile session: the parallel gate-3 body D25-D31 m
 
 The deck of 18 (gate 3, D25-D31) + D32-D39 are LIVE at
 https://ajin.im/is/building/metro-match/ and hub-listed on /is/building
-(D40; the old world-metros URL redirects). Still noindex; the sitemap
-and the home teaser are SEPARATE owner calls. Items carried to
+(D40; the old world-metros URL redirects), indexable and in the
+sitemap since D41 (2026-06-13; the redirect stub stays noindexed). The
+home teaser is the one remaining soft-launch norm, a separate call. Items carried to
 the live review: the 15 new epithets; the Istanbul scope call (Marmaray
 excluded, could be pulled in); the Seoul-tops-ridership claim
 (full-capital scope, sourced); Osaka's two soft spots (c.2011 diagram

--- a/_scripts/world_metros/build_metro_cards.py
+++ b/_scripts/world_metros/build_metro_cards.py
@@ -793,7 +793,6 @@ def main():
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="robots" content="noindex"><!-- soft launch: unlisted until the owner verdict gate -->
 <meta name="theme-color" content="#0f0f12">
 <title>Metro Match</title>
 <meta name="description" content="A collectible card deck for the world's defining metro systems. Eighteen cities, honest dated stats in two sets (scale and character), a battle and a daily guess. Trading cards with footnotes.">

--- a/is/building/metro-match/index.html
+++ b/is/building/metro-match/index.html
@@ -4,7 +4,6 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="robots" content="noindex"><!-- soft launch: unlisted until the owner verdict gate -->
 <meta name="theme-color" content="#0f0f12">
 <title>Metro Match</title>
 <meta name="description" content="A collectible card deck for the world's defining metro systems. Eighteen cities, honest dated stats in two sets (scale and character), a battle and a daily guess. Trading cards with footnotes.">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,7 +6,7 @@
   </url>
   <url>
     <loc>https://ajin.im/is/building/</loc>
-    <lastmod>2026-06-10T08:29:03+09:00</lastmod>
+    <lastmod>2026-06-13T10:08:13+09:00</lastmod>
   </url>
   <url>
     <loc>https://ajin.im/is/building/all-at-once/</loc>
@@ -39,6 +39,10 @@
   <url>
     <loc>https://ajin.im/is/building/lunaronce/</loc>
     <lastmod>2026-06-08T03:17:40+09:00</lastmod>
+  </url>
+  <url>
+    <loc>https://ajin.im/is/building/metro-match/</loc>
+    <lastmod>2026-06-13T03:43:19+09:00</lastmod>
   </url>
   <url>
     <loc>https://ajin.im/is/building/omen.ops/</loc>


### PR DESCRIPTION
Owner call: hub-listed means default visibility, like the neighbouring Lately builds (premise verified: the canary, LunarOnce, sky-over-seoul and omen.ops all carry no robots meta and sit in the sitemap).

- noindex meta removed from the generator; page rebuilt clean
- sitemap regenerated (107 urls): metro-match in; the world-metros redirect stub keeps its noindex + canonical and stays out
- remaining soft-launch norm: the home teaser only (separate curation call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)