### PR TITLE
site: KRIB — tap-hints + gloss firm-up

### DIFF
--- a/_scripts/crib/crib_solver.py
+++ b/_scripts/crib/crib_solver.py
@@ -26,7 +26,7 @@ LEVELS=[
  ('band3 · wide bank',    None,  True,  ['사람','소리','하나','하루','게','네']),
  ('band3 · wide bank',    None,  True,  ['바지','자리','거리','머리','그림','드라마']),
  ('band4 · finals',       None,  True,  ['강','공','방','책','차','개','문','밥']),
- ('band4 · finals',       None,  True,  ['코','키','토','타','발','곰','짐','산']),
+ ('band4 · finals',       None,  True,  ['코','키','토','탑','발','곰','짐','산']),
  ('band5 · thin overlap', None,  True,  ['포도','파','풀','바다','거리','그림']),
 ]
 

--- a/is/building/krib/index.html
+++ b/is/building/krib/index.html
@@ -222,7 +222,7 @@ const LEVELS=[
   { event:'finals in play', crib:null, wide:true,
     words:[{w:'강',g:'river'},{w:'공',g:'ball'},{w:'방',g:'room'},{w:'책',g:'book'},{w:'차',g:'car'},{w:'개',g:'dog'},{w:'문',g:'door'},{w:'밥',g:'rice'}] },
   { event:null, crib:null, wide:true,
-    words:[{w:'코',g:'nose'},{w:'키',g:'height'},{w:'토',g:'soil'},{w:'타',g:'ride'},{w:'발',g:'foot'},{w:'곰',g:'bear'},{w:'짐',g:'load'},{w:'산',g:'mountain'}] },
+    words:[{w:'코',g:'nose'},{w:'키',g:'height'},{w:'토',g:'soil'},{w:'탑',g:'tower'},{w:'발',g:'foot'},{w:'곰',g:'bear'},{w:'짐',g:'luggage'},{w:'산',g:'mountain'}] },
   { event:'overlap thinned', crib:null, wide:true,
     words:[{w:'포도',g:'grape'},{w:'파',g:'scallion'},{w:'풀',g:'grass'},{w:'바다',g:'sea'},{w:'거리',g:'street'},{w:'그림',g:'picture'}] },
 ];
@@ -355,6 +355,9 @@ function renderNav(){
     adv.textContent=(li===LEVELS.length-1)?'✓ all pieces recovered — the finale →':'✓ stage decoded — next stage →';
     adv.classList.add('show');
   } else adv.classList.remove('show');
+  const intro=li===0;
+  $('howKey').innerHTML=intro?'<b>tap a piece</b> to give it a sound.':'';
+  $('howWords').innerHTML=intro?'<b>tap a dashed square</b> to open it.':'';
 }
 function renderProgress(){
   if(li===maxReached && !merged.has(li) && LEVELS[li].words.every(o=>wordState(o)==='solved')) clearLevel();


### PR DESCRIPTION
Immediate fixes from the copy review:
- **Restored the tap-hints** on stage 1 only ('tap a piece to give it a sound' / 'tap a dashed square to open it'); they were dropped in the stage-selector rewrite. Color-agnostic wording (no 'teal', since known pieces are now calamine-blue).
- **타 → 탑** (tower): 타 isn't a standalone noun ('ride' is a verb stem), 탑 is a real concrete word. Solver re-run: ALL LEVELS CLEAN, 22 jamo (탑 keeps the same ㅌ foothold).
- **짐** gloss load → luggage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)