### PR TITLE
building: metro-match D42 LAUNCHED (soft launch formally closed)

### DIFF
--- a/_scripts/world_metros/BUILD-SPEC.md
+++ b/_scripts/world_metros/BUILD-SPEC.md
@@ -106,11 +106,14 @@ that card; never shown as zero.
    freezes + D26 build record); the owner verdict on the gate-3 page is
    the open gate.
 
-## Soft-launch conditions (repo norm, unchanged)
+## Launch state (the soft launch closed at D42, 2026-06-13)
 
-`noindex` meta · not in sitemap · no `/is/building` hub card · no home-teaser
-line · site-wide `/analytics.js` loads as on every page. Lifting any of these
-is an owner call after gate 3.
+The original soft-launch bundle (noindex, no sitemap entry, no hub card,
+no home teaser) lifted in stages: hub card at D40, noindex + sitemap at
+D41, the bundle formally closed at D42. LAUNCHED: live, indexed,
+hub-listed at /is/building/metro-match/. The home teaser is homepage
+curation (swap a line, never append), decoupled from launch. Site-wide
+`/analytics.js` loads as on every page.
 
 ## Acceptance checklist
 

--- a/_scripts/world_metros/DECISIONS.md
+++ b/_scripts/world_metros/DECISIONS.md
@@ -1183,3 +1183,26 @@ indexed, thats by default and others are like that too right?").**
   sitemap IN. The home teaser is the one remaining norm, a separate
   curation call (the IA rule: swap one of building's two teaser lines,
   never add a third).
+
+**D42 · LAUNCHED: the soft launch formally closes - RATIFIED 2026-06-13
+(owner: "so this is now from soft launch to full public isnt it? there
+should be way to ratify transition").**
+- The soft launch was a four-norm bundle (BUILD-SPEC, D12): noindex, no
+  sitemap entry, no /is/building hub card, no home teaser. The transition
+  ledger: hub card LISTED at D40 (2026-06-13, after the zero-blocker D39
+  sweep); noindex LIFTED and sitemap ENTERED at D41 (2026-06-13). This
+  entry closes the bundle: METRO MATCH IS LAUNCHED, fully public at
+  https://ajin.im/is/building/metro-match/.
+- The home teaser is hereby DECOUPLED from launch: it is homepage
+  curation under the home IA rule (each verb shows exactly two lines;
+  featuring something means swapping a line, never appending a third).
+  An un-teased launched build is a normal state; the swap is a separate
+  curation call whenever the owner wants it.
+- Steady state from here: the page is live, indexed and hub-listed; data
+  refresh is the annual scripted pass (D6) over the committed snapshots
+  (geometry via build_page_geometry.py, almanac re-research, FX re-pin;
+  watch items recorded at D29/D38: Moscow's 17th line and Shanghai's
+  Line 22 arrive ~2026 and touch counts; the Osaka diagram wants a
+  re-source when a current Commons map appears). New design rounds are
+  ordinary owner-directed work, no standing gate.
+- The world-metros redirect stub stays noindexed forever by design.

--- a/_scripts/world_metros/README.md
+++ b/_scripts/world_metros/README.md
@@ -11,7 +11,7 @@ atlas vision 2026-06-12 (DECISIONS D17–D19) after four map-hero rounds
 died at their gates; the data contracts and licensing posture carry over
 unchanged.
 
-The deck is live (soft-launched, noindex) at the URL since 2026-06-12.
+The deck is LAUNCHED: live, indexed and hub-listed (soft launch closed at D42, 2026-06-13; live at the URL since 2026-06-12).
 Gate 3 (the roster scale-up) is built: all 18 cards real with lore backs
 (D27 grew the deck from 16 to 18 with Osaka + Istanbul; grid is 1/2/3
 columns, never 4), scopes frozen per city (D25/D27; Seoul completed with a

--- a/_scripts/world_metros/STATUS.md
+++ b/_scripts/world_metros/STATUS.md
@@ -1,6 +1,6 @@
 # STATUS — Metro Match (was World Metros Atlas)
 
-_Last updated: 2026-06-12 (reconcile session: the parallel gate-3 body D25-D31 merged to master as PR #164; this session's card-IA round, URL move and three-face flip recorded as D32-D34 and shipped on top)._
+_Last updated: 2026-06-13 (LAUNCHED at D42; soft launch closed)._
 
 ## Done
 
@@ -247,13 +247,22 @@ _Last updated: 2026-06-12 (reconcile session: the parallel gate-3 body D25-D31 m
   trading cards; pick a stat, beat the cpu."). Noindex, the sitemap and
   the home teaser stay until called separately.
 
-## Current gate: owner live-testing the shipped deck
+- D42 (2026-06-13, owner): LAUNCHED. The soft-launch bundle formally
+  closes (hub card D40, noindex + sitemap D41, ratified as a transition
+  at D42). The home teaser is decoupled: homepage curation, not a launch
+  norm.
 
-The deck of 18 (gate 3, D25-D31) + D32-D39 are LIVE at
-https://ajin.im/is/building/metro-match/ and hub-listed on /is/building
-(D40; the old world-metros URL redirects), indexable and in the
-sitemap since D41 (2026-06-13; the redirect stub stays noindexed). The
-home teaser is the one remaining soft-launch norm, a separate call. Items carried to
+## State: LAUNCHED (no standing gate)
+
+Metro Match is live, indexed and hub-listed at
+https://ajin.im/is/building/metro-match/ (the old world-metros URL
+redirects via a permanently noindexed stub). Steady state: the annual
+scripted refresh (D6) over committed snapshots; watch items at the next
+refresh: Moscow's 17th line and Shanghai's Line 22 (~2026) touch
+line counts, and the Osaka diagram wants a re-source when a current
+Commons map appears. The home-teaser swap on the homepage is an open
+curation option, not a gate. New rounds are ordinary owner-directed
+work. Items carried to
 the live review: the 15 new epithets; the Istanbul scope call (Marmaray
 excluded, could be pulled in); the Seoul-tops-ridership claim
 (full-capital scope, sourced); Osaka's two soft spots (c.2011 diagram


### PR DESCRIPTION
Owner ratified the transition: the soft-launch bundle is formally closed. The ledger: hub card listed at D40, noindex lifted + sitemap entered at D41, the bundle closed and ratified at D42. The home teaser is decoupled from launch (homepage curation under the swap-a-line rule).

Docs flipped from gate language to steady state: DECISIONS D42 (with the transition ledger + refresh watch items), BUILD-SPEC launch-state section, STATUS (no standing gate; annual refresh cadence), README first paragraph, registry stanza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)