### PR TITLE
site: AC00 at /is/building/ac00/ (soft-launch, noindex): hangul syllable = integer

### DIFF
--- a/_scripts/ac00/CLAUDE.md
+++ b/_scripts/ac00/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md — AC00
+
+Single-file static HTML tool. Working title `AC00` (the Unicode base codepoint for Hangul syllables). Part of ajin.im's family of single-file tools (debug::u, deadend, lemon, omen.ops): dark monospace aesthetic, human/cultural subject run through a systems lens.
+
+## Thesis
+
+Hangul composes by addition at every level. Strokes add to make letters, letters pack into a block, and the block is literally an integer:
+
+```
+codepoint = 0xAC00 + 초성_index×588 + 중성_index×28 + 종성_index
+```
+
+The eventual full claim (Phase 2): the script never bottoms out into arbitrariness. Latin eventually hits "why does A look like A" and the answer is an accident; Hangul's shapes derive from articulation + stroke-addition rules documented in the 훈민정음 해례본.
+
+## Current state
+
+**SHIPPED (Phase 1, 2026-06-13):** live at https://ajin.im/is/building/ac00/ (soft-launch: noindex, no hub listing; lifting that is Ajin's call). Source of truth is `is/building/ac00/index.html` in mobetter20.github.io; the `~/Downloads/Hangul_zoom/` mock is the pre-ship snapshot. The page has:
+
+- **Compose mode**: 19/21/28 jamo chip pickers, live glyph + schematic + equation
+- **Decompose mode**: text input (default 한글은 정수다), clickable per-syllable chips, same view
+- Live equation panel: base + three terms → hex/decimal + UTF-8 bytes
+- Layout-rule detection (vertical / horizontal / wrapped compound vowel) with matching schematic redraw
+- Random syllable button
+- State persists across mode switches
+- URL state: `#한` or `#D55C` loads that syllable in compose mode; user interactions rewrite the hash via replaceState
+- Decompose is the default mode on load (when no hash is present)
+- Ship chrome: noindex meta, text-only OG/twitter meta (subtitle verbatim, no image card), `/img/a3.png` favicon, `/analytics.js`, `made by ajin.im` footer link
+
+## Hard constraints
+
+- **Single .html file, no build step, no backend, vanilla JS.** Google Fonts CDN (IBM Plex Mono, Noto Sans KR) is the only external dependency.
+- Schematic block diagram stays **beside** the rendered glyph, never overlaid on it. Overlays can't align with real font metrics; honest-schematic over fake precision.
+- 해례본-derived facts only in any explanatory copy. No learner mnemonics ("ㄱ looks like a gun" is banned).
+
+## Design tokens (do not drift)
+
+```
+bg      #101013    panel  #17171b    panel2 #1d1d22
+line    #2a2a31    text   #e8e4da    dim    #6e6a60   faint #44423c
+초성 cho  #e3492b  (vermilion)
+중성 jung #d9a441  (ochre)
+종성 jong #4fa3a5  (teal)
+mono: IBM Plex Mono · hangul: Noto Sans KR
+```
+
+**Signature device**: the three role colors thread through chip selection, schematic regions, and equation terms simultaneously. They encode the mapping between spatial position and arithmetic term. Any new feature touching jamo must respect this correspondence.
+
+## Reference data
+
+```
+초성 (19): ㄱㄲㄴㄷㄸㄹㅁㅂㅃㅅㅆㅇㅈㅉㅊㅋㅌㅍㅎ
+중성 (21): ㅏㅐㅑㅒㅓㅔㅕㅖㅗㅘㅙㅚㅛㅜㅝㅞㅟㅠㅡㅢㅣ
+종성 (28): ∅ ㄱㄲㄳㄴㄵㄶㄷㄹㄺㄻㄼㄽㄾㄿㅀㅁㅂㅄㅅㅆㅇㅈㅊㅋㅌㅍㅎ
+
+vowel layout classes (by 중성 index):
+  vertical  {0,1,2,3,4,5,6,7,20}      ㅏㅐㅑㅒㅓㅔㅕㅖㅣ
+  horizontal {8,12,13,17,18}           ㅗㅛㅜㅠㅡ
+  wrapped    remainder                 ㅘㅙㅚㅝㅞㅟㅢ etc.
+
+valid syllable range: U+AC00 가 … U+D7A3 힣 (11,172 blocks)
+decompose: s = cp − 0xAC00; cho = ⌊s/588⌋; jung = ⌊(s mod 588)/28⌋; jong = s mod 28
+```
+
+## Decisions (resolved 2026-06-13)
+
+1. **Default mode on load**: decompose-first (a shared `#syllable` URL opens in compose instead)
+2. **Framing copy**: none for Phase 1; subtitle + footer already carry the thesis, the bigger "never bottoms out" claim waits for Phase 2
+3. **Name**: `AC00`, at `/is/building/ac00/`
+4. **Listing**: soft-launch (noindex, not on /is/building); hub-listing is a later owner call
+
+## Roadmap
+
+**Phase 1 polish**
+- ~~URL state~~ DONE at ship (reads `#한`/`#D55C`, writes on interaction)
+- ~~OG meta tags + favicon~~ DONE at ship (text-only meta, a3 favicon)
+- Mobile pass beyond the current single breakpoint (3-width check passed at ship; a deeper device pass stays open)
+- Keyboard input in compose mode (typing a Korean syllable loads it): nice-to-have, still open
+
+**Phase 2 (the stroke layer — the merge that justifies the project)**
+- Zoom from a selected jamo down to its 해례본 derivation
+- Consonants: 가획 chains from 5 primitives (ㄱ velar, ㄴ lingual, ㅁ labial, ㅅ dental, ㅇ laryngeal), each with a minimal sagittal articulator SVG; 이체자 (ㆁ ㄹ ㅿ) flagged as the documented exceptions; tense = doubling
+- Vowels: ㆍ ㅡ ㅣ primitives (heaven/earth/human) composing outward
+- Full derivation table is in `hangul-zoom-spec.md` §3
+
+**Phase 3**
+- Archaic letters (ㆍ ㆁ ㆆ ㅿ) in the stroke layer
+- Thesis/tour copy ("never bottoms out into arbitrariness")
+
+## Companion file
+
+`hangul-zoom-spec.md` — the full original spec with the derivation tables, worked example (한 = U+D55C), and audience rationale. Read it before starting Phase 2.

--- a/_scripts/ac00/hangul-zoom-spec.md
+++ b/_scripts/ac00/hangul-zoom-spec.md
@@ -1,0 +1,159 @@
+# SPEC: Hangul as an additive system (working title: `AC00`)
+
+A single-file static HTML tool. One thesis, shown at three joints.
+
+**Thesis:** Hangul composes by addition at every level. Strokes add to make letters, letters add to make a block, and the block is literally an integer. No other major script stays systematic all the way down; with Latin you eventually hit "why does A look like A" and the answer is an accident you memorize. Hangul never bottoms out into arbitrariness.
+
+Name candidates (your call): `AC00` (the Unicode base codepoint, reads like a memory address, fits debug::u / omen.ops), `가획` (the stroke-addition principle itself), `+stroke`. I lean `AC00`.
+
+---
+
+## 0. The audience fork (decide first)
+
+This assumption shapes the whole build:
+
+- **A. Systems-curious audience (assumed).** People who'll enjoy the script-as-system reveal. No audio, no pronunciation, no "learn to read" promise. The payoff is the arithmetic and the 해례본 derivation. This is your lane and what the rest of this spec assumes.
+- **B. Actual novice learners.** Then you need audio, romanization, spaced repetition, and you're back competing with letslearnhangul. Different tool. If this is the goal, stop and rescope.
+
+Everything below is written for A.
+
+---
+
+## 1. Core interaction: the zoom spine
+
+One gesture: a syllable decomposes downward through four levels, and each boundary makes an *addition* explicit. Worked example uses 한.
+
+| Level | What shows | The addition at this level |
+|---|---|---|
+| 3. Codepoint | `한 = U+D55C` | `0xAC00 + 초성×588 + 중성×28 + 종성` (integer arithmetic) |
+| 2. Block | the square, 초성/중성/종성 positions | spatial: positions filled by layout rule |
+| 1. Jamo | `ㅎ` `ㅏ` `ㄴ` as discrete units | three letters placed into the square |
+| 0. Strokes | each jamo's 해례본 derivation | 가획: base + stroke; vowel = primitives combined |
+
+### Worked example: 한
+
+```
+초성 ㅎ  index 18
+중성 ㅏ  index 0
+종성 ㄴ  index 4
+
+codepoint = 0xAC00 + (18 × 588) + (0 × 28) + 4
+          = 44032 + 10584 + 0 + 4
+          = 54620
+          = U+D55C
+```
+
+Stroke level for the same syllable:
+
+- `ㅎ` ← `ㅇ` → `ㆆ` (+stroke) → `ㅎ` (+stroke). Laryngeal series (후음).
+- `ㅏ` ← `ㅣ` (human) + `ㆍ` (heaven), dot to the right.
+- `ㄴ` ← base lingual primitive (설음), tongue tip at the alveolar ridge. No stroke added; it's a primitive.
+
+This single example exercises all three additions (arithmetic, spatial, stroke), so use 한 as the default load state.
+
+---
+
+## 2. Two modes on the same spine
+
+- **Compose (zoom out / build up).** Start from primitives or jamo, add strokes, drop jamo into positions, watch the codepoint compute live as you go. This is the playful core. Ship this first.
+- **Decompose (zoom in / break down).** Type or paste a syllable, watch it fall apart down the four levels. This is the explanatory mode.
+
+Same data, same visual spine, reversed direction. Build compose first; decompose is mostly the same components run backward.
+
+---
+
+## 3. Data model
+
+The accuracy-critical part. Source the derivations from the 해례본 logic, not learner mnemonics (no "ㄱ looks like a gun").
+
+### Codepoint composition
+
+```
+S = 0xAC00 + (초성_index × 588) + (중성_index × 28) + 종성_index
+588 = 21 × 28   (medials × finals)
+초성_index: 0–18   (19 initials)
+중성_index: 0–20   (21 medials)
+종성_index: 0–27   (28 finals, 0 = none)
+```
+
+Index arrays follow standard Unicode jamo order (Claude Code can hardcode them):
+
+```
+초성: ㄱ ㄲ ㄴ ㄷ ㄸ ㄹ ㅁ ㅂ ㅃ ㅅ ㅆ ㅇ ㅈ ㅉ ㅊ ㅋ ㅌ ㅍ ㅎ
+중성: ㅏ ㅐ ㅑ ㅒ ㅓ ㅔ ㅕ ㅖ ㅗ ㅘ ㅙ ㅚ ㅛ ㅜ ㅝ ㅞ ㅟ ㅠ ㅡ ㅢ ㅣ
+종성: (none) ㄱ ㄲ ㄳ ㄴ ㄵ ㄶ ㄷ ㄹ ㄺ ㄻ ㄼ ㄽ ㄾ ㄿ ㅀ ㅁ ㅂ ㅄ ㅅ ㅆ ㅇ ㅈ ㅊ ㅋ ㅌ ㅍ ㅎ
+```
+
+### Consonant derivation (가획)
+
+Five primitives, each strengthened by adding strokes. Three 이체자 (variants) sit outside the stroke rule and are the documented exceptions that make the system credible.
+
+| Class | Primitive | +stroke | +stroke | 이체자 (variant) |
+|---|---|---|---|---|
+| 아음 velar | ㄱ | ㅋ | | ㆁ |
+| 설음 lingual | ㄴ | ㄷ | ㅌ | ㄹ |
+| 순음 labial | ㅁ | ㅂ | ㅍ | |
+| 치음 dental | ㅅ | ㅈ | ㅊ | ㅿ |
+| 후음 laryngeal | ㅇ | ㆆ | ㅎ | |
+
+Tense consonants are another addition: doubling. `ㄲ ㄸ ㅃ ㅆ ㅉ` from `ㄱ ㄷ ㅂ ㅅ ㅈ`.
+
+### Vowel derivation
+
+Three primitives: `ㆍ` heaven (dot), `ㅡ` earth (horizontal), `ㅣ` human (vertical).
+
+```
+ㅗ = ㅡ + ㆍ above
+ㅏ = ㅣ + ㆍ right
+ㅜ = ㅡ + ㆍ below
+ㅓ = ㅣ + ㆍ left
+iotated (add 2nd ㆍ): ㅛ ㅑ ㅠ ㅕ
+compounds: ㅐ=ㅏ+ㅣ  ㅔ=ㅓ+ㅣ  ㅘ=ㅗ+ㅏ  ㅝ=ㅜ+ㅓ  ㅢ=ㅡ+ㅣ  (etc.)
+```
+
+### Block layout rule (Level 2)
+
+Vowel orientation decides where the pieces sit in the square:
+
+- **Vertical vowels** (ㅏㅑㅓㅕㅣ and the ㅐㅔ family): 초성 left, 중성 right, 종성 full-width bottom.
+- **Horizontal vowels** (ㅗㅛㅜㅠㅡ): 초성 top, 중성 bottom, 종성 bottom.
+- **Compound** (ㅘㅙㅚㅝㅞㅟㅢ): wrapped layout. Phase 2.
+
+---
+
+## 4. Visual direction
+
+The main risk in merging the math layer and the shape layer is tonal clash: cold terminal vs warm calligraphy. Resolve it by keeping the whole tool in the systems register.
+
+- Dark background, monospace chrome, restrained palette with one accent (your vermilion/ink accent works). Same family as omen.ops.
+- Render Hangul glyphs in a clean typeface; render stroke-addition as **vector strokes drawn on a grid**, not skeuomorphic brush. Keep it diagrammatic.
+- Articulator diagrams: minimal sagittal line drawings (mouth cross-section), single accent color, five of them only (velar, lingual, labial, dental, laryngeal). Not illustrative, not painterly.
+- The codepoint readout is the hero of Level 3: show it as live hex + decimal, updating per keystroke.
+
+---
+
+## 5. Tech constraints
+
+- Single `.html` file, no backend, no build step. Vanilla JS.
+- Jamo decomposition is pure arithmetic; no library needed.
+- Articulator diagrams and stroke animations are inline SVG.
+- No external runtime deps. CDN only if unavoidable.
+
+---
+
+## 6. Phasing
+
+- **Phase 1 (MVP, ship in a sitting).** Compose + decompose at the block/codepoint level. Vertical and horizontal vowels. Live arithmetic. No stroke layer. This is the standalone #2 from our chat.
+- **Phase 2 (the merge).** Stroke level: drill a jamo into its 가획 chain with the five articulator diagrams and the vowel-primitive composition. This is where the shape story joins, under the additive frame.
+- **Phase 3 (polish).** Compound-vowel layouts, archaic letters (`ㆍ ㆁ ㆆ ㅿ`) shown in the stroke layer as historical derivation, the "no arbitrary layer" framing copy, optional guided tour.
+
+The zoom architecture lets Phase 2 graft under Phase 1 without rewriting it.
+
+---
+
+## 7. Open decisions for you
+
+1. **Audience:** confirm A (systems-curious) vs B (learners). Everything assumes A.
+2. **Default mode:** compose-first or decompose-first on load.
+3. **Archaic letters:** modern jamo only, or include `ㆍ ㆁ ㆆ ㅿ` in the stroke layer for the full 해례본 derivation. Including them strengthens the "documented exceptions" story; adds scope.
+4. **Name:** `AC00` / `가획` / `+stroke` / other.

--- a/is/building/ac00/index.html
+++ b/is/building/ac00/index.html
@@ -1,0 +1,392 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AC00 · hangul is an integer</title>
+<meta name="description" content="every hangul syllable is an integer. 0xAC00 + 초×588 + 중×28 + 종">
+<link rel="canonical" href="https://ajin.im/is/building/ac00/">
+<meta property="og:site_name" content="ajin.im">
+<meta property="og:title" content="AC00 · hangul is an integer">
+<meta property="og:description" content="every hangul syllable is an integer. 0xAC00 + 초×588 + 중×28 + 종">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ajin.im/is/building/ac00/">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="AC00 · hangul is an integer">
+<meta name="twitter:description" content="every hangul syllable is an integer. 0xAC00 + 초×588 + 중×28 + 종">
+<meta name="robots" content="noindex"><!-- soft launch: unlisted until the owner verdict gate -->
+<link rel="icon" type="image/png" href="/img/a3.png">
+<link rel="apple-touch-icon" href="/img/a3.png">
+<script src="/analytics.js" defer></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Noto+Sans+KR:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#101013;
+  --panel:#17171b;
+  --panel2:#1d1d22;
+  --line:#2a2a31;
+  --text:#e8e4da;
+  --dim:#6e6a60;
+  --faint:#44423c;
+  --cho:#e3492b;   /* vermilion · initial */
+  --jung:#d9a441;  /* ochre · medial */
+  --jong:#4fa3a5;  /* teal · final */
+  --mono:'IBM Plex Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+  --kr:'Noto Sans KR','Apple SD Gothic Neo','Malgun Gothic',sans-serif;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{
+  background:var(--bg);color:var(--text);
+  font-family:var(--mono);font-size:14px;line-height:1.5;
+  min-height:100vh;display:flex;flex-direction:column;align-items:center;
+  padding:28px 20px 60px;
+}
+.wrap{width:100%;max-width:880px}
+
+/* ── header ── */
+header{display:flex;align-items:flex-end;justify-content:space-between;gap:16px;margin-bottom:26px;flex-wrap:wrap}
+.title{display:flex;align-items:center;gap:14px}
+.seal{
+  border:2px solid var(--cho);color:var(--cho);
+  padding:6px 10px;font-weight:600;font-size:18px;letter-spacing:.08em;
+  user-select:none;
+}
+.subtitle{color:var(--dim);font-size:12px;max-width:340px}
+.subtitle b{color:var(--text);font-weight:500}
+.modes{display:flex;border:1px solid var(--line)}
+.modes button{
+  background:none;border:none;color:var(--dim);font-family:var(--mono);
+  font-size:12px;padding:8px 16px;cursor:pointer;letter-spacing:.05em;
+}
+.modes button.on{background:var(--panel2);color:var(--text)}
+.modes button:focus-visible{outline:2px solid var(--cho);outline-offset:-2px}
+
+/* ── stage ── */
+.stage{
+  display:grid;grid-template-columns:auto auto 1fr;gap:28px;align-items:center;
+  background:var(--panel);border:1px solid var(--line);padding:26px 28px;
+}
+.glyph{
+  font-family:var(--kr);font-weight:700;font-size:150px;line-height:1;
+  min-width:170px;text-align:center;user-select:none;
+}
+.schematic{display:flex;flex-direction:column;gap:8px;align-items:center}
+.schematic svg{display:block}
+.rule{color:var(--dim);font-size:11px;text-align:center;max-width:150px}
+.rule b{color:var(--text);font-weight:500}
+
+/* ── equation ── */
+.eq{font-size:14px;justify-self:end;min-width:300px}
+.eq .row{display:grid;grid-template-columns:64px 96px 1fr;gap:10px;padding:3px 0;align-items:baseline}
+.eq .lbl{color:var(--dim);font-size:11px}
+.eq .mid{color:var(--dim)}
+.eq .val{text-align:right;font-variant-numeric:tabular-nums}
+.eq .jamo-k{font-family:var(--kr);font-weight:700;margin-right:6px}
+.eq .r-cho .jamo-k,.eq .r-cho .val{color:var(--cho)}
+.eq .r-jung .jamo-k,.eq .r-jung .val{color:var(--jung)}
+.eq .r-jong .jamo-k,.eq .r-jong .val{color:var(--jong)}
+.eq .sum{border-top:1px solid var(--line);margin-top:6px;padding-top:8px}
+.eq .sum .val,.eq .sum .mid{color:var(--text);font-weight:600;font-size:16px}
+.eq .bytes{margin-top:10px;color:var(--dim);font-size:11px}
+.eq .bytes span{color:var(--text)}
+.flash{animation:flash .5s ease-out}
+@keyframes flash{0%{background:var(--panel2)}100%{background:transparent}}
+@media(prefers-reduced-motion:reduce){.flash{animation:none}}
+
+/* ── pickers ── */
+.pickers{margin-top:22px;display:flex;flex-direction:column;gap:18px}
+.group .ghead{display:flex;align-items:baseline;gap:10px;margin-bottom:8px}
+.ghead .tag{font-size:11px;font-weight:600;letter-spacing:.06em}
+.ghead .note{color:var(--dim);font-size:11px}
+.g-cho .tag{color:var(--cho)} .g-jung .tag{color:var(--jung)} .g-jong .tag{color:var(--jong)}
+.chips{display:flex;flex-wrap:wrap;gap:5px}
+.chip{
+  font-family:var(--kr);font-size:17px;font-weight:500;
+  background:var(--panel);border:1px solid var(--line);color:var(--text);
+  width:40px;height:40px;cursor:pointer;position:relative;
+  display:flex;align-items:center;justify-content:center;
+}
+.chip .idx{position:absolute;top:2px;right:4px;font-family:var(--mono);font-size:8px;color:var(--faint)}
+.chip:hover{background:var(--panel2)}
+.chip:focus-visible{outline:2px solid var(--text);outline-offset:-2px}
+.g-cho .chip.sel{border-color:var(--cho);color:var(--cho);background:var(--panel2)}
+.g-jung .chip.sel{border-color:var(--jung);color:var(--jung);background:var(--panel2)}
+.g-jong .chip.sel{border-color:var(--jong);color:var(--jong);background:var(--panel2)}
+.chip.none{font-family:var(--mono);font-size:10px;color:var(--dim)}
+.toolbar{display:flex;gap:8px;margin-top:4px}
+.btn{
+  background:none;border:1px solid var(--line);color:var(--dim);
+  font-family:var(--mono);font-size:11px;padding:6px 12px;cursor:pointer;letter-spacing:.04em;
+}
+.btn:hover{color:var(--text);background:var(--panel)}
+.btn:focus-visible{outline:2px solid var(--cho);outline-offset:-2px}
+
+/* ── decompose ── */
+.decomp{margin-top:22px;display:none;flex-direction:column;gap:14px}
+.decomp input{
+  background:var(--panel);border:1px solid var(--line);color:var(--text);
+  font-family:var(--kr);font-size:18px;padding:12px 14px;width:100%;
+}
+.decomp input:focus-visible{outline:2px solid var(--cho);outline-offset:-1px}
+.decomp .hint{color:var(--dim);font-size:11px}
+.sylls{display:flex;flex-wrap:wrap;gap:5px}
+.syll{
+  font-family:var(--kr);font-size:20px;font-weight:500;
+  background:var(--panel);border:1px solid var(--line);color:var(--text);
+  min-width:46px;height:46px;padding:0 6px;cursor:pointer;
+  display:flex;align-items:center;justify-content:center;
+}
+.syll:hover{background:var(--panel2)}
+.syll:focus-visible{outline:2px solid var(--text);outline-offset:-2px}
+.syll.sel{border-color:var(--cho);color:var(--cho);background:var(--panel2)}
+.syll.inert{color:var(--faint);border-color:transparent;cursor:default;background:none}
+
+footer{margin-top:34px;color:var(--faint);font-size:11px;max-width:880px;width:100%}
+footer span{color:var(--dim)}
+
+@media(max-width:760px){
+  .stage{grid-template-columns:1fr;justify-items:center;gap:18px}
+  .eq{justify-self:center;min-width:0;width:100%;max-width:340px}
+  .glyph{font-size:110px;min-width:0}
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <div class="title">
+    <div class="seal">AC00</div>
+    <div class="subtitle">every hangul syllable is an integer.<br><b>0xAC00 + 초×588 + 중×28 + 종</b></div>
+  </div>
+  <div class="modes" role="tablist">
+    <button id="mCompose" class="on" role="tab" aria-selected="true">compose</button>
+    <button id="mDecomp" role="tab" aria-selected="false">decompose</button>
+  </div>
+</header>
+
+<section class="stage">
+  <div class="glyph" id="glyph">한</div>
+  <div class="schematic">
+    <svg id="schema" width="140" height="140" viewBox="0 0 140 140" aria-hidden="true"></svg>
+    <div class="rule" id="ruleLabel"></div>
+  </div>
+  <div class="eq" id="eq"></div>
+</section>
+
+<section class="pickers" id="pickers">
+  <div class="group g-cho">
+    <div class="ghead"><span class="tag">초성 · initial</span><span class="note">19 consonants · ×588</span></div>
+    <div class="chips" id="choChips"></div>
+  </div>
+  <div class="group g-jung">
+    <div class="ghead"><span class="tag">중성 · medial</span><span class="note">21 vowels · ×28 · decides the layout</span></div>
+    <div class="chips" id="jungChips"></div>
+  </div>
+  <div class="group g-jong">
+    <div class="ghead"><span class="tag">종성 · final</span><span class="note">28 endings · ×1</span></div>
+    <div class="chips" id="jongChips"></div>
+  </div>
+  <div class="toolbar">
+    <button class="btn" id="btnRandom">⚄ random syllable</button>
+  </div>
+</section>
+
+<section class="decomp" id="decomp">
+  <input id="decompInput" value="한글은 정수다" spellcheck="false" autocomplete="off">
+  <div class="hint">type or paste korean · click a syllable to take it apart</div>
+  <div class="sylls" id="sylls"></div>
+</section>
+
+<footer>
+  one square = three indices = one number. <span>11,172 possible syllables, U+AC00 가 through U+D7A3 힣, every one of them computed, none of them stored.</span> · <a href="/" style="color:var(--dim);text-decoration:underline;text-underline-offset:2px">made by ajin.im</a>
+</footer>
+
+</div>
+
+<script>
+'use strict';
+const CHO  = [...'ㄱㄲㄴㄷㄸㄹㅁㅂㅃㅅㅆㅇㅈㅉㅊㅋㅌㅍㅎ'];
+const JUNG = [...'ㅏㅐㅑㅒㅓㅔㅕㅖㅗㅘㅙㅚㅛㅜㅝㅞㅟㅠㅡㅢㅣ'];
+const JONG = ['', ...'ㄱㄲㄳㄴㄵㄶㄷㄹㄺㄻㄼㄽㄾㄿㅀㅁㅂㅄㅅㅆㅇㅈㅊㅋㅌㅍㅎ'];
+
+const VERT = new Set([0,1,2,3,4,5,6,7,20]);     // ㅏㅐㅑㅒㅓㅔㅕㅖㅣ
+const HORZ = new Set([8,12,13,17,18]);          // ㅗㅛㅜㅠㅡ
+// remainder = wrapped compounds
+
+const state = { cho:18, jung:0, jong:4, mode:'compose' };
+const $ = id => document.getElementById(id);
+const enc = new TextEncoder();
+
+function codepoint(s){ return 0xAC00 + s.cho*588 + s.jung*28 + s.jong; }
+
+/* ── chips ── */
+function buildChips(el, arr, key){
+  arr.forEach((j,i)=>{
+    const b = document.createElement('button');
+    b.className = 'chip' + (j===''?' none':'');
+    b.innerHTML = (j===''?'∅':j) + `<span class="idx">${i}</span>`;
+    b.title = `index ${i}`;
+    b.addEventListener('click', ()=>{ state[key]=i; render(true); });
+    el.appendChild(b);
+  });
+}
+buildChips($('choChips'), CHO, 'cho');
+buildChips($('jungChips'), JUNG, 'jung');
+buildChips($('jongChips'), JONG, 'jong');
+
+function markSel(el, idx){
+  [...el.children].forEach((c,i)=>c.classList.toggle('sel', i===idx));
+}
+
+/* ── schematic ── */
+function schematic(){
+  const svg = $('schema');
+  const cs = getComputedStyle(document.documentElement);
+  const col = { cho:cs.getPropertyValue('--cho'), jung:cs.getPropertyValue('--jung'), jong:cs.getPropertyValue('--jong') };
+  const hasJong = state.jong !== 0;
+  const j = state.jung;
+  let regions;
+  const H = hasJong ? 95 : 134;            // vertical space above final
+  if (VERT.has(j)) {
+    regions = [
+      {k:'cho',  x:3,  y:3, w:64, h:H},
+      {k:'jung', x:73, y:3, w:64, h:H},
+    ];
+  } else if (HORZ.has(j)) {
+    const half = (H-3)/2;
+    regions = [
+      {k:'cho',  x:3, y:3,        w:134, h:half},
+      {k:'jung', x:3, y:6+half,   w:134, h:half},
+    ];
+  } else { // wrapped compound: medial hugs right + below
+    const h2 = (H-3)/2;
+    regions = [
+      {k:'cho',  x:3,  y:3,      w:64,  h:h2},
+      {k:'jung', x:73, y:3,      w:64,  h:H, wrap:{x:3,y:6+h2,w:64,h:h2-3}},
+    ];
+  }
+  if (hasJong) regions.push({k:'jong', x:3, y:101, w:134, h:36});
+
+  const LBL = {cho:'초', jung:'중', jong:'종'};
+  let s = '';
+  for (const r of regions){
+    s += `<rect x="${r.x}" y="${r.y}" width="${r.w}" height="${r.h}" fill="${col[r.k]}" fill-opacity="0.10" stroke="${col[r.k]}" stroke-width="1.5"/>`;
+    s += `<text x="${r.x+r.w/2}" y="${r.y+r.h/2+5}" fill="${col[r.k]}" font-size="13" text-anchor="middle" font-family="Noto Sans KR,sans-serif" font-weight="700">${LBL[r.k]}</text>`;
+    if (r.wrap){
+      const w = r.wrap;
+      s += `<rect x="${w.x}" y="${w.y}" width="${w.w}" height="${w.h}" fill="${col[r.k]}" fill-opacity="0.10" stroke="${col[r.k]}" stroke-width="1.5" stroke-dasharray="4 3"/>`;
+    }
+  }
+  svg.innerHTML = s;
+
+  const rl = $('ruleLabel');
+  if (VERT.has(j))      rl.innerHTML = `<b>vertical vowel</b> → medial sits right of the initial`;
+  else if (HORZ.has(j)) rl.innerHTML = `<b>horizontal vowel</b> → medial sits below the initial`;
+  else                  rl.innerHTML = `<b>compound vowel</b> → medial wraps right + below`;
+}
+
+/* ── equation ── */
+function pad(n,w){ return String(n).padStart(w,'\u2007'); }
+function equation(flash){
+  const cp = codepoint(state);
+  const ch = String.fromCharCode(cp);
+  const bytes = [...enc.encode(ch)].map(b=>b.toString(16).toUpperCase().padStart(2,'0')).join(' ');
+  const rows = [
+    `<div class="row"><span class="lbl">base</span><span class="mid">0xAC00</span><span class="val">${pad(44032,6)}</span></div>`,
+    `<div class="row r-cho ${flash?'flash':''}"><span class="lbl">초성</span><span class="mid"><span class="jamo-k">${CHO[state.cho]}</span>${pad(state.cho,2)} × 588</span><span class="val">+${pad(state.cho*588,5)}</span></div>`,
+    `<div class="row r-jung ${flash?'flash':''}"><span class="lbl">중성</span><span class="mid"><span class="jamo-k">${JUNG[state.jung]}</span>${pad(state.jung,2)} × 28</span><span class="val">+${pad(state.jung*28,5)}</span></div>`,
+    `<div class="row r-jong ${flash?'flash':''}"><span class="lbl">종성</span><span class="mid"><span class="jamo-k">${JONG[state.jong]||'∅'}</span>${pad(state.jong,2)} × 1</span><span class="val">+${pad(state.jong,5)}</span></div>`,
+    `<div class="row sum"><span class="lbl"></span><span class="mid">U+${cp.toString(16).toUpperCase()}</span><span class="val">${pad(cp,6)}</span></div>`,
+    `<div class="bytes">utf-8 <span>${bytes}</span></div>`
+  ];
+  $('eq').innerHTML = rows.join('');
+}
+
+/* ── render ── */
+function render(flash=false){
+  $('glyph').textContent = String.fromCharCode(codepoint(state));
+  markSel($('choChips'), state.cho);
+  markSel($('jungChips'), state.jung);
+  markSel($('jongChips'), state.jong);
+  schematic();
+  equation(flash);
+  if (flash) history.replaceState(null, '', '#' + String.fromCharCode(codepoint(state)));
+}
+
+/* ── decompose ── */
+function decompose(){
+  const txt = $('decompInput').value;
+  const box = $('sylls');
+  box.innerHTML = '';
+  let firstLoaded = false;
+  [...txt].forEach(ch=>{
+    const cp = ch.codePointAt(0);
+    const b = document.createElement('button');
+    if (cp >= 0xAC00 && cp <= 0xD7A3){
+      b.className = 'syll';
+      b.textContent = ch;
+      b.addEventListener('click', ()=>{
+        const s = cp - 0xAC00;
+        state.cho = Math.floor(s/588);
+        state.jung = Math.floor((s%588)/28);
+        state.jong = s%28;
+        [...box.children].forEach(c=>c.classList.remove('sel'));
+        b.classList.add('sel');
+        render(true);
+      });
+      if (!firstLoaded){ firstLoaded = true; b.classList.add('sel');
+        const s = cp - 0xAC00;
+        state.cho = Math.floor(s/588); state.jung = Math.floor((s%588)/28); state.jong = s%28;
+      }
+    } else {
+      b.className = 'syll inert';
+      b.textContent = ch === ' ' ? '·' : ch;
+      b.tabIndex = -1;
+    }
+    box.appendChild(b);
+  });
+  render();
+}
+
+/* ── modes ── */
+function setMode(m){
+  state.mode = m;
+  $('mCompose').classList.toggle('on', m==='compose');
+  $('mDecomp').classList.toggle('on', m==='decompose');
+  $('mCompose').setAttribute('aria-selected', m==='compose');
+  $('mDecomp').setAttribute('aria-selected', m==='decompose');
+  $('pickers').style.display = m==='compose' ? 'flex' : 'none';
+  $('decomp').style.display = m==='decompose' ? 'flex' : 'none';
+  if (m==='decompose') decompose();
+}
+$('mCompose').addEventListener('click', ()=>setMode('compose'));
+$('mDecomp').addEventListener('click', ()=>setMode('decompose'));
+$('decompInput').addEventListener('input', decompose);
+
+$('btnRandom').addEventListener('click', ()=>{
+  state.cho = Math.floor(Math.random()*19);
+  state.jung = Math.floor(Math.random()*21);
+  state.jong = Math.floor(Math.random()*28);
+  render(true);
+});
+
+/* ── url state ── */
+function applyHash(){
+  let h = '';
+  try { h = decodeURIComponent(location.hash.slice(1)); } catch { return false; }
+  if (!h) return false;
+  const cp = /^[0-9A-Fa-f]{4,5}$/.test(h) ? parseInt(h, 16) : h.codePointAt(0);
+  if (!(cp >= 0xAC00 && cp <= 0xD7A3)) return false;
+  const s = cp - 0xAC00;
+  state.cho = Math.floor(s/588); state.jung = Math.floor((s%588)/28); state.jong = s%28;
+  return true;
+}
+window.addEventListener('hashchange', ()=>{ if (applyHash()){ setMode('compose'); render(true); } });
+
+setMode(applyHash() ? 'compose' : 'decompose');
+render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Ships AC00 (every hangul syllable is an integer) at /is/building/ac00/, soft-launch.

- Page from the Hangul_zoom Phase 1 mock + ship chrome: noindex, text-only OG/twitter meta, a3 favicon, analytics.js, made-by footer link
- Decompose-first on load; #한 / #D55C URL state (a hash opens compose; interactions rewrite the hash via replaceState)
- Docs copied to _scripts/ac00/ (CLAUDE.md updated to shipped state + resolved decisions)
- Verified: 375/768/1280 no overflow, hash round-trip both forms, zero console errors
- Not hub-listed; sitemap untouched (noindex pages stay out, metro-match precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)