### PR TITLE
essays: add Atom feed at /writes/feed.xml

### DIFF
--- a/_scripts/build_essays.py
+++ b/_scripts/build_essays.py
@@ -305,6 +305,7 @@ def build_post_page(post: EssayPost) -> str:
         kicker=kicker,
         back_href="/writes/",
         back_label="← ajin.im/writes",
+        feed_url="/writes/feed.xml",
     )
 
 
@@ -322,6 +323,61 @@ def load_posts() -> list[EssayPost]:
     return sorted(posts, key=lambda post: post.order)
 
 
+SITE_BASE_URL = "https://ajin.im"
+ESSAY_FEED_TITLE = "ajin.im — Collected Writing"
+ESSAY_FEED_ALTERNATE = f"{SITE_BASE_URL}/writes/"
+ESSAY_FEED_SELF = f"{SITE_BASE_URL}/writes/feed.xml"
+ESSAY_FEED_PATH = WRITES_ROOT / "feed.xml"
+
+
+def xml_escape(value: str) -> str:
+    """html.escape(quote=True) yields valid XML entity/char references."""
+    return html.escape(value, quote=True)
+
+
+def render_feed(posts: list[EssayPost]) -> str:
+    """Build a valid Atom 1.0 feed from the live essays.
+
+    Mirrors build_bird_coo.render_feed. Essay front matter carries only a
+    year (`date: 2026`), so timestamps are pinned to YYYY-01-01 — coarse but
+    honest; the feed exists for discovery/followability, not minute-accuracy.
+    Posts are emitted in `order` (0 first = the featured/most-recent piece)."""
+    def timestamp(post: EssayPost) -> str:
+        year = post.year or "2026"
+        return f"{year}-01-01T00:00:00Z"
+
+    entries = []
+    for post in posts:
+        entry_url = f"{SITE_BASE_URL}/writes/{post.slug}/"
+        ts = timestamp(post)
+        summary = post.excerpt or post.title
+        entries.append(
+            "<entry>\n"
+            f"<id>{xml_escape(entry_url)}</id>\n"
+            f'<link rel="alternate" href="{xml_escape(entry_url)}"/>\n'
+            f"<title>{xml_escape(post.title)}</title>\n"
+            f"<updated>{ts}</updated>\n"
+            f"<published>{ts}</published>\n"
+            f'<summary type="text">{xml_escape(summary)}</summary>\n'
+            "</entry>"
+        )
+
+    feed_updated = max((timestamp(p) for p in posts), default="2026-01-01T00:00:00Z")
+    entries_block = ("\n" + "\n".join(entries) + "\n") if entries else "\n"
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        '<feed xmlns="http://www.w3.org/2005/Atom">\n'
+        f"<title>{xml_escape(ESSAY_FEED_TITLE)}</title>\n"
+        f'<link rel="alternate" href="{xml_escape(ESSAY_FEED_ALTERNATE)}"/>\n'
+        f'<link rel="self" href="{xml_escape(ESSAY_FEED_SELF)}"/>\n'
+        f"<id>{xml_escape(ESSAY_FEED_ALTERNATE)}</id>\n"
+        f"<updated>{feed_updated}</updated>\n"
+        "<author><name>ajin</name></author>"
+        f"{entries_block}"
+        "</feed>\n"
+    )
+
+
 def main() -> None:
     posts = load_posts()
     for post in posts:
@@ -336,6 +392,8 @@ def main() -> None:
             encoding="utf-8",
         )
         print(f"built {out_dir / 'index.html'}")
+    ESSAY_FEED_PATH.write_text(render_feed(posts), encoding="utf-8")
+    print(f"built {ESSAY_FEED_PATH}")
 
 
 if __name__ == "__main__":

--- a/_scripts/build_writes.py
+++ b/_scripts/build_writes.py
@@ -94,6 +94,7 @@ def render_index() -> str:
         bar_href="/",
         note_html=NOTE_HTML,
         body_html=body,
+        feed_url="/writes/feed.xml",
     )
 
 

--- a/_scripts/writes_common.py
+++ b/_scripts/writes_common.py
@@ -19,10 +19,22 @@ FONTS = (
 )
 
 
-def head(title: str, description: str, canonical: str, *, og_type: str = "website") -> str:
-    """The shared <head> block. `title` and `description` are escaped here."""
+def head(
+    title: str, description: str, canonical: str, *, og_type: str = "website", feed_url: str = ""
+) -> str:
+    """The shared <head> block. `title` and `description` are escaped here.
+
+    `feed_url`, when set, emits an Atom autodiscovery <link>. Only pages that
+    belong to that feed (the essays + the /writes index) pass it; comedy and
+    /wrote leave it empty so the essays-only feed isn't advertised there."""
     t = html.escape(title)
     d = html.escape(description)
+    feed_link = (
+        f'\n    <link rel="alternate" type="application/atom+xml" '
+        f'title="ajin.im — Collected Writing" href="{feed_url}" />'
+        if feed_url
+        else ""
+    )
     return f"""  <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -30,7 +42,7 @@ def head(title: str, description: str, canonical: str, *, og_type: str = "websit
     <link rel="apple-touch-icon" href="/img/a3.png" />
     <title>{t}</title>
     <meta name="description" content="{d}" />
-    <link rel="canonical" href="{canonical}" />
+    <link rel="canonical" href="{canonical}" />{feed_link}
     <meta property="og:site_name" content="ajin.im" />
     <meta property="og:title" content="{t}" />
     <meta property="og:description" content="{d}" />
@@ -62,6 +74,7 @@ def reading_page(
     back_label: str,
     subtitle: str = "",
     note_html: str = "",
+    feed_url: str = "",
 ) -> str:
     """A single piece. `body_html` is already-rendered HTML (indented)."""
     subtitle_html = (
@@ -70,7 +83,7 @@ def reading_page(
     note_block = f"      {note_html}\n" if note_html else ""
     return f"""<!DOCTYPE html>
 <html lang="en">
-{head(title, description, canonical, og_type="article")}
+{head(title, description, canonical, og_type="article", feed_url=feed_url)}
   <body class="read-page">
     <main class="shell">
       <a class="back" href="{back_href}">{html.escape(back_label)}</a>
@@ -106,11 +119,12 @@ def log_page(
     bar_href: str,
     note_html: str,
     body_html: str,
+    feed_url: str = "",
 ) -> str:
     """A log index (/writes or /wrote). `body_html` is the rendered .log block."""
     return f"""<!DOCTYPE html>
 <html lang="en">
-{head(title, description, canonical)}
+{head(title, description, canonical, feed_url=feed_url)}
   <body class="log-page">
     <main class="shell">
       <div class="bar"><a href="{bar_href}">{html.escape(bar_text)}</a></div>

--- a/writes/adventure-is-danger-past-tense/index.html
+++ b/writes/adventure-is-danger-past-tense/index.html
@@ -8,6 +8,7 @@
     <title>Adventure Is Danger, Past Tense</title>
     <meta name="description" content="A young woman once got on the wrong train in a country where she didn’t speak the language." />
     <link rel="canonical" href="https://ajin.im/writes/adventure-is-danger-past-tense/" />
+    <link rel="alternate" type="application/atom+xml" title="ajin.im — Collected Writing" href="/writes/feed.xml" />
     <meta property="og:site_name" content="ajin.im" />
     <meta property="og:title" content="Adventure Is Danger, Past Tense" />
     <meta property="og:description" content="A young woman once got on the wrong train in a country where she didn’t speak the language." />

--- a/writes/already-seen/index.html
+++ b/writes/already-seen/index.html
@@ -8,6 +8,7 @@
     <title>Already Seen</title>
     <meta name="description" content="At Hanoi Train Street, the train is not symbolic. It is loud, close, and solid. When it comes through, people flatten themselves against the..." />
     <link rel="canonical" href="https://ajin.im/writes/already-seen/" />
+    <link rel="alternate" type="application/atom+xml" title="ajin.im — Collected Writing" href="/writes/feed.xml" />
     <meta property="og:site_name" content="ajin.im" />
     <meta property="og:title" content="Already Seen" />
     <meta property="og:description" content="At Hanoi Train Street, the train is not symbolic. It is loud, close, and solid. When it comes through, people flatten themselves against the..." />

--- a/writes/call-of-the-void/index.html
+++ b/writes/call-of-the-void/index.html
@@ -8,6 +8,7 @@
     <title>Call of the Void</title>
     <meta name="description" content="Have you ever heard of the call of the void?" />
     <link rel="canonical" href="https://ajin.im/writes/call-of-the-void/" />
+    <link rel="alternate" type="application/atom+xml" title="ajin.im — Collected Writing" href="/writes/feed.xml" />
     <meta property="og:site_name" content="ajin.im" />
     <meta property="og:title" content="Call of the Void" />
     <meta property="og:description" content="Have you ever heard of the call of the void?" />

--- a/writes/feed.xml
+++ b/writes/feed.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+<title>ajin.im — Collected Writing</title>
+<link rel="alternate" href="https://ajin.im/writes/"/>
+<link rel="self" href="https://ajin.im/writes/feed.xml"/>
+<id>https://ajin.im/writes/</id>
+<updated>2026-01-01T00:00:00Z</updated>
+<author><name>ajin</name></author>
+<entry>
+<id>https://ajin.im/writes/the-house-chips-of-ai/</id>
+<link rel="alternate" href="https://ajin.im/writes/the-house-chips-of-ai/"/>
+<title>The House Chips of AI</title>
+<updated>2026-01-01T00:00:00Z</updated>
+<published>2026-01-01T00:00:00Z</published>
+<summary type="text">An AI subscription is not a software product. It is access to a private economy — paid in dollars, metered in tokens, credits, and limits the platform sets.</summary>
+</entry>
+<entry>
+<id>https://ajin.im/writes/already-seen/</id>
+<link rel="alternate" href="https://ajin.im/writes/already-seen/"/>
+<title>Already Seen</title>
+<updated>2026-01-01T00:00:00Z</updated>
+<published>2026-01-01T00:00:00Z</published>
+<summary type="text">At Hanoi Train Street, the train is not symbolic. It is loud, close, and solid. When it comes through, people flatten themselves against the...</summary>
+</entry>
+<entry>
+<id>https://ajin.im/writes/adventure-is-danger-past-tense/</id>
+<link rel="alternate" href="https://ajin.im/writes/adventure-is-danger-past-tense/"/>
+<title>Adventure Is Danger, Past Tense</title>
+<updated>2026-01-01T00:00:00Z</updated>
+<published>2026-01-01T00:00:00Z</published>
+<summary type="text">A young woman once got on the wrong train in a country where she didn’t speak the language.</summary>
+</entry>
+<entry>
+<id>https://ajin.im/writes/call-of-the-void/</id>
+<link rel="alternate" href="https://ajin.im/writes/call-of-the-void/"/>
+<title>Call of the Void</title>
+<updated>2026-01-01T00:00:00Z</updated>
+<published>2026-01-01T00:00:00Z</published>
+<summary type="text">Have you ever heard of the call of the void?</summary>
+</entry>
+<entry>
+<id>https://ajin.im/writes/korea-was-the-beta-test-zone-for-modern-loneliness/</id>
+<link rel="alternate" href="https://ajin.im/writes/korea-was-the-beta-test-zone-for-modern-loneliness/"/>
+<title>Korea was the beta test zone for modern loneliness.</title>
+<updated>2026-01-01T00:00:00Z</updated>
+<published>2026-01-01T00:00:00Z</published>
+<summary type="text">Korea didn’t invent loneliness.</summary>
+</entry>
+<entry>
+<id>https://ajin.im/writes/how-to-cry-on-the-subway-and-not-be-seen/</id>
+<link rel="alternate" href="https://ajin.im/writes/how-to-cry-on-the-subway-and-not-be-seen/"/>
+<title>How to Cry on the Subway and Not Be Seen</title>
+<updated>2026-01-01T00:00:00Z</updated>
+<published>2026-01-01T00:00:00Z</published>
+<summary type="text">You’re surrounded by hundreds of people. You’re crying. No one looks.</summary>
+</entry>
+</feed>

--- a/writes/how-to-cry-on-the-subway-and-not-be-seen/index.html
+++ b/writes/how-to-cry-on-the-subway-and-not-be-seen/index.html
@@ -8,6 +8,7 @@
     <title>How to Cry on the Subway and Not Be Seen</title>
     <meta name="description" content="You’re surrounded by hundreds of people. You’re crying. No one looks." />
     <link rel="canonical" href="https://ajin.im/writes/how-to-cry-on-the-subway-and-not-be-seen/" />
+    <link rel="alternate" type="application/atom+xml" title="ajin.im — Collected Writing" href="/writes/feed.xml" />
     <meta property="og:site_name" content="ajin.im" />
     <meta property="og:title" content="How to Cry on the Subway and Not Be Seen" />
     <meta property="og:description" content="You’re surrounded by hundreds of people. You’re crying. No one looks." />

--- a/writes/index.html
+++ b/writes/index.html
@@ -8,6 +8,7 @@
     <title>ajin.im writes</title>
     <meta name="description" content="A running log of thoughts — essays in the present voice." />
     <link rel="canonical" href="https://ajin.im/writes/" />
+    <link rel="alternate" type="application/atom+xml" title="ajin.im — Collected Writing" href="/writes/feed.xml" />
     <meta property="og:site_name" content="ajin.im" />
     <meta property="og:title" content="ajin.im writes" />
     <meta property="og:description" content="A running log of thoughts — essays in the present voice." />

--- a/writes/korea-was-the-beta-test-zone-for-modern-loneliness/index.html
+++ b/writes/korea-was-the-beta-test-zone-for-modern-loneliness/index.html
@@ -8,6 +8,7 @@
     <title>Korea was the beta test zone for modern loneliness.</title>
     <meta name="description" content="Korea didn’t invent loneliness." />
     <link rel="canonical" href="https://ajin.im/writes/korea-was-the-beta-test-zone-for-modern-loneliness/" />
+    <link rel="alternate" type="application/atom+xml" title="ajin.im — Collected Writing" href="/writes/feed.xml" />
     <meta property="og:site_name" content="ajin.im" />
     <meta property="og:title" content="Korea was the beta test zone for modern loneliness." />
     <meta property="og:description" content="Korea didn’t invent loneliness." />

--- a/writes/the-house-chips-of-ai/index.html
+++ b/writes/the-house-chips-of-ai/index.html
@@ -8,6 +8,7 @@
     <title>The House Chips of AI</title>
     <meta name="description" content="An AI subscription is not a software product. It is access to a private economy — paid in dollars, metered in tokens, credits, and limits the platform sets." />
     <link rel="canonical" href="https://ajin.im/writes/the-house-chips-of-ai/" />
+    <link rel="alternate" type="application/atom+xml" title="ajin.im — Collected Writing" href="/writes/feed.xml" />
     <meta property="og:site_name" content="ajin.im" />
     <meta property="og:title" content="The House Chips of AI" />
     <meta property="og:description" content="An AI subscription is not a software product. It is access to a private economy — paid in dollars, metered in tokens, credits, and limits the platform sets." />


### PR DESCRIPTION
Adds an Atom 1.0 feed of the 6 live essays (`/writes/feed.xml`), generated by `build_essays.py` on the same pattern as The Municipal Coo's feed. Scoped autodiscovery `<link>` added to essay pages + the /writes index only (opt-in `feed_url` param), so comedy/wrote don't advertise the essays-only feed.

**Why:** unlocks the IndieWeb aggregator tier (ooh.directory, Kagi Small Web, indieblog.page, Bubbles) — all require a feed. This is also the followability fix the creative-constellation doc names under §3.

Feed validates as Atom XML; 6 entries (year-granular timestamps, matching the essays' year-only `date:` front matter).