### PR TITLE
site: KRIB — drop 'writing system' from meta

### DIFF
--- a/is/building/krib/index.html
+++ b/is/building/krib/index.html
@@ -4,11 +4,11 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>KRIB · decode hangul</title>
-<meta name="description" content="Decode hangul, the Korean writing system, as a cipher. One word is given; crack a piece and every word that shares it resolves at once.">
+<meta name="description" content="Decode hangul from a single given word. Crack a piece and every Korean word that shares it resolves at once.">
 <link rel="canonical" href="https://ajin.im/is/building/krib/">
 <meta property="og:site_name" content="ajin.im">
 <meta property="og:title" content="KRIB · decode hangul">
-<meta property="og:description" content="Decode hangul, the Korean writing system, from one given word. Crack a piece and every word that shares it resolves at once. Hangul was built to come apart this fast.">
+<meta property="og:description" content="Decode hangul from a single given word. Crack a piece and every Korean word that shares it resolves at once. Hangul was built to come apart this fast.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://ajin.im/is/building/krib/">
 <meta name="twitter:card" content="summary">


### PR DESCRIPTION
Follow-up to PR #196: 'writing system' (a term flagged earlier) had crept back into the meta description + og:description as a gloss for hangul. Replaced with a natural 'every Korean word' anchor. Full flagged-term sweep now clean (ciphertext/writing system/alphabet/script all 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)