### PR TITLE
site: KRIB — drop ciphertext from meta tags

### DIFF
--- a/is/building/krib/index.html
+++ b/is/building/krib/index.html
@@ -4,11 +4,11 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>KRIB · decode the Korean script</title>
-<meta name="description" content="A cryptogram pointed at Korean. One word is given, the rest is ciphertext. Sound out a piece and every word that holds it resolves at once.">
+<meta name="description" content="A cryptogram pointed at Korean. One word is given; sound out a piece and every word that shares it resolves at once. Reconstruct the alphabet in a sitting.">
 <link rel="canonical" href="https://ajin.im/is/building/krib/">
 <meta property="og:site_name" content="ajin.im">
 <meta property="og:title" content="KRIB · decode the Korean script">
-<meta property="og:description" content="A cryptogram pointed at Korean. One word given, the rest ciphertext. Crack a piece, every word that shares it resolves. The script was engineered to come apart this fast.">
+<meta property="og:description" content="One word is given, the rest is unread. Sound out a piece and every word that shares it resolves at once. Korean was built to come apart this fast.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://ajin.im/is/building/krib/">
 <meta name="twitter:card" content="summary">


### PR DESCRIPTION
Follow-up to PR #194: 'ciphertext' was removed from the visible frame but still lived in the meta description and og:description (user-facing in search/share). Now aligned with the plain on-page copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)