### PR TITLE
site: KRIB — logic hardening from Codex review

### DIFF
--- a/_scripts/crib/README.md
+++ b/_scripts/crib/README.md
@@ -11,7 +11,7 @@ A logic puzzle that reverse-engineers the Korean alphabet from almost nothing. T
 1. **Mechanic** — phoneme cryptogram + the block-composition bridge folded in (open a square, its pieces enter a shared key; recurrence carries the bridge). The bridge is not its own tier.
 2. **Curve** — 5 staged levers, one wrinkle per band: loop → withhold the crib → widen the sound bank → finals (a piece in any position) → thin the overlap. Anchor-withholding is band 2, not the whole lever.
 3. **Length** — one sitting, 7 cryptogram levels + a finale, ~22 basic jamo. The recovered key **persists across levels**, so it reads as reconstructing one alphabet, not seven puzzles.
-4. **Finale** — flip decode→encode: read one unseen line, then compose two unseen words (봄, 길) from the recovered alphabet via AC00's codepoint math.
+4. **Finale**: flip decode→encode. Compose-only ("reverse the cipher"): build two unseen words (봄, 돈) from the recovered alphabet via AC00's codepoint math. Targets avoid syllable-final ㄹ so the romanization stays consistent with the cipher (ㄹ=r), not real-Korean ㄹ=l.
 5. **Naming**: handle **KRIB**. The on-page 해독 seal was removed (owner call, 2026-06-14: it read as a confusing logo); the title and OG carry "decode the Korean script". 해독 stays the project working title in the canon only.
 
 ## v1.1 copy + UX pass (2026-06-14)

--- a/is/building/krib/index.html
+++ b/is/building/krib/index.html
@@ -226,9 +226,9 @@ const LEVELS=[
   { event:'overlap thinned', crib:null, wide:true,
     words:[{w:'포도',g:'grape'},{w:'파',g:'scallion'},{w:'풀',g:'grass'},{w:'바다',g:'sea'},{w:'거리',g:'street'},{w:'그림',g:'picture'}] },
 ];
-const FINALE={ compose:[ {g:'spring',rom:'bom',target:'봄'}, {g:'road',rom:'gil',target:'길'} ] };
+const FINALE={ compose:[ {g:'spring',rom:'bom',target:'봄'}, {g:'money',rom:'don',target:'돈'} ] };
 
-function blockAtoms(ch){const c=ch.charCodeAt(0)-0xAC00;const a=[CHO[Math.floor(c/588)],JUNG[Math.floor((c%588)/28)]];const jo=JONG[c%28];if(jo)a.push(jo);return a;}
+function blockAtoms(ch){const c=ch.charCodeAt(0)-0xAC00;if(c<0||c>=11172)return [];const a=[CHO[Math.floor(c/588)],JUNG[Math.floor((c%588)/28)]];const jo=JONG[c%28];if(jo)a.push(jo);return a;}
 function wordBlocks(w){return [...w].map(blockAtoms);}
 function wordAtoms(w){return wordBlocks(w).flat();}
 
@@ -270,9 +270,20 @@ function saveState(){
 function loadState(){
   try{
     const d=JSON.parse(localStorage.getItem(SAVE)||'null');
-    if(!d) return false;
-    solvedKey=d.solvedKey||{}; maxReached=d.maxReached||0; li=d.li||0; merged=new Set(d.merged||[]);
-    levelState=(d.levels||[]).map(s=> s? {assigned:s.assigned||{}, opened:new Set(s.opened||[])} : null);
+    if(!d||typeof d!=='object') return false;
+    const sk=d.solvedKey||{};
+    for(const k in sk){ if(TRUTH[k]===undefined||sk[k]!==TRUTH[k]) return false; }   // every carried piece is a real jamo at its true sound
+    const mr=d.maxReached, mg=Array.isArray(d.merged)?d.merged:[];
+    if(!Number.isInteger(mr)||mr<0||mr>=LEVELS.length) return false;
+    const mset=new Set(mg); if(mset.size!==mg.length) return false;
+    for(let i=0;i<mg.length;i++){ if(!mset.has(i)) return false; }                   // merged is a {0..n-1} prefix
+    if(mr!==(mg.length<LEVELS.length?mg.length:LEVELS.length-1)) return false;        // frontier consistent with cleared count
+    const exp=new Set(); mg.forEach(i=>LEVELS[i].words.forEach(o=>wordAtoms(o.w).forEach(p=>exp.add(p))));
+    const sks=Object.keys(sk);
+    if(sks.length!==exp.size||sks.some(k=>!exp.has(k))) return false;                 // key == exactly the cleared levels' pieces
+    let cli=Number.isInteger(d.li)?d.li:mr; if(cli<0||cli>mr) cli=mr;
+    solvedKey=sk; maxReached=mr; li=cli; merged=mset;
+    levelState=(Array.isArray(d.levels)?d.levels:[]).map(s=> s&&typeof s==='object'?{assigned:(s.assigned&&typeof s.assigned==='object')?s.assigned:{},opened:new Set(Array.isArray(s.opened)?s.opened:[])}:null);
     ensure(li); ensure(maxReached);
     return true;
   }catch(e){ return false; }
@@ -410,11 +421,11 @@ $('reviewBtn').addEventListener('click',e=>{e.stopPropagation();$('win').style.d
 $('resetBtn').addEventListener('click',e=>{e.stopPropagation();clearState();solvedKey={};levelState=[];merged=new Set();maxReached=0;li=0;ensure(0);start();});
 
 /* finale — compose only (reverse the cipher) */
-let cmpIdx, slot, activeSlot;
+let cmpIdx, slot, activeSlot, finTimer=null;
 function knownConsonants(){return CHO.filter(c=>carried(c));}
 function knownVowels(){return JUNG.filter(v=>carried(v));}
-function enterFinale(){ $('play').style.display='none'; $('win').style.display='none'; $('finale').style.display='block'; cmpIdx=0; resetSlots(); renderFinale(); }
-$('finBack').addEventListener('click',e=>{e.stopPropagation();$('finale').style.display='none';$('play').style.display='block';viewLevel(LEVELS.length-1);});
+function enterFinale(){ if(finTimer){clearTimeout(finTimer);finTimer=null;} $('play').style.display='none'; $('win').style.display='none'; $('finale').style.display='block'; cmpIdx=0; resetSlots(); renderFinale(); }
+$('finBack').addEventListener('click',e=>{e.stopPropagation();if(finTimer){clearTimeout(finTimer);finTimer=null;}$('finale').style.display='none';$('play').style.display='block';viewLevel(LEVELS.length-1);});
 function resetSlots(){slot={cho:null,jung:null,jong:null};activeSlot='cho';}
 function renderFinale(){
   const t=FINALE.compose[cmpIdx];
@@ -439,21 +450,21 @@ function renderFinale(){
   $('cmpCheck').addEventListener('click',e=>{e.stopPropagation();checkCompose();});
 }
 function tapJamo(j,type){
-  if(type==='v'){ slot.jung=JUNG.indexOf(j); activeSlot='jong'; }
-  else { const ci=CHO.indexOf(j), ji=JONG.indexOf(j);
-    if(activeSlot==='jong'&&ji>0) slot.jong=ji;
-    else if(slot.cho==null&&ci>=0){ slot.cho=ci; activeSlot='jung'; }
-    else if(ji>0) slot.jong=ji;
-    else if(ci>=0){ slot.cho=ci; activeSlot='jung'; } }
+  const ci=CHO.indexOf(j), ji=JONG.indexOf(j);
+  if(type==='v'){ slot.jung=JUNG.indexOf(j); activeSlot = slot.cho==null?'cho':(slot.jong==null?'jong':'jung'); }
+  else if(activeSlot==='cho'){ if(ci>=0){ slot.cho=ci; activeSlot='jung'; } }
+  else if(activeSlot==='jong'){ if(ji>0) slot.jong=ji; }
+  else { if(slot.cho==null&&ci>=0){ slot.cho=ci; activeSlot='jung'; } else if(ji>0) slot.jong=ji; else if(ci>=0) slot.cho=ci; }
   renderFinale();
 }
 function checkCompose(){
+  if(finTimer) return;
   const t=FINALE.compose[cmpIdx];
   if(slot.cho==null||slot.jung==null){ fmsg('bad','need an initial and a vowel'); return; }
   const ch=String.fromCharCode(0xAC00+slot.cho*588+slot.jung*28+(slot.jong??0));
   if(ch===t.target){
-    if(cmpIdx+1<FINALE.compose.length){ fmsg('good',`${ch} — correct. one more.`); setTimeout(()=>{cmpIdx++;resetSlots();renderFinale();},800); }
-    else { fmsg('good',`${ch} — correct.`); setTimeout(finWin,800); }
+    if(cmpIdx+1<FINALE.compose.length){ fmsg('good',`${ch} — correct. one more.`); finTimer=setTimeout(()=>{finTimer=null;cmpIdx++;resetSlots();renderFinale();},800); }
+    else { fmsg('good',`${ch} — correct.`); finTimer=setTimeout(()=>{finTimer=null;finWin();},800); }
   } else fmsg('bad',`${ch||'?'} is not it — check each piece against ${t.rom}`);
 }
 function fmsg(k,t){const m=$('cmpmsg');if(m){m.className='cmpmsg '+k;m.textContent=t;}}


### PR DESCRIPTION
Fixes from a Codex game-logic review (the file verified correct on the codepoint math, cascade, bank, and level-forcing; these are the holes it found):

- **High — save validation.** loadState() now rejects any semantically inconsistent save (corrupt solvedKey values, skip-to-stage-N with a mismatched key, stuck merged/maxReached) and falls back to a fresh game instead of restoring a broken/exploitable state. Valid saves still restore (verified no false rejection).
- **Medium — finale re-entrancy.** Double-clicking 'check' no longer double-advances cmpIdx into an undefined target; the advance timer is tracked and cancelled on back/re-enter.
- **Medium — slot routing.** Selecting the 초 slot then tapping a consonant now replaces the initial (was routing to 종, e.g. 곰→봄 vs the old 곱).
- **Low — finale clue consistency.** 길 (real-rom 'gil', but cipher teaches ㄹ=r) → 돈 ('don'), so the hint matches the learned substitution.
- **Low — defensive.** blockAtoms() returns [] for out-of-range input.

Left as accepted-minor: finale/win state isn't persisted (replaying it after a reload is trivial).

Verified: valid + 3 corrupt saves, double-click guard, slot reselect, 돈 compose, full play to win, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)