### PR TITLE
canary: hand-log Jun 13 compensation reset the watcher missed

### DIFF
--- a/is/building/did-claude-just-reset-usage/state.json
+++ b/is/building/did-claude-just-reset-usage/state.json
@@ -1,22 +1,29 @@
 {
   "_note": "machine-updated by canary_watcher (LaunchAgent com.ajin.canary-watcher, see _scripts/canary/) — hand edits may be overwritten within 30 minutes",
-  "last_polled_utc": "2026-06-12T00:20:40Z",
+  "last_polled_utc": "2026-06-13T02:13:47Z",
   "canary_now": {
     "seven_day_used_pct": 3.0,
-    "seven_day_resets_at": "2026-06-18T23:00:00.009115+00:00"
+    "seven_day_resets_at": "2026-06-18T23:00:00Z"
   },
   "verdict_override": null,
   "watching_note": null,
   "last_reset": {
-    "detected_utc": "2026-06-09T22:13:00Z",
-    "bracket": "between 22:06 and 22:13 UTC, Jun 9",
-    "from_pct": 77,
+    "detected_utc": "2026-06-13T02:08:41Z",
+    "bracket": "between 01:27 and 02:08 UTC, Jun 13",
+    "from_pct": 40,
     "to_pct": 0,
     "window": "unchanged",
     "announced": false,
-    "suspected_trigger": "Claude Opus 4.6 elevated-errors incident, resolved 22:10 UTC"
+    "suspected_trigger": null
   },
   "resets": [
+    {
+      "date": "2026-06-13",
+      "counter": "40% → 0%",
+      "window": "unchanged",
+      "announced": "no",
+      "note": "unannounced; trigger unknown"
+    },
     {
       "date": "2026-06-09",
       "counter": "77% → 0%",


### PR DESCRIPTION
The canary's OAuth token expired 2026-06-12 05:34Z; every poll since 401'd, so the LaunchAgent missed a real compensation reset.

**Reset confirmed independently** (CodexBar history + cfo snapshot):
- seven_day util **40%** (01:27:53Z) → **3%** (02:08:41Z, still 3% at 02:13:47Z)
- `resets_at` held at 2026-06-18T23:00Z → compensation reset, **not** the scheduled weekly roll (that one was Jun 11 23:00Z, 78%→1%, window +7d)

Page now reports **YES** through Jun 15 02:08Z and lists the Jun 13 entry. `suspected_trigger` left null pending a known cause.

Watcher token-expiry root cause is a separate fix (not in this PR).