### PR TITLE
prepublish: scrub employer name + personal paths from tree

### DIFF
--- a/_scripts/ac00/CLAUDE.md
+++ b/_scripts/ac00/CLAUDE.md
@@ -14,7 +14,7 @@ The eventual full claim (Phase 2): the script never bottoms out into arbitrarine
 
 ## Current state
 
-**SHIPPED (Phase 1, 2026-06-13):** live at https://ajin.im/is/building/ac00/ (soft-launch: noindex, no hub listing; lifting that is Ajin's call). Source of truth is `is/building/ac00/index.html` in mobetter20.github.io; the `~/Downloads/Hangul_zoom/` mock is the pre-ship snapshot. The page has:
+**SHIPPED (Phase 1, 2026-06-13):** live at https://ajin.im/is/building/ac00/ (soft-launch: noindex, no hub listing; lifting that is Ajin's call). Source of truth is `is/building/ac00/index.html` in mobetter20.github.io; a local Downloads snapshot (not committed) is the pre-ship mock. The page has:
 
 - **Compose mode**: 19/21/28 jamo chip pickers, live glyph + schematic + equation
 - **Decompose mode**: text input (default 한글은 정수다), clickable per-syllable chips, same view

--- a/_scripts/canary/canary_watcher.py
+++ b/_scripts/canary/canary_watcher.py
@@ -74,7 +74,7 @@ def log(msg):
 def poll():
     """Read Claude usage from cfo's state.json.
 
-    cfo (com.tradlinx.cfo-state) extracts the meter from CodexBar's menubar
+    cfo extracts the meter from CodexBar's menubar
     snapshot every 30 min and writes it under ~/.local/share — a path this
     background agent can read. CodexBar's own Group Container cannot be read
     from a launchd job (macOS TCC: "Operation not permitted"), and cfo already

--- a/_scripts/crib/README.md
+++ b/_scripts/crib/README.md
@@ -32,7 +32,7 @@ The corpus in the solver must mirror `LEVELS` in `index.html`. First-draft gloss
 
 - `NORTH-STAR.md` — the constitution (cryptanalysis primary, decode voice, honest ceiling). Wins on conflict.
 - `HANDOFF.md` — the build handoff. The morpheme/grammar tier was prototyped and **cut** (its decode target is metalanguage, so it plays as a grammar lesson); the script is the whole scope.
-- Prototypes (in `~/Downloads/Decode_hangul/` and `~/Downloads/`, not committed): `dig-proto` (phoneme loop, accepted), `flow-proto` (bridge fold), `curve-proto` (the ramp + persistence). Rejected tiers: grammar / grid / morph / bridge.
+- Prototypes (in a local Downloads dir, not committed): `dig-proto` (phoneme loop, accepted), `flow-proto` (bridge fold), `curve-proto` (the ramp + persistence). Rejected tiers: grammar / grid / morph / bridge.
 
 ## Phase 2 (parked)
 


### PR DESCRIPTION
Tree fixes from the prepublish audit (repo is already public; these clean the working tree, history retains them — accepted, not worth a rewrite for moderate/benign items):
- `_scripts/canary/canary_watcher.py`: dropped `com.tradlinx.cfo-state` (employer name) from a docstring comment → 'cfo extracts…'
- `_scripts/ac00/CLAUDE.md` + `_scripts/crib/README.md`: genericized `~/Downloads/...` personal paths → 'a local Downloads snapshot/dir (not committed)'

Secrets + commit-authors were already clean. tradlinx was hist-ok (prior documented decision) so history is already accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)